### PR TITLE
Update RPM specfile to build 0.3.0 instead of older 0.1.x version.  Add ...

### DIFF
--- a/scripts/dynomite-aa
+++ b/scripts/dynomite-aa
@@ -1,0 +1,12 @@
+--- configure.ac	2014-10-02 20:07:56.000000000 +0000
++++ configure.ac	2014-12-11 19:08:12.000000000 +0000
+@@ -5,7 +5,7 @@
+ m4_define([DN_BUGS], [mdo@netflix.com])
+
+ # Initialize autoconf
+-AC_PREREQ([2.68])
++AC_PREREQ([2.63])
+ AC_INIT([dynomite], [DN_MAJOR.DN_MINOR.DN_PATCH], [DN_BUGS])
+ AC_CONFIG_SRCDIR([src/dynomite.c])
+ AC_CONFIG_AUX_DIR([config])
+

--- a/scripts/dynomite-ab
+++ b/scripts/dynomite-ab
@@ -1,0 +1,11 @@
+--- contrib/murmur3/makefile.orig	2014-12-11 19:51:26.000000000 +0000
++++ contrib/murmur3/makefile	2014-12-11 19:51:36.000000000 +0000
+@@ -3,5 +3,7 @@
+ all: example
+ example: murmur3.o
+
++install:
++
+ clean:
+ 	rm -rf *.o
+

--- a/scripts/dynomite.spec
+++ b/scripts/dynomite.spec
@@ -1,25 +1,33 @@
-Summary: Dynomite: generic replicator
-Name: dynomite
-Version: 0.1.19
-Release: 1
-URL: https://github.com/Netflix/Dynomite
-Source0: %{name}-%{version}.tar.gz
-License: Apache License 2.0
-Group: System Environment/Libraries
-Packager:  Tom Parrott <tomp@tomp.co.uk>
-BuildRoot: %{_tmppath}/%{name}-root
+Name:           dynomite
+Version:        0.3.0
+Release:        1%{?dist}
+Summary:        Netflix Dynomite
+
+License:       Apache 2.0
+URL:           https://github.com/Netflix/dynomite
+Source0:       https://github.com/Netflix/dynomite/archive/v0.3.0.tar.gz
+Patch0:	dynomite-aa
+Patch1: dynomite-ab
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+
+Group: Custom
+BuildRequires: gcc gcc-c++ make openssl-devel git
+Requires:      make
 
 %description
-dynomite is thin replication layer for different storage.  Currently, we support memcached and redis protocol.
-The goal is to use this as a caching system or a in-memory storage
+Netflix Dynomite.  Helps build redundant and cross-datacenter redis and memcache replication rings.
 
 %prep
-%setup -q
-autoreconf -fvi
+%setup -q -n %{name}-%{version}
+
+%patch -P 0
+%patch -P 1
 
 %build
+autoreconf -fvi
 
-%configure
+%configure --enable-debug=log
+
 %__make
 
 %install
@@ -47,6 +55,9 @@ fi
 
 %files
 %defattr(-,root,root,-)
-/usr/bin/dynomite
+/usr/sbin/dynomite
 %{_initrddir}/%{name}
 %config(noreplace)%{_sysconfdir}/%{name}/%{name}.yml
+
+%changelog
+


### PR DESCRIPTION
...patches to enable build with older autoconf (2.63 - on e.g. CentOS 6.3/6.5) and to add an empty 'install' makefile target to contrib/murmur.
