### PR TITLE
Issue #59: include datacenter in default memcache configs

### DIFF
--- a/conf/dynomite_mc1.yml
+++ b/conf/dynomite_mc1.yml
@@ -2,19 +2,16 @@ dyn_o_mite:
   auto_eject_hosts: false
   datacenter: localdc1
   rack: localrack1
-  distribution: vnode
   dyn_listen: 127.0.0.1:8101
-  dyn_read_timeout: 200000
   dyn_seed_provider: simple_provider
   dyn_seeds:
-  - 127.0.0.2:8101:localrack2:localdc2:5622637,721812480,851406979,1036155118,2147653893,2233516174
-  dyn_write_timeout: 200000
-  gos_interval: 10000
+  - 127.0.0.2:8101:localrack2:localdc2:5622637
   hash: murmur
   listen: 127.0.0.1:8102
   preconnect: true
-  server_retry_timeout: 200000
   servers:
   - 127.0.0.1:11211:1
   timeout: 10000
-  tokens: 437425602,1122629340,1683099499,2400294391,2772631304,4271597971
+  tokens: 3101134286
+  secure_server_option: none
+  pem_key_file: conf/dynomite.pem

--- a/conf/dynomite_mc2.yml
+++ b/conf/dynomite_mc2.yml
@@ -1,20 +1,17 @@
 dyn_o_mite:
   auto_eject_hosts: false
-  datacenter: localdc2
-  rack: localrack2
-  distribution: vnode
-  dyn_listen: 127.0.0.2:8101
-  dyn_read_timeout: 200000
+  datacenter: localdc1
+  rack: localrack1
+  dyn_listen: 127.0.0.1:8101
   dyn_seed_provider: simple_provider
   dyn_seeds:
-  - 127.0.0.1:8101:localrack1:localdc1:437425602,1122629340,1683099499,2400294391,2772631304,4271597971
-  dyn_write_timeout: 200000
-  gos_interval: 10000
+  - 127.0.0.2:8101:localrack2:localdc2:5622637
   hash: murmur
-  listen: 127.0.0.2:8102
+  listen: 127.0.0.1:8102
   preconnect: true
-  server_retry_timeout: 200000
   servers:
   - 127.0.0.1:11211:1
   timeout: 10000
-  tokens: 5622637,721812480,851406979,1036155118,2147653893,2233516174
+  tokens: 3101134286
+  secure_server_option: none
+  pem_key_file: conf/dynomite.pem


### PR DESCRIPTION
dyn_seeds requires a datacenter.  Using DC1 as a default.
