### PR TITLE
Support "touch" command for memcached and allow negative

### DIFF
--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -55,6 +55,7 @@ typedef enum msg_type {
     MSG_REQ_MC_PREPEND,
     MSG_REQ_MC_INCR,                      /* memcache arithmetic request */
     MSG_REQ_MC_DECR,
+    MSG_REQ_MC_TOUCH,                     /* memcache touch request */
     MSG_REQ_MC_QUIT,                      /* memcache quit request */
     MSG_RSP_MC_NUM,                       /* memcache arithmetic response */
     MSG_RSP_MC_STORED,                    /* memcache cas and storage response */
@@ -64,6 +65,7 @@ typedef enum msg_type {
     MSG_RSP_MC_END,
     MSG_RSP_MC_VALUE,
     MSG_RSP_MC_DELETED,                   /* memcache delete response */
+    MSG_RSP_MC_TOUCHED,                   /* memcachd touch response */
     MSG_RSP_MC_ERROR,                     /* memcache error responses */
     MSG_RSP_MC_CLIENT_ERROR,
     MSG_RSP_MC_SERVER_ERROR,

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -537,7 +537,7 @@ request_send_to_all_racks(struct msg *msg) {
     // yeah, there's probably a better way to do this...
     return t == MSG_REQ_MC_SET || t == MSG_REQ_MC_CAS || t == MSG_REQ_MC_DELETE || t == MSG_REQ_MC_ADD ||
            t == MSG_REQ_MC_REPLACE || t == MSG_REQ_MC_APPEND || t == MSG_REQ_MC_PREPEND || t == MSG_REQ_MC_INCR ||
-           t == MSG_REQ_MC_DECR;
+           t == MSG_REQ_MC_DECR || t == MSG_REQ_MC_TOUCH;
 }
 
 

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -558,7 +558,7 @@ memcache_parse_req(struct msg *r)
 
         case SW_SPACES_BEFORE_NUM:
             if (ch != ' ') {
-                if (!isdigit(ch)) {
+                if (!(isdigit(ch) || ch == '-')) {
                     goto error;
                 }
                 /* num_start <- p; num <- ch - '0'  */

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -126,6 +126,20 @@ memcache_delete(struct msg *r)
     return false;
 }
 
+/*
+ * Return true if the memcache command is a touch command, otherwise
+ * return false
+ */
+static bool
+memcache_touch(struct msg *r)
+{
+    if (r->type == MSG_REQ_MC_TOUCH) {
+        return true;
+    }
+
+    return false;
+}
+
 void
 memcache_parse_req(struct msg *r)
 {
@@ -254,6 +268,15 @@ memcache_parse_req(struct msg *r)
 
                     break;
 
+                case 5:
+                    if (str5cmp(m, 't', 'o', 'u', 'c', 'h')) {
+                        r->type = MSG_REQ_MC_TOUCH;
+                        r->is_read = 0;
+                        break;
+                    }
+
+                    break;
+
                 case 6:
                     if (str6cmp(m, 'a', 'p', 'p', 'e', 'n', 'd')) {
                         r->type = MSG_REQ_MC_APPEND;
@@ -297,6 +320,7 @@ memcache_parse_req(struct msg *r)
                 case MSG_REQ_MC_PREPEND:
                 case MSG_REQ_MC_INCR:
                 case MSG_REQ_MC_DECR:
+                case MSG_REQ_MC_TOUCH:
                     if (ch == CR) {
                         goto error;
                     }
@@ -345,7 +369,7 @@ memcache_parse_req(struct msg *r)
                 /* get next state */
                 if (memcache_storage(r)) {
                     state = SW_SPACES_BEFORE_FLAGS;
-                } else if (memcache_arithmetic(r)) {
+                } else if (memcache_arithmetic(r) || memcache_touch(r)) {
                     state = SW_SPACES_BEFORE_NUM;
                 } else if (memcache_delete(r)) {
                     state = SW_RUNTO_CRLF;
@@ -565,7 +589,7 @@ memcache_parse_req(struct msg *r)
                 break;
 
             case 'n':
-                if (memcache_storage(r) || memcache_arithmetic(r) || memcache_delete(r)) {
+                if (memcache_storage(r) || memcache_arithmetic(r) || memcache_delete(r) || memcache_touch(r)) {
                     /* noreply_start <- p */
                     r->token = p;
                     state = SW_NOREPLY;
@@ -596,7 +620,7 @@ memcache_parse_req(struct msg *r)
             case CR:
                 m = r->token;
                 if (((p - m) == 7) && str7cmp(m, 'n', 'o', 'r', 'e', 'p', 'l', 'y')) {
-                    ASSERT(memcache_storage(r) || memcache_arithmetic(r) || memcache_delete(r));
+                    ASSERT(memcache_storage(r) || memcache_arithmetic(r) || memcache_delete(r) || memcache_touch(r));
                     r->token = NULL;
                     /* noreply_end <- p - 1 */
                     r->noreply = 1;
@@ -861,6 +885,11 @@ memcache_parse_rsp(struct msg *r)
                         break;
                     }
 
+                    if (str7cmp(m, 'T', 'O', 'U', 'C', 'H', 'E', 'D')) {
+                        r->type = MSG_RSP_MC_TOUCHED;
+                        break;
+                    }
+
                     break;
 
                 case 9:
@@ -902,6 +931,7 @@ memcache_parse_rsp(struct msg *r)
                 case MSG_RSP_MC_EXISTS:
                 case MSG_RSP_MC_NOT_FOUND:
                 case MSG_RSP_MC_DELETED:
+                case MSG_RSP_MC_TOUCHED:
                     state = SW_CRLF;
                     break;
 


### PR DESCRIPTION
The [touch command](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L318) is neither supported in dynomite nor in twemproxy(cc @manju @idning ), I'm not sure if there's any deliberate purpose, if so, please tell me.

Touch with negative exptime is supported by memcached while not well documented. I'm not familiar with its inner implements but I guess the proxy should better transport without any interruption.

```
 telnet localhost 11211
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
set foo 0 0 2
10
STORED
get foo
VALUE foo 0 2
10
END
touch foo -1
TOUCHED
get foo
END
```