### PR TITLE
Added support for HyperLogLog's PFADD and PFCOUNT

### DIFF
--- a/notes/redis.md
+++ b/notes/redis.md
@@ -248,6 +248,19 @@
 * ZINTERSTORE and ZUNIONSTORE support requires that the supplied keys hash to the same server. You can ensure this by using the same [hashtag](notes/recommendation.md#hash-tags) for all keys in the command. Dynomite does no checking on its end to verify that all the keys hash to the same server, and the given command is forwarded to the server that the first key hashes to.
 
 
+### HyperLogLog
+
+    +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+
+    |      Command      | Supported? | Format                                                                                                              |
+    +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+
+    |     PFADD         |    Yes     | PFADD key element [element...]                                                                                      |
+    +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+
+    |     PFCOUNT       |    Yes     | PFCOUNT key [key...]                                                                                                |
+    +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+
+    |     PFMERGE       |    No      | PFMERGE destkey sourcekey [sourcekey ...]                                                                           |
+    +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+
+
+
 ### Pub/Sub
 
     +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+

--- a/scripts/redis-check.sh
+++ b/scripts/redis-check.sh
@@ -561,6 +561,19 @@ printf '*6\r\n$4\r\nzadd\r\n$7\r\n{zfoo}2\r\n$3\r\n100\r\n$3\r\nbar\r\n$3\r\n101
 printf '*5\r\n$11\r\nzunionstore\r\n$7\r\n{zfoo}3\r\n$1\r\n2\r\n$6\r\n{zfoo}\r\n$7\r\n{zfoo}2\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
 printf '*5\r\n$6\r\nzrange\r\n$7\r\n{zfoo}3\r\n$1\r\n0\r\n$1\r\n3\r\n$10\r\nWITHSCORES\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
 
+# hyperloglog
+
+printf '\npfadd\n'
+printf '*2\r\n$3\r\ndel\r\n$4\r\npfoo\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
+printf '*4\r\n$5\r\npfadd\r\n$4\r\npfoo\r\n$3\r\nbar\r\n$3\r\nbas\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
+printf '*2\r\n$7\r\npfcount\r\n$4\r\npfoo\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
+
+printf '\npfcount\n'
+printf '*2\r\n$3\r\ndel\r\n$4\r\npfoo\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
+printf '*2\r\n$7\r\npfcount\r\n$4\r\npfoo\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
+printf '*4\r\n$5\r\npfadd\r\n$4\r\npfoo\r\n$3\r\nbar\r\n$3\r\nbas\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
+printf '*2\r\n$7\r\npfcount\r\n$4\r\npfoo\r\n' | socat ${debug} ${timeout} - TCP:localhost:${port},shut-close
+
 # scripting
 
 printf '\neval\n'

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -133,6 +133,8 @@ typedef enum msg_type {
     MSG_REQ_REDIS_RPOPLPUSH,
     MSG_REQ_REDIS_RPUSH,
     MSG_REQ_REDIS_RPUSHX,
+    MSG_REQ_REDIS_PFADD,                     /* redis requests - hyperloglog */
+    MSG_REQ_REDIS_PFCOUNT,
     MSG_REQ_REDIS_SADD,                   /* redis requests - sets */
     MSG_REQ_REDIS_SCARD,
     MSG_REQ_REDIS_SDIFF,

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -63,6 +63,7 @@ redis_arg0(struct msg *r)
     case MSG_REQ_REDIS_ZCARD:
 
     case MSG_REG_REDIS_KEYS:
+    case MSG_REQ_REDIS_PFCOUNT:
         return true;
 
     default:
@@ -210,6 +211,7 @@ redis_argn(struct msg *r)
     case MSG_REQ_REDIS_ZREVRANGE:
     case MSG_REQ_REDIS_ZREVRANGEBYSCORE:
     case MSG_REQ_REDIS_ZUNIONSTORE:
+    case MSG_REQ_REDIS_PFADD:
         return true;
 
     default:
@@ -698,6 +700,11 @@ redis_parse_req(struct msg *r)
                     break;
                 }
 
+                if (str5icmp(m, 'p', 'f', 'a', 'd', 'd')) {
+                    r->type = MSG_REQ_REDIS_PFADD;
+                    break;
+                }
+
                 break;
 
             case 6:
@@ -882,6 +889,11 @@ redis_parse_req(struct msg *r)
                     r->type = MSG_REQ_REDIS_SLAVEOF;
                     r->msg_type = 1;
                     r->is_read = 0;
+                    break;
+                }
+
+                if (str7icmp(m, 'p', 'f', 'c', 'o', 'u', 'n', 't')) {
+                    r->type = MSG_REQ_REDIS_PFCOUNT;
                     break;
                 }
 


### PR DESCRIPTION
Added HyperLogLog PFADD & PFCOUNT operations. 

Ported from the Twemproxy PR mentioned in this issue
https://github.com/Netflix/dynomite/issues/42

Note: PFMERGE wasn't added due to the fact that we can't guarantee that they keys live on the same node.

Note 2: PFCOUNT supports multiple keys. If multiple keys are specified Redis will return the union of their cardinality. Internally, it performs a PFMERGE operation. This is not supported here since we can't guarantee that the keys live on the same node.