### PR TITLE
Rectify Dnode msg id

### DIFF
--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -540,6 +540,8 @@ dnode_peer_ack_err(struct context *ctx, struct conn *conn, struct msg*msg)
     rsp->error = msg->error = 1;
     rsp->err = msg->err = conn->err;
     rsp->dyn_error = msg->dyn_error = PEER_CONNECTION_REFUSE;
+    rsp->dmsg = dmsg_get();
+    rsp->dmsg->id = msg->id;
 
     log_debug(LOG_INFO, "dyn: close s %d schedule error for req %"PRIu64" "
               "len %"PRIu32" type %d from c %d%c %s", conn->sd, msg->id,

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -388,8 +388,6 @@ void dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
         return;
     }
 
-    uint64_t msg_id = peer_msg_id++;
-
     struct mbuf *header_buf = mbuf_get();
     if (header_buf == NULL) {
         loga("Unable to obtain an mbuf for dnode msg's header!");
@@ -420,17 +418,17 @@ void dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
                log_debug(LOG_VERB, "#encrypted bytes : %d", status);
             }
 
-            dmsg_write(header_buf, msg_id, msg_type, p_conn, msg_length(msg));
+            dmsg_write(header_buf, msg->id, msg_type, p_conn, msg_length(msg));
         } else {
             if (log_loggable(LOG_VVERB)) {
                log_debug(LOG_VERB, "no encryption on the msg payload");
             }
-            dmsg_write(header_buf, msg_id, msg_type, p_conn, msg_length(msg));
+            dmsg_write(header_buf, msg->id, msg_type, p_conn, msg_length(msg));
         }
 
     } else {
         //write dnode header
-        dmsg_write(header_buf, msg_id, msg_type, p_conn, msg_length(msg));
+        dmsg_write(header_buf, msg->id, msg_type, p_conn, msg_length(msg));
     }
 
     mbuf_insert_head(&msg->mhdr, header_buf);

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -66,6 +66,7 @@
     ACTION( peer_in_queue_bytes,          STATS_GAUGE,        "current peer request bytes in incoming queue")             \
     ACTION( peer_out_queue,               STATS_GAUGE,        "# peer requests in outgoing queue")                        \
     ACTION( peer_out_queue_bytes,         STATS_GAUGE,        "current peer request bytes in outgoing queue")             \
+    ACTION( peer_mismatch_requests,       STATS_COUNTER,      "current dnode peer mismatched messages")                   \
     /* forwarder behavior */                                                                                              \
     ACTION( forward_error,                STATS_COUNTER,      "# times we encountered a forwarding error")                \
     ACTION( fragments,                    STATS_COUNTER,      "# fragments created from a multi-vector request")          \


### PR DESCRIPTION
While testing the consistency feature, it was observed that there were a lot of
inconsistencies. Further digging it was found out that the dnode message responses
were off by one. This patch is for the ground work for that issue.

This patch uses the request's message id as the id in the dnode msg header. That
way the responses and requests can be matched.
There was another bug where while sending responses to the dnode message, the code
would use the same dnode msg id for all the responses (that was the dnode msg id
for the dnode msg at the head of the out queue). Rectified that too. Yay!!