### PR TITLE
Fix a compile error for non-epoll environment. (#44)

### DIFF
--- a/src/dyn_dnode_server.c
+++ b/src/dyn_dnode_server.c
@@ -151,7 +151,7 @@ dnode_listen(struct context *ctx, struct conn *p)
         return DN_ERROR;
     }
 
-    log_debug(LOG_INFO, "dyn: e %d with nevent %d", ctx->evb->ep, ctx->evb->nevent);
+    log_debug(LOG_INFO, "dyn: e %d with nevent %d", event_fd(ctx->evb), ctx->evb->nevent);
     status = event_add_conn(ctx->evb, p);
     if (status < 0) {
         log_error("dyn: event add conn p %d on addr '%.*s' failed: %s",

--- a/src/event/dyn_event.h
+++ b/src/event/dyn_event.h
@@ -51,6 +51,12 @@ struct event_base {
     event_cb_t    cb;          /* event callback */
 };
 
+static inline int
+event_fd(struct event_base *evb)
+{
+    return evb->kq;
+}
+
 #elif DN_HAVE_EPOLL
 
 struct event_base {
@@ -61,6 +67,12 @@ struct event_base {
 
     event_cb_t         cb;      /* event callback */
 };
+
+static inline int
+event_fd(struct event_base *evb)
+{
+    return evb->ep;
+}
 
 #elif DN_HAVE_EVENT_PORTS
 
@@ -74,6 +86,12 @@ struct event_base {
 
     event_cb_t   cb;      /* event callback */
 };
+
+static inline int
+event_fd(struct event_base *evb)
+{
+    return evb->evp;
+}
 
 #else
 # error missing scalable I/O event notification mechanism


### PR DESCRIPTION
struct `event_base` have different descriptor name depending on the
environment. It can be `kq` or `evp` if non-epoll environment.
