### PR TITLE
Rectify the dnode request response mismatch

### DIFF
--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -110,6 +110,8 @@ conn_to_ctx(struct conn *conn)
         pool = conn->owner;
     } else {
         struct server *server = conn->owner;
+        if (!server)
+            return NULL;
         pool = server->owner;
     }
 

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -212,6 +212,9 @@ dnode_req_forward(struct context *ctx, struct conn *conn, struct msg *msg)
     if (log_loggable(LOG_DEBUG)) {
        log_debug(LOG_DEBUG, "dnode_req_forward entering ");
     }
+    log_debug(LOG_DEBUG, "DNODE REQ RECEIVED %c %d dmsg->id %u",
+             conn->dnode_client ? 'c' : (conn->dnode_server ? 's' : 'p'),
+             conn->sd, msg->dmsg->id);
 
     ASSERT(conn->dnode_client && !conn->dnode_server);
 
@@ -342,6 +345,9 @@ dnode_req_send_done(struct context *ctx, struct conn *conn, struct msg *msg)
        log_debug(LOG_VERB, "dnode_req_send_done entering!!!");
     }
     ASSERT(!conn->dnode_client && !conn->dnode_server);
+    log_debug(LOG_DEBUG, "DNODE REQ SEND %c %d dmsg->id %u",
+             conn->dnode_client ? 'c' : (conn->dnode_server ? 's' : 'p'),
+             conn->sd, msg->dmsg->id);
     req_send_done(ctx, conn, msg);
 }
 

--- a/src/dyn_log.h
+++ b/src/dyn_log.h
@@ -66,6 +66,8 @@ struct logger {
 
 #define log_notice(...)                                                     \
     log_debug(LOG_NOTICE, __VA_ARGS__);
+#define log_info(...)                                                     \
+    log_debug(LOG_INFO, __VA_ARGS__);
 
 #define log_hexdump(_level, _data, _datalen, ...) do {                      \
     if (log_loggable(_level) != 0) {                                        \


### PR DESCRIPTION
    o This patch skips over the dnode request in the connection outqueue if it
      sees a response from a latter request.
    o Adds some extra debugging just in case there are issues.
    o Adds extra logging when non consistent data is seen
    o Rename variables to exactly depict what is req and what is rsp