### PR TITLE
Fix for Issue #52, broken make install

### DIFF
--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -1,3 +1,3 @@
-SUBDIRS = yaml-0.1.4 murmur3
+SUBDIRS = yaml-0.1.4
 
 EXTRA_DIST = yaml-0.1.4.tar.gz


### PR DESCRIPTION
murmur3 is included in the Makefile.am for the contrib directory.
murmur3 does not have an install rule for make. Removing so that
make install completes without error.
