### PR TITLE
Differentiate between stats for local dc and remote dc peers

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -407,7 +407,10 @@ core_timeout(struct context *ctx)
 		if (conn->dyn_mode) {
 			if (!conn->dnode_client && !conn->dnode_server) { //outgoing peer requests
 		 	   struct server *server = conn->owner;
-			   stats_pool_incr(ctx, server->owner, peer_timedout_requests);
+                if (conn->same_dc)
+			        stats_pool_incr(ctx, server->owner, peer_timedout_requests);
+                else
+			        stats_pool_incr(ctx, server->owner, remote_peer_timedout_requests);
 			}
 		} else {
 			if (!conn->client && !conn->proxy) { //storage server requests

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -71,7 +71,10 @@ dnode_req_peer_dequeue_imsgq(struct context *ctx, struct conn *conn, struct msg 
     log_debug(LOG_VERB, "conn %p dequeue inq %d:%d", conn, msg->id, msg->parent_id);
 
     struct server_pool *pool = (struct server_pool *) array_get(&ctx->pool, 0);
-    stats_pool_decr(ctx, pool, peer_in_queue);
+    if (conn->same_dc)
+        stats_pool_decr(ctx, pool, peer_in_queue);
+    else
+        stats_pool_decr(ctx, pool, remote_peer_in_queue);
     stats_pool_decr_by(ctx, pool, peer_in_queue_bytes, msg->mlen);
 }
 
@@ -101,7 +104,10 @@ dnode_req_peer_enqueue_omsgq(struct context *ctx, struct conn *conn, struct msg 
 
     //use only the 1st pool
     struct server_pool *pool = (struct server_pool *) array_get(&ctx->pool, 0);
-    stats_pool_incr(ctx, pool, peer_out_queue);
+    if (conn->same_dc)
+        stats_pool_incr(ctx, pool, peer_out_queue);
+    else
+        stats_pool_incr(ctx, pool, remote_peer_out_queue);
    stats_pool_incr_by(ctx, pool, peer_out_queue_bytes, msg->mlen);
 }
 

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -264,7 +264,10 @@ req_server_enqueue_imsgq(struct context *ctx, struct conn *conn, struct msg *msg
        stats_server_incr_by(ctx, conn->owner, in_queue_bytes, msg->mlen);
     } else {
        struct server_pool *pool = (struct server_pool *) array_get(&ctx->pool, 0);
-       stats_pool_incr(ctx, pool, peer_in_queue);
+       if (conn->same_dc)
+            stats_pool_incr(ctx, pool, peer_in_queue);
+        else
+            stats_pool_incr(ctx, pool, remote_peer_in_queue);
        stats_pool_incr_by(ctx, pool, peer_in_queue_bytes, msg->mlen);
     }
 }

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -50,11 +50,13 @@
     ACTION( dnode_client_out_queue,       STATS_GAUGE,        "# dnode client requests in outgoing queue")                \
     ACTION( dnode_client_out_queue_bytes, STATS_GAUGE,        "current dnode client request bytes in outgoing queue")     \
     /* peer behavior */                                                                                                   \
-    ACTION( peer_dropped_requests,        STATS_COUNTER,      "# peer dropped requests")                                  \
-    ACTION( peer_timedout_requests,       STATS_COUNTER,      "# peer timedout requests")                                 \
+    ACTION( peer_dropped_requests,        STATS_COUNTER,      "# local dc peer dropped requests")                                  \
+    ACTION( peer_timedout_requests,       STATS_COUNTER,      "# local dc peer timedout requests")                                 \
+    ACTION( remote_peer_timedout_requests,STATS_COUNTER,      "# remote dc peer timedout requests")                                 \
     ACTION( peer_eof,                     STATS_COUNTER,      "# eof on peer connections")                                \
     ACTION( peer_err,                     STATS_COUNTER,      "# errors on peer connections")                             \
-    ACTION( peer_timedout,                STATS_COUNTER,      "# timeouts on peer connections")                           \
+    ACTION( peer_timedout,                STATS_COUNTER,      "# timeouts on local dc peer connections")                           \
+    ACTION( remote_peer_timedout,         STATS_COUNTER,      "# timeouts on remote dc peer connections")                           \
     ACTION( peer_connections,             STATS_GAUGE,        "# active peer connections")                                \
     ACTION( peer_forward_error,           STATS_GAUGE,        "# times we encountered a peer forwarding error")           \
     ACTION( peer_requests,                STATS_COUNTER,      "# peer requests")                                          \
@@ -62,9 +64,11 @@
     ACTION( peer_responses,               STATS_COUNTER,      "# peer respones")                                          \
     ACTION( peer_response_bytes,          STATS_COUNTER,      "total peer response bytes")                                \
     ACTION( peer_ejects,                  STATS_COUNTER,      "# times a peer was ejected")                               \
-    ACTION( peer_in_queue,                STATS_GAUGE,        "# peer requests in incoming queue")                        \
+    ACTION( peer_in_queue,                STATS_GAUGE,        "# local dc peer requests in incoming queue")                        \
+    ACTION( remote_peer_in_queue,         STATS_GAUGE,        "# remote dc peer requests in incoming queue")                        \
     ACTION( peer_in_queue_bytes,          STATS_GAUGE,        "current peer request bytes in incoming queue")             \
-    ACTION( peer_out_queue,               STATS_GAUGE,        "# peer requests in outgoing queue")                        \
+    ACTION( peer_out_queue,               STATS_GAUGE,        "# local dc peer requests in outgoing queue")                        \
+    ACTION( remote_peer_out_queue,        STATS_GAUGE,        "# remote dc peer requests in outgoing queue")                        \
     ACTION( peer_out_queue_bytes,         STATS_GAUGE,        "current peer request bytes in outgoing queue")             \
     ACTION( peer_mismatch_requests,       STATS_COUNTER,      "current dnode peer mismatched messages")                   \
     /* forwarder behavior */                                                                                              \


### PR DESCRIPTION
It will be helpful to differentiate between local and remote dc stats. Especially when we start hitting capacity of the cluster.