### PR TITLE
set_consistency interface on stats port

### DIFF
--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -192,8 +192,8 @@ _conn_get(void)
     conn->attempted_reconnect = 0;
     conn->non_bytes_recv = 0;
     //conn->non_bytes_send = 0;
-    conn_set_read_consistency(conn, DEFAULT_READ_CONSISTENCY);
-    conn_set_write_consistency(conn, DEFAULT_WRITE_CONSISTENCY);
+    conn_set_read_consistency(conn, g_read_consistency);
+    conn_set_write_consistency(conn, g_write_consistency);
     conn->type = CONN_UNSPECIFIED;
     conn->rsp_handler = conn_cant_handle_response; // default rsp handler
 

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -142,7 +142,8 @@ typedef enum {
     CMD_LOG_LEVEL_UP,
     CMD_LOG_LEVEL_DOWN,
     CMD_HISTO_RESET,
-    CMD_CL_DESCRIBE /* cluster_describe */
+    CMD_CL_DESCRIBE,  /* cluster_describe */
+    CMD_SET_CONSISTENCY
 } stats_cmd_t;
 
 struct stats_metric {


### PR DESCRIPTION
    o to keep things going faster implement a stats port command to set consistency
    o seperate url for read and write
    o tested using : curl http://localhost:22224/set_consistency/write/local_quorum
      and curl http://localhost:22224/set_consistency/write/local_one
    o Important Caveat: With this all messages will start having the same
      consistency level irrespective of the connection.