### PR TITLE
Encapsulate request forwarding inside the protocol definition itself for messages that need replication

### DIFF
--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -326,6 +326,7 @@ msg_get(struct conn *conn, bool request, bool redis)
         msg->post_splitcopy = redis_post_splitcopy;
         msg->pre_coalesce = redis_pre_coalesce;
         msg->post_coalesce = redis_post_coalesce;
+        msg->broadcast_racks = redis_broadcast_racks;
     } else {
         if (request) {
             if (conn->dyn_mode) {
@@ -344,6 +345,7 @@ msg_get(struct conn *conn, bool request, bool redis)
         msg->post_splitcopy = memcache_post_splitcopy;
         msg->pre_coalesce = memcache_pre_coalesce;
         msg->post_coalesce = memcache_post_coalesce;
+        msg->broadcast_racks = memcache_broadcast_racks;
     }
 
     log_debug(LOG_VVERB, "get msg %p id %"PRIu64" request %d owner sd %d",

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1320,3 +1320,32 @@ void
 memcache_post_coalesce(struct msg *r)
 {
 }
+
+
+/*
+ * Broadcast-racks is invoked to determine whether a message needs to
+ * be sent to all downstream replicas. Returning 'true' will invoke
+ * replication, 'false' will not. In general, all write operations
+ * should return 'true' and all read operations should return 'false'
+ */
+bool
+memcache_broadcast_racks(struct msg *r)
+{
+    switch (r->type) {
+    case MSG_REQ_MC_SET:
+    case MSG_REQ_MC_CAS:
+    case MSG_REQ_MC_DELETE:
+    case MSG_REQ_MC_ADD:
+    case MSG_REQ_MC_REPLACE:
+    case MSG_REQ_MC_APPEND:
+    case MSG_REQ_MC_PREPEND:
+    case MSG_REQ_MC_INCR:
+    case MSG_REQ_MC_DECR:
+        return true;
+
+    default:
+        break;
+    }
+
+    return false;
+}

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -35,6 +35,7 @@ void memcache_pre_splitcopy(struct mbuf *mbuf, void *arg);
 rstatus_t memcache_post_splitcopy(struct msg *r);
 void memcache_pre_coalesce(struct msg *r);
 void memcache_post_coalesce(struct msg *r);
+bool memcache_broadcast_racks(struct msg *r);
 
 void redis_parse_req(struct msg *r);
 void redis_parse_rsp(struct msg *r);
@@ -42,5 +43,6 @@ void redis_pre_splitcopy(struct mbuf *mbuf, void *arg);
 rstatus_t redis_post_splitcopy(struct msg *r);
 void redis_pre_coalesce(struct msg *r);
 void redis_post_coalesce(struct msg *r);
+bool redis_broadcast_racks(struct msg *r);
 
 #endif

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -2256,3 +2256,44 @@ redis_post_coalesce(struct msg *r)
         NOT_REACHED();
     }
 }
+
+/*
+ * Broadcast-racks is invoked to determine whether a message needs to
+ * be sent to all downstream replicas. Returning 'true' will invoke
+ * replication, 'false' will not. In general, all write operations
+ * should return 'true' and all read operations should return 'false'
+ */
+
+bool
+redis_broadcast_racks(struct msg *r)
+{
+    switch (r->type) {
+    case MSG_REQ_REDIS_SET:
+    case MSG_REQ_REDIS_DEL:
+    case MSG_REQ_REDIS_DECR:
+    case MSG_REQ_REDIS_HDEL:
+    case MSG_REQ_REDIS_HSET:
+    case MSG_REQ_REDIS_INCR:
+    case MSG_REQ_REDIS_LPOP:
+    case MSG_REQ_REDIS_LREM:
+    case MSG_REQ_REDIS_LSET:
+    case MSG_REQ_REDIS_RPOP:
+    case MSG_REQ_REDIS_SADD:
+    case MSG_REQ_REDIS_SPOP:
+    case MSG_REQ_REDIS_SREM:
+    case MSG_REQ_REDIS_ZADD:
+    case MSG_REQ_REDIS_ZREM:
+    case MSG_REQ_REDIS_HMSET:
+    case MSG_REQ_REDIS_LPUSH:
+    case MSG_REQ_REDIS_LTRIM:
+    case MSG_REQ_REDIS_RPUSH:
+    case MSG_REQ_REDIS_SETEX:
+    case MSG_REQ_REDIS_SETNX:
+        return true;
+
+    default:
+        break;
+    }
+
+    return false;
+}


### PR DESCRIPTION
Hey!

In a very first step towards the goal outlined in https://github.com/Netflix/dynomite/issues/85, this PR removes the `request_send_to_all_racks(struct msg *msg)` call inside `dyn_request` in favor of encapsulated protocol level functions that check if downstream replication is needed.

Also: can you think of a better name than `broadcast_racks`?

Let me know what you think,

Blake