### PR TITLE
Connection code cleanup

### DIFF
--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -106,7 +106,10 @@ conn_to_ctx(struct conn *conn)
 {
     struct server_pool *pool;
 
-    if (conn->proxy || conn->client || conn->dnode_server || conn->dnode_client) {
+    if ((conn->type == CONN_PROXY) ||
+        (conn->type == CONN_CLIENT) ||
+        (conn->type == CONN_DNODE_SERVER)||
+        (conn->type == CONN_DNODE_PEER_CLIENT)) {
         pool = conn->owner;
     } else {
         struct server *server = conn->owner;
@@ -172,8 +175,6 @@ _conn_get(void)
     conn->send_active = 0;
     conn->send_ready = 0;
 
-    conn->client = 0;
-    conn->proxy = 0;
     conn->connecting = 0;
     conn->connected = 0;
     conn->eof = 0;
@@ -181,8 +182,6 @@ _conn_get(void)
     conn->data_store = DATA_REDIS;
 
     /* for dynomite */
-    conn->dnode_client = 0;
-    conn->dnode_server = 0;
     conn->dyn_mode = 0;
     conn->dnode_secured = 0;
     conn->dnode_crypto_state = 0;
@@ -197,7 +196,6 @@ _conn_get(void)
     conn_set_read_consistency(conn, g_read_consistency);
     conn_set_write_consistency(conn, g_write_consistency);
     conn->type = CONN_UNSPECIFIED;
-    conn->rsp_handler = conn_cant_handle_response; // default rsp handler
 
     unsigned char *ase_key = generate_aes_key();
     strncpy(conn->aes_key, ase_key, strlen(ase_key)); //generate a new key for each connection
@@ -237,6 +235,41 @@ test_conn_get(void)
    return _conn_get();
 }
 
+struct conn_ops dnode_peer_client_ops = {
+    msg_recv,
+    dnode_req_recv_next,
+    dnode_req_recv_done,
+    msg_send,
+    dnode_rsp_send_next,
+    dnode_rsp_send_done,
+    dnode_client_close,
+    dnode_client_active,
+    dnode_client_ref,
+    dnode_client_unref,
+    NULL,
+    NULL,
+    dnode_req_client_enqueue_omsgq,
+    dnode_req_client_dequeue_omsgq,
+    dnode_client_handle_response 
+};
+
+struct conn_ops dnode_peer_server_ops = {
+    msg_recv,
+    dnode_rsp_recv_next,
+    dnode_rsp_recv_done,
+    msg_send,
+    dnode_req_send_next,
+    dnode_req_send_done,
+    dnode_peer_close,
+    dnode_peer_active,
+    dnode_peer_ref,
+    dnode_peer_unref,
+    dnode_req_peer_enqueue_imsgq,
+    dnode_req_peer_dequeue_imsgq,
+    dnode_req_peer_enqueue_omsgq,
+    dnode_req_peer_dequeue_omsgq,
+    conn_cant_handle_response
+};
 
 struct conn *
 conn_get_peer(void *owner, bool client, int data_store)
@@ -249,33 +282,15 @@ conn_get_peer(void *owner, bool client, int data_store)
     }
 
     conn->data_store = data_store;
-    conn->dnode_client = client? 1 : 0;   
     conn->dyn_mode = 1;
 
-    if (conn->dnode_client) {
+    if (client) {
         /* incoming peer connection to dnode server
          * dyn client receives a request, possibly parsing it, and sends a
          * response downstream.
          */
         conn->type = CONN_DNODE_PEER_CLIENT;
-        conn->recv = msg_recv;
-        conn->recv_next = dnode_req_recv_next;
-        conn->recv_done = dnode_req_recv_done;
-
-        conn->send = msg_send;
-        conn->send_next = dnode_rsp_send_next;
-        conn->send_done = dnode_rsp_send_done;
-
-        conn->close = dnode_client_close;
-        conn->active = dnode_client_active;
-
-        conn->ref = dnode_client_ref;
-        conn->unref = dnode_client_unref;
-
-        conn->enqueue_inq = NULL;
-        conn->dequeue_inq = NULL;
-        conn->enqueue_outq = dnode_req_client_enqueue_omsgq;
-        conn->dequeue_outq = dnode_req_client_dequeue_omsgq;
+        conn->ops = &dnode_peer_client_ops;
     } else {
         /*
          * outgoing peer connection
@@ -283,33 +298,51 @@ conn_get_peer(void *owner, bool client, int data_store)
          * request upstream.
          */
         conn->type = CONN_DNODE_PEER_SERVER;
-        conn->recv = msg_recv;
-        conn->recv_next = dnode_rsp_recv_next;
-        conn->recv_done = dnode_rsp_recv_done;
-
-        conn->send = msg_send;
-        conn->send_next = dnode_req_send_next;
-        conn->send_done = dnode_req_send_done;
-
-        conn->close = dnode_peer_close;
-        conn->active = dnode_peer_active;
-
-        conn->ref = dnode_peer_ref;
-        conn->unref = dnode_peer_unref;
- 
-        conn->enqueue_inq = dnode_req_peer_enqueue_imsgq;
-        conn->dequeue_inq = dnode_req_peer_dequeue_imsgq;
-        conn->enqueue_outq = dnode_req_peer_enqueue_omsgq;
-        conn->dequeue_outq = dnode_req_peer_dequeue_omsgq;
+        conn->ops = &dnode_peer_server_ops;
     }
 
-    conn->ref(conn, owner);
+    conn_ref(conn, owner);
 
-    log_debug(LOG_VVERB, "get dyn peer  conn %p client %d", conn, conn->dnode_client);
+    log_debug(LOG_VVERB, "get conn %p %s", conn, conn_get_type_string(conn));
 
     return conn;
 }
 
+struct conn_ops client_ops = {
+    msg_recv,
+    req_recv_next,
+    req_recv_done,
+    msg_send,
+    rsp_send_next,
+    rsp_send_done,
+    client_close,
+    client_active,
+    client_ref,
+    client_unref,
+    NULL,
+    NULL,
+    req_client_enqueue_omsgq,
+    req_client_dequeue_omsgq,
+    client_handle_response 
+};
+
+struct conn_ops server_ops = {
+    msg_recv,
+    rsp_recv_next,
+    server_rsp_recv_done,
+    msg_send,
+    req_send_next,
+    req_send_done,
+    server_close,
+    server_active,
+    server_ref,
+    server_unref,
+    req_server_enqueue_imsgq,
+    req_server_dequeue_imsgq,
+    req_server_enqueue_omsgq,
+    req_server_dequeue_omsgq,
+    conn_cant_handle_response
+};
 
 struct conn *
 conn_get(void *owner, bool client, int data_store)
@@ -324,66 +357,48 @@ conn_get(void *owner, bool client, int data_store)
     /* connection handles the data store messages (redis, memcached or other) */
     conn->data_store = data_store;
 
-    conn->client = client ? 1 : 0;
     conn->dyn_mode = 0;
 
-    if (conn->client) {
+    if (client) {
         /*
          * client receives a request, possibly parsing it, and sends a
          * response downstream.
          */
         conn->type = CONN_CLIENT;
-        conn->recv = msg_recv;
-        conn->recv_next = req_recv_next;
-        conn->recv_done = req_recv_done;
-
-        conn->send = msg_send;
-        conn->send_next = rsp_send_next;
-        conn->send_done = rsp_send_done;
-
-        conn->close = client_close;
-        conn->active = client_active;
-
-        conn->ref = client_ref;
-        conn->unref = client_unref;
-
-        conn->enqueue_inq = NULL;
-        conn->dequeue_inq = NULL;
-        conn->enqueue_outq = req_client_enqueue_omsgq;
-        conn->dequeue_outq = req_client_dequeue_omsgq;
+        conn->ops = &client_ops;
     } else {
         /*
          * server receives a response, possibly parsing it, and sends a
          * request upstream.
          */
         conn->type = CONN_SERVER;
-        conn->recv = msg_recv;
-        conn->recv_next = rsp_recv_next;
-        conn->recv_done = server_rsp_recv_done;
-
-        conn->send = msg_send;
-        conn->send_next = req_send_next;
-        conn->send_done = req_send_done;
-
-        conn->close = server_close;
-        conn->active = server_active;
-
-        conn->ref = server_ref;
-        conn->unref = server_unref;
-
-        conn->enqueue_inq = req_server_enqueue_imsgq;
-        conn->dequeue_inq = req_server_dequeue_imsgq;
-        conn->enqueue_outq = req_server_enqueue_omsgq;
-        conn->dequeue_outq = req_server_dequeue_omsgq;
+        conn->ops = &server_ops;
     }
 
-    conn->ref(conn, owner);
+    conn_ref(conn, owner);
 
-    log_debug(LOG_VVERB, "get conn %p client %d", conn, conn->client);
+    log_debug(LOG_VVERB, "get conn %p %s", conn, conn_get_type_string(conn));
 
     return conn;
 }
 
+struct conn_ops dnode_server_ops = {
+    dnode_recv,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    dnode_close,
+    NULL,
+    dnode_ref,
+    dnode_unref,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    conn_cant_handle_response
+};
 
 struct conn *
 conn_get_dnode(void *owner)
@@ -399,35 +414,33 @@ conn_get_dnode(void *owner)
     conn->data_store = pool->data_store;
     conn->type = CONN_DNODE_SERVER;
 
-    conn->dnode_server = 1;
     conn->dyn_mode = 1;
+    conn->ops = &dnode_server_ops;
+    conn_ref(conn, owner);
 
-    conn->recv = dnode_recv;
-    conn->recv_next = NULL;
-    conn->recv_done = NULL;
-
-    conn->send = NULL;
-    conn->send_next = NULL;
-    conn->send_done = NULL;
-
-    conn->close = dnode_close;
-    conn->active = NULL;
-
-    conn->ref = dnode_ref;
-    conn->unref = dnode_unref;
-
-    conn->enqueue_inq = NULL;
-    conn->dequeue_inq = NULL;
-    conn->enqueue_outq = NULL;
-    conn->dequeue_outq = NULL;
-
-    conn->ref(conn, owner);
-
-    log_debug(LOG_VVERB, "get conn %p dnode %d", conn, conn->proxy);
+    log_debug(LOG_VVERB, "get conn %p %s", conn, conn_get_type_string(conn));
 
     return conn;
 }
 
+struct conn_ops proxy_ops = {
+    proxy_recv,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    proxy_close,
+    NULL,
+    proxy_ref,
+    proxy_unref,
+    // enqueue, dequeues
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    conn_cant_handle_response
+};
 
 struct conn *
 conn_get_proxy(void *owner)
@@ -443,31 +456,12 @@ conn_get_proxy(void *owner)
     conn->type = CONN_PROXY;
     conn->data_store = pool->data_store;
 
-    conn->proxy = 1;
     conn->dyn_mode = 0;
+    conn->ops = &proxy_ops;
 
-    conn->recv = proxy_recv;
-    conn->recv_next = NULL;
-    conn->recv_done = NULL;
+    conn_ref(conn, owner);
 
-    conn->send = NULL;
-    conn->send_next = NULL;
-    conn->send_done = NULL;
-
-    conn->close = proxy_close;
-    conn->active = NULL;
-
-    conn->ref = proxy_ref;
-    conn->unref = proxy_unref;
-
-    conn->enqueue_inq = NULL;
-    conn->dequeue_inq = NULL;
-    conn->enqueue_outq = NULL;
-    conn->dequeue_outq = NULL;
-
-    conn->ref(conn, owner);
-
-    log_debug(LOG_VVERB, "get conn %p proxy %d", conn, conn->proxy);
+    log_debug(LOG_VVERB, "get conn %p %s", conn, conn_get_type_string(conn));
 
     return conn;
 }
@@ -514,7 +508,7 @@ conn_deinit(void)
 }
 
 ssize_t
-conn_recv(struct conn *conn, void *buf, size_t size)
+conn_recv_data(struct conn *conn, void *buf, size_t size)
 {
     ssize_t n;
 
@@ -566,7 +560,7 @@ conn_recv(struct conn *conn, void *buf, size_t size)
 }
 
 ssize_t
-conn_sendv(struct conn *conn, struct array *sendv, size_t nsend)
+conn_sendv_data(struct conn *conn, struct array *sendv, size_t nsend)
 {
     ssize_t n;
 
@@ -624,21 +618,14 @@ conn_print(struct conn *conn)
 {
 	log_debug(LOG_VERB, "sd %d", conn->sd);
 	log_debug(LOG_VERB, "data store %d", conn->data_store);
-
-	log_debug(LOG_VERB, "client %d", conn->client);
-	log_debug(LOG_VERB, "proxy %d", conn->proxy);
+	log_debug(LOG_VERB, "Type: %s", conn_get_type_string(conn));
 
 	log_debug(LOG_VERB, "dyn_mode %d", conn->dyn_mode);
-
-	log_debug(LOG_VERB, "dnode_client %d", conn->dnode_client);
-	log_debug(LOG_VERB, "dnode_server %d", conn->dnode_server);
-
 
 	log_debug(LOG_VERB, "dnode_crypto_state %d", conn->dnode_crypto_state);
 	log_debug(LOG_VERB, "dnode_secured %d", conn->dnode_secured);
 
 	log_debug(LOG_VERB, "connected %d", conn->connected);
-	log_debug(LOG_VERB, "dnode_client %d", conn->connecting);
 	log_debug(LOG_VERB, "done %d", conn->done);
 
 

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -108,7 +108,7 @@ conn_to_ctx(struct conn *conn)
 
     if ((conn->type == CONN_PROXY) ||
         (conn->type == CONN_CLIENT) ||
-        (conn->type == CONN_DNODE_SERVER)||
+        (conn->type == CONN_DNODE_PEER_PROXY)||
         (conn->type == CONN_DNODE_PEER_CLIENT)) {
         pool = conn->owner;
     } else {
@@ -412,7 +412,7 @@ conn_get_dnode(void *owner)
     }
 
     conn->data_store = pool->data_store;
-    conn->type = CONN_DNODE_SERVER;
+    conn->type = CONN_DNODE_PEER_PROXY;
 
     conn->dyn_mode = 1;
     conn->ops = &dnode_server_ops;

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -21,6 +21,19 @@
  */
 
 
+/**
+ * In twemproxy there are 3 types of connections:
+ * PROXY - listens for client connections (default: 8102)
+ * CLIENT - incoming connection from the client
+ * SERVER - outgoing connection to the underlying data store.
+ *
+ * Dynomite extended this same concept and added 3 other types of connections
+ * DNODE_PEER_PROXY - listens to connections from other dynomite node (default 8101)
+ * DNODE_PEER_CLIENT - incoming connection from other dnode
+ * DNODE_PEER_SERVER - outgoing connection to other dnode.
+ *
+ */
+ 
 #ifndef _DYN_CONNECTION_H_
 #define _DYN_CONNECTION_H_
 #include "dyn_core.h"
@@ -71,10 +84,10 @@ typedef enum connection_type {
     CONN_UNSPECIFIED,
     CONN_PROXY, // a dynomite proxy (listening) connection 
     CONN_CLIENT, // this is connected to a client connection
+    CONN_SERVER, // this is connected to underlying datastore ...redis/memcache
+    CONN_DNODE_PEER_PROXY, // this is a dnode (listening) connection...default 8101
     CONN_DNODE_PEER_CLIENT, // this is connected to a dnode peer client
     CONN_DNODE_PEER_SERVER, // this is connected to a dnode peer server
-    CONN_DNODE_SERVER, // this is a dnode (listening) connection...default 8101
-    CONN_SERVER, // this is connected to underlying datastore ...redis/memcache
 } connection_type_t;
 
 struct conn {
@@ -136,10 +149,10 @@ conn_get_type_string(struct conn *conn)
         case CONN_UNSPECIFIED: return "UNSPEC";
         case CONN_PROXY : return "PROXY";
         case CONN_CLIENT: return "CLIENT";
+        case CONN_SERVER: return "SERVER";
+        case CONN_DNODE_PEER_PROXY: return "PEER_PROXY";
         case CONN_DNODE_PEER_CLIENT: return "PEER_CLIENT";
         case CONN_DNODE_PEER_SERVER: return "PEER_SERVER";
-        case CONN_DNODE_SERVER: return "DNODE_SERVER";
-        case CONN_SERVER: return "SERVER";
     }
     return "INVALID";
 }

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -29,23 +29,44 @@
 #define MAX_CONN_ALLOWABLE_NON_RECV   5
 #define MAX_CONN_ALLOWABLE_NON_SEND   5
 
-typedef rstatus_t (*conn_recv_t)(struct context *, struct conn*);
-typedef struct msg* (*conn_recv_next_t)(struct context *, struct conn *, bool);
-typedef void (*conn_recv_done_t)(struct context *, struct conn *, struct msg *, struct msg *);
+typedef rstatus_t (*func_recv_t)(struct context *, struct conn*);
+typedef struct msg* (*func_recv_next_t)(struct context *, struct conn *, bool);
+typedef void (*func_recv_done_t)(struct context *, struct conn *, struct msg *, struct msg *);
 
-typedef rstatus_t (*conn_send_t)(struct context *, struct conn*);
-typedef struct msg* (*conn_send_next_t)(struct context *, struct conn *);
-typedef void (*conn_send_done_t)(struct context *, struct conn *, struct msg *);
+typedef rstatus_t (*func_send_t)(struct context *, struct conn*);
+typedef struct msg* (*func_send_next_t)(struct context *, struct conn *);
+typedef void (*func_send_done_t)(struct context *, struct conn *, struct msg *);
 
-typedef void (*conn_close_t)(struct context *, struct conn *);
-typedef bool (*conn_active_t)(struct conn *);
+typedef void (*func_close_t)(struct context *, struct conn *);
+typedef bool (*func_active_t)(struct conn *);
 
-typedef void (*conn_ref_t)(struct conn *, void *);
-typedef void (*conn_unref_t)(struct conn *);
+typedef void (*func_ref_t)(struct conn *, void *);
+typedef void (*func_unref_t)(struct conn *);
 
-typedef void (*conn_msgq_t)(struct context *, struct conn *, struct msg *);
-typedef rstatus_t (*conn_response_handler)(struct conn *, msgid_t reqid,
+typedef void (*func_msgq_t)(struct context *, struct conn *, struct msg *);
+typedef rstatus_t (*func_response_handler)(struct conn *, msgid_t reqid,
                                            struct msg *rsp);
+
+struct conn_ops {
+    func_recv_t        recv;          /* recv (read) handler */
+    func_recv_next_t   recv_next;     /* recv next message handler */
+    func_recv_done_t   recv_done;     /* read done handler */
+    func_send_t        send;          /* send (write) handler */
+    func_send_next_t   send_next;     /* write next message handler */
+    func_send_done_t   send_done;     /* write done handler */
+    func_close_t       close;         /* close handler */
+    func_active_t      active;        /* active? handler */
+
+    func_ref_t         ref;           /* connection reference handler */
+    func_unref_t       unref;         /* connection unreference handler */
+
+    func_msgq_t        enqueue_inq;   /* connection inq msg enqueue handler */
+    func_msgq_t        dequeue_inq;   /* connection inq msg dequeue handler */
+    func_msgq_t        enqueue_outq;  /* connection outq msg enqueue handler */
+    func_msgq_t        dequeue_outq;  /* connection outq msg dequeue handler */
+    func_response_handler rsp_handler;
+};
+
 typedef enum connection_type {
     CONN_UNSPECIFIED,
     CONN_PROXY, // a dynomite proxy (listening) connection 
@@ -74,23 +95,7 @@ struct conn {
     struct msg         *rmsg;         /* current message being rcvd */
     struct msg         *smsg;         /* current message being sent */
 
-    conn_recv_t        recv;          /* recv (read) handler */
-    conn_recv_next_t   recv_next;     /* recv next message handler */
-    conn_recv_done_t   recv_done;     /* read done handler */
-    conn_send_t        send;          /* send (write) handler */
-    conn_send_next_t   send_next;     /* write next message handler */
-    conn_send_done_t   send_done;     /* write done handler */
-    conn_close_t       close;         /* close handler */
-    conn_active_t      active;        /* active? handler */
-
-    conn_ref_t         ref;           /* connection reference handler */
-    conn_unref_t       unref;         /* connection unreference handler */
-
-    conn_msgq_t        enqueue_inq;   /* connection inq msg enqueue handler */
-    conn_msgq_t        dequeue_inq;   /* connection inq msg dequeue handler */
-    conn_msgq_t        enqueue_outq;  /* connection outq msg enqueue handler */
-    conn_msgq_t        dequeue_outq;  /* connection outq msg dequeue handler */
-
+    struct conn_ops    *ops;
     size_t             recv_bytes;    /* received (read) bytes */
     size_t             send_bytes;    /* sent (written) bytes */
 
@@ -101,14 +106,10 @@ struct conn {
     unsigned           send_active:1; /* send active? */
     unsigned           send_ready:1;  /* send ready? */
 
-    unsigned           client:1;      /* client? or server? */
-    unsigned           proxy:1;       /* proxy? */
     unsigned           connecting:1;  /* connecting? */
     unsigned           connected:1;   /* connected? */
     unsigned           eof:1;         /* eof? aka passive close? */
     unsigned           done:1;        /* done? aka close? */
-    unsigned           dnode_server:1;       /* dnode server connection? */
-    unsigned           dnode_client:1;       /* dnode client? */
     unsigned           dyn_mode:1;           /* is a dyn connection? */
     unsigned           dnode_secured:1;      /* is a secured connection? */
     unsigned           dnode_crypto_state:1; /* crypto state */
@@ -126,15 +127,61 @@ struct conn {
     consistency_t      write_consistency;
     dict               *outstanding_msgs_dict;
     connection_type_t  type;
-    conn_response_handler rsp_handler;
 };
+
+static inline char *
+conn_get_type_string(struct conn *conn)
+{
+    switch(conn->type) {
+        case CONN_UNSPECIFIED: return "UNSPEC";
+        case CONN_PROXY : return "PROXY";
+        case CONN_CLIENT: return "CLIENT";
+        case CONN_DNODE_PEER_CLIENT: return "PEER_CLIENT";
+        case CONN_DNODE_PEER_SERVER: return "PEER_SERVER";
+        case CONN_DNODE_SERVER: return "DNODE_SERVER";
+        case CONN_SERVER: return "SERVER";
+    }
+    return "INVALID";
+}
+
 
 static inline rstatus_t
 conn_handle_response(struct conn *conn, msgid_t msgid, struct msg *rsp)
 {
-    return conn->rsp_handler(conn, msgid, rsp);
+    return conn->ops->rsp_handler(conn, msgid, rsp);
 }
 
+#define conn_recv(ctx, conn)                        \
+        (conn)->ops->recv(ctx, conn)
+#define conn_recv_next(ctx, conn, alloc)            \
+        (conn)->ops->recv_next(ctx, conn, alloc)
+#define conn_recv_done(ctx, conn, msg, nmsg)        \
+        (conn)->ops->recv_done(ctx, conn, msg, nmsg)
+
+#define conn_send(ctx, conn)                        \
+        (conn)->ops->send(ctx, conn)
+#define conn_send_next(ctx, conn)                   \
+        (conn)->ops->send_next(ctx, conn)
+#define conn_send_done(ctx, conn, msg)              \
+        (conn)->ops->send_done(ctx, conn, msg)
+
+#define conn_close(ctx, conn)                       \
+        (conn)->ops->close(ctx, conn)
+#define conn_active(conn)                           \
+        (conn)->ops->active(conn)
+#define conn_ref(conn, owner)                       \
+        (conn)->ops->ref(conn, owner)
+#define conn_unref(conn)                            \
+        (conn)->ops->unref(conn)
+
+#define conn_enqueue_inq(ctx, conn, msg)            \
+        (conn)->ops->enqueue_inq(ctx, conn, msg)
+#define conn_dequeue_inq(ctx, conn, msg)            \
+        (conn)->ops->dequeue_inq(ctx, conn, msg)
+#define conn_enqueue_outq(ctx, conn, msg)            \
+        (conn)->ops->enqueue_outq(ctx, conn, msg)
+#define conn_dequeue_outq(ctx, conn, msg)            \
+        (conn)->ops->dequeue_outq(ctx, conn, msg)
 TAILQ_HEAD(conn_tqh, conn);
 
 void conn_set_write_consistency(struct conn *conn, consistency_t cons);
@@ -148,8 +195,8 @@ struct conn *conn_get_proxy(void *owner);
 struct conn *conn_get_peer(void *owner, bool client, int data_store);
 struct conn *conn_get_dnode(void *owner);
 void conn_put(struct conn *conn);
-ssize_t conn_recv(struct conn *conn, void *buf, size_t size);
-ssize_t conn_sendv(struct conn *conn, struct array *sendv, size_t nsend);
+ssize_t conn_recv_data(struct conn *conn, void *buf, size_t size);
+ssize_t conn_sendv_data(struct conn *conn, struct array *sendv, size_t nsend);
 void conn_init(void);
 void conn_deinit(void);
 void conn_print(struct conn *conn);

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -283,13 +283,11 @@ core_close_log(struct conn *conn)
 	} else {
 		addrstr = dn_unresolve_addr(conn->addr, conn->addrlen);
 	}
-    addrstr = 0x87234978;
 	log_debug(LOG_NOTICE, "close %s %d '%s' on event %04"PRIX32" eof %d done "
 			  "%d rb %zu sb %zu%c %s", conn_get_type_string(conn), conn->sd,
               addrstr, conn->events, conn->eof, conn->done, conn->recv_bytes,
               conn->send_bytes,
               conn->err ? ':' : ' ', conn->err ? strerror(conn->err) : "");
-    log_info("%s", addrstr);
 
 }
 

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -283,11 +283,13 @@ core_close_log(struct conn *conn)
 	} else {
 		addrstr = dn_unresolve_addr(conn->addr, conn->addrlen);
 	}
+    addrstr = 0x87234978;
 	log_debug(LOG_NOTICE, "close %s %d '%s' on event %04"PRIX32" eof %d done "
 			  "%d rb %zu sb %zu%c %s", conn_get_type_string(conn), conn->sd,
               addrstr, conn->events, conn->eof, conn->done, conn->recv_bytes,
               conn->send_bytes,
               conn->err ? ':' : ' ', conn->err ? strerror(conn->err) : "");
+    log_info("%s", addrstr);
 
 }
 

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -250,11 +250,10 @@ core_recv(struct context *ctx, struct conn *conn)
 {
 	rstatus_t status;
 
-	status = conn->recv(ctx, conn);
+	status = conn_recv(ctx, conn);
 	if (status != DN_OK) {
-		log_debug(LOG_INFO, "recv on %c %d failed: %s",
-				conn->client ? 'c' : (conn->proxy ? 'p' : 's'), conn->sd,
-						strerror(errno));
+		log_info("recv on %s %d failed: %s", conn_get_type_string(conn),
+				 conn->sd, strerror(errno));
 	}
 
 	return status;
@@ -265,51 +264,30 @@ core_send(struct context *ctx, struct conn *conn)
 {
 	rstatus_t status;
 
-	status = conn->send(ctx, conn);
+	status = conn_send(ctx, conn);
 	if (status != DN_OK) {
-		log_debug(LOG_INFO, "send on %c %d failed: %s",
-				conn->client ? 'c' : (conn->proxy ? 'p' : 's'), conn->sd,
-						strerror(errno));
+		log_info("send on %s %d failed: %s", conn_get_type_string(conn),
+				 conn->sd, strerror(errno));
 	}
 
 	return status;
 }
 
 static void
-core_dnode_close_log(struct conn *conn)
-{
-	char type, *addrstr;
-
-	if (conn->dnode_client) {
-		type = 'c';
-		addrstr = dn_unresolve_peer_desc(conn->sd);
-	} else {
-		type = conn->dnode_server ? 's' : 'p';
-		addrstr = dn_unresolve_addr(conn->addr, conn->addrlen);
-	}
-	log_debug(LOG_NOTICE, "dnode close %c %d '%s' on event %04"PRIX32" eof %d done "
-			"%d rb %zu sb %zu%c %s", type, conn->sd, addrstr, conn->events,
-			conn->eof, conn->done, conn->recv_bytes, conn->send_bytes,
-			conn->err ? ':' : ' ', conn->err ? strerror(conn->err) : "");
-
-}
-
-static void
 core_close_log(struct conn *conn)
 {
-	char type, *addrstr;
+	char *addrstr;
 
-	if (conn->client) {
-		type = 'c';
+	if ((conn->type == CONN_CLIENT) || (conn->type == CONN_DNODE_PEER_CLIENT)) {
 		addrstr = dn_unresolve_peer_desc(conn->sd);
 	} else {
-		type = conn->proxy ? 'p' : 's';
 		addrstr = dn_unresolve_addr(conn->addr, conn->addrlen);
 	}
-	log_debug(LOG_NOTICE, "close %c %d '%s' on event %04"PRIX32" eof %d done "
-			"%d rb %zu sb %zu%c %s", type, conn->sd, addrstr, conn->events,
-			conn->eof, conn->done, conn->recv_bytes, conn->send_bytes,
-			conn->err ? ':' : ' ', conn->err ? strerror(conn->err) : "");
+	log_debug(LOG_NOTICE, "close %s %d '%s' on event %04"PRIX32" eof %d done "
+			  "%d rb %zu sb %zu%c %s", conn_get_type_string(conn), conn->sd,
+              addrstr, conn->events, conn->eof, conn->done, conn->recv_bytes,
+              conn->send_bytes,
+              conn->err ? ':' : ' ', conn->err ? strerror(conn->err) : "");
 
 }
 
@@ -320,12 +298,7 @@ core_close(struct context *ctx, struct conn *conn)
 
 	ASSERT(conn->sd > 0);
 
-
-	if (conn->dyn_mode) {
-		core_dnode_close_log(conn);
-	} else {
-		core_close_log(conn);
-	}
+    core_close_log(conn);
 
 	status = event_del_conn(ctx->evb, conn);
 	if (status < 0) {
@@ -333,7 +306,7 @@ core_close(struct context *ctx, struct conn *conn)
 		          conn->sd, strerror(errno));
 	}
 
-	conn->close(ctx, conn);
+	conn_close(ctx, conn);
 }
 
 static void
@@ -343,21 +316,8 @@ core_error(struct context *ctx, struct conn *conn)
 
 	status = dn_get_soerror(conn->sd);
 	if (status < 0) {
-		if (!conn->dyn_mode) {
-                        if (conn->client)
-		                log_warn("get soerr on client %d failed, ignored: %s", conn->sd, strerror(errno));
-			else if (conn->proxy)
-				log_warn("get soerr on proxy %d failed, ignored: %s", conn->sd, strerror(errno));
-			else
-				log_warn("get soerr on storage server %d failed, ignored: %s", conn->sd, strerror(errno));
-		} else {
-			if (conn->dnode_client)
-		                log_warn("get soerr on dnode client %d failed, ignored: %s", conn->sd, strerror(errno));
-			else if (conn->dnode_server)
-				log_warn("get soerr on dnode server %d failed, ignored: %s", conn->sd, strerror(errno));
-			else
-				log_warn("get soerr on peer %d failed, ignored: %s", conn->sd, strerror(errno));
-		}
+	log_warn("get soerr on %s client %d failed, ignored: %s",
+             conn_get_type_string(conn), conn->sd, strerror(errno));
 	}
 	conn->err = errno;
 
@@ -405,7 +365,7 @@ core_timeout(struct context *ctx)
 		msg_tmo_delete(msg);
 
 		if (conn->dyn_mode) {
-			if (!conn->dnode_client && !conn->dnode_server) { //outgoing peer requests
+			if (conn->type == CONN_DNODE_PEER_SERVER) { //outgoing peer requests
 		 	   struct server *server = conn->owner;
                 if (conn->same_dc)
 			        stats_pool_incr(ctx, server->owner, peer_timedout_requests);
@@ -413,7 +373,7 @@ core_timeout(struct context *ctx)
 			        stats_pool_incr(ctx, server->owner, remote_peer_timedout_requests);
 			}
 		} else {
-			if (!conn->client && !conn->proxy) { //storage server requests
+			if (conn->type == CONN_SERVER) { //storage server requests
 			   stats_server_incr(ctx, conn->owner, server_dropped_requests);
 			}
 		}
@@ -433,40 +393,8 @@ core_core(void *arg, uint32_t events)
 	struct conn *conn = arg;
 	struct context *ctx = conn_to_ctx(conn);
 
-
-	/*
-	if (!conn->dyn_mode) {
-		if (conn->client && !conn->proxy) {
-         struct server_pool *sp = conn->owner;
-         log_debug(LOG_VERB, "Client           : '%.*s'", sp->name);
-		} else if (!conn->client && !conn->proxy) {
-			struct server *server = conn->owner;
-			log_debug(LOG_VERB, "Storage server           : '%.*s'", server->name);
-		} else {
-			struct server_pool *sp = conn->owner;
-			log_debug(LOG_VERB, "Proxy           : '%.*s'", sp->name);
-		}
-	} else {
-      if (conn->dnode_client && !conn->dnode_server) {
-      	struct server_pool *sp = conn->owner;
-      	log_debug(LOG_VERB, "Dnode client           : '%.*s'", sp->name);
-      } else if (!conn->dnode_client && !conn->dnode_server) {
-			struct server *server = conn->owner;
-			log_debug(LOG_VERB, "Dnode peer           : '%.*s'", server->name);
-      } else {
-			struct server_pool *sp = conn->owner;
-			log_debug(LOG_VERB, "Dnode server           : '%.*s'", sp->name);
-      }
-	}
-	 */
-
-	if (conn->dyn_mode) {
-		log_debug(LOG_VVERB, "event %04"PRIX32" on d_%c %d", events,
-				conn->dnode_client ? 'c' : (conn->dnode_server ? 's' : 'p'), conn->sd);
-	} else {
-		log_debug(LOG_VVERB, "event %04"PRIX32" on %c %d", events,
-				conn->client ? 'c' : (conn->proxy ? 'p' : 's'), conn->sd);
-	}
+    log_debug(LOG_VVERB, "event %04"PRIX32" on %s %d", events,
+              conn_get_type_string(conn), conn->sd);
 
 	conn->events = events;
 

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -60,8 +60,8 @@
 #endif
 
 #ifdef HAVE_BACKTRACE
-#endif
 # define DN_HAVE_BACKTRACE 1
+#endif
 
 #define DN_NOOPS     1
 #define DN_OK        0

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -60,8 +60,8 @@
 #endif
 
 #ifdef HAVE_BACKTRACE
-# define DN_HAVE_BACKTRACE 1
 #endif
+# define DN_HAVE_BACKTRACE 1
 
 #define DN_NOOPS     1
 #define DN_OK        0

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -18,7 +18,7 @@ dnode_req_get(struct conn *conn)
 {
     struct msg *msg;
 
-    ASSERT(conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
 
     msg = msg_get(conn, true, conn->data_store);
     if (msg == NULL) {
@@ -35,26 +35,11 @@ dnode_req_put(struct msg *msg)
 }
 
 
-bool
-dnode_req_done(struct conn *conn, struct msg *msg)
-{
-    //ASSERT(!conn->dnode_client && !conn->dnode_server );
-    return req_done(conn, msg);
-}
-
-
-bool
-dnode_req_error(struct conn *conn, struct msg *msg)
-{
-    ASSERT(msg->request && dnode_req_done(conn, msg));
-    return req_error(conn, msg);
-}
-
 void
 dnode_req_peer_enqueue_imsgq(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     ASSERT(msg->request);
-    ASSERT(!conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_SERVER);
 
     log_debug(LOG_VERB, "conn %p enqueue inq %d:%d calling req_server_enqueue_imsgq",
               conn, msg->id, msg->parent_id);
@@ -65,7 +50,7 @@ void
 dnode_req_peer_dequeue_imsgq(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     ASSERT(msg->request);
-    ASSERT(!conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_SERVER);
 
     TAILQ_REMOVE(&conn->imsg_q, msg, s_tqe);
     log_debug(LOG_VERB, "conn %p dequeue inq %d:%d", conn, msg->id, msg->parent_id);
@@ -82,7 +67,7 @@ void
 dnode_req_client_enqueue_omsgq(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     ASSERT(msg->request);
-    ASSERT(conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
 
     log_debug(LOG_VERB, "conn %p enqueue outq %p", conn, msg);
     TAILQ_INSERT_TAIL(&conn->omsg_q, msg, c_tqe);
@@ -97,7 +82,7 @@ void
 dnode_req_peer_enqueue_omsgq(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     ASSERT(msg->request);
-    ASSERT(!conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_SERVER);
 
     TAILQ_INSERT_TAIL(&conn->omsg_q, msg, s_tqe);
     log_debug(LOG_VERB, "conn %p enqueue outq %d:%d", conn, msg->id, msg->parent_id);
@@ -115,7 +100,7 @@ void
 dnode_req_client_dequeue_omsgq(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     ASSERT(msg->request);
-    ASSERT(conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
 
     TAILQ_REMOVE(&conn->omsg_q, msg, c_tqe);
     log_debug(LOG_VERB, "conn %p dequeue outq %p", conn, msg);
@@ -130,7 +115,7 @@ void
 dnode_req_peer_dequeue_omsgq(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     ASSERT(msg->request);
-    ASSERT(!conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_SERVER);
 
     msg_tmo_delete(msg);
 
@@ -146,14 +131,14 @@ dnode_req_peer_dequeue_omsgq(struct context *ctx, struct conn *conn, struct msg 
 struct msg *
 dnode_req_recv_next(struct context *ctx, struct conn *conn, bool alloc)
 {
-    ASSERT(conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
     return req_recv_next(ctx, conn, alloc);
 }
 
 static bool
 dnode_req_filter(struct context *ctx, struct conn *conn, struct msg *msg)
 {
-    ASSERT(conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
 
     if (msg_empty(msg)) {
         ASSERT(conn->rmsg == NULL);
@@ -182,7 +167,7 @@ dnode_req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     rstatus_t status;
 
-    ASSERT(conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
 
     log_debug(LOG_INFO, "dyn: forward req %"PRIu64" len %"PRIu32" type %d from "
             "c %d failed: %s", msg->id, msg->mlen, msg->type, conn->sd,
@@ -198,7 +183,7 @@ dnode_req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg)
         return;
     }
 
-    if (dnode_req_done(conn, TAILQ_FIRST(&conn->omsg_q))) {
+    if (req_done(conn, TAILQ_FIRST(&conn->omsg_q))) {
         status = event_add_out(ctx->evb, conn);
         if (status != DN_OK) {
             conn->err = errno;
@@ -218,11 +203,10 @@ dnode_req_forward(struct context *ctx, struct conn *conn, struct msg *msg)
     if (log_loggable(LOG_DEBUG)) {
        log_debug(LOG_DEBUG, "dnode_req_forward entering ");
     }
-    log_debug(LOG_DEBUG, "DNODE REQ RECEIVED %c %d dmsg->id %u",
-             conn->dnode_client ? 'c' : (conn->dnode_server ? 's' : 'p'),
-             conn->sd, msg->dmsg->id);
+    log_debug(LOG_DEBUG, "DNODE REQ RECEIVED %s %d dmsg->id %u",
+              conn_get_type_string(conn), conn->sd, msg->dmsg->id);
 
-    ASSERT(conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
 
     pool = conn->owner;
     key = NULL;
@@ -291,7 +275,7 @@ void
 dnode_req_recv_done(struct context *ctx, struct conn *conn,
                     struct msg *msg, struct msg *nmsg)
 {
-    ASSERT(conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
     ASSERT(msg->request);
     ASSERT(msg->owner == conn);
     ASSERT(conn->rmsg == msg);
@@ -314,7 +298,7 @@ dnode_req_send_next(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
 
-    ASSERT(!conn->dnode_client && !conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_PEER_SERVER);
 
     uint32_t now = time(NULL);
     //throttling the sending traffics here
@@ -350,10 +334,9 @@ dnode_req_send_done(struct context *ctx, struct conn *conn, struct msg *msg)
     if (log_loggable(LOG_DEBUG)) {
        log_debug(LOG_VERB, "dnode_req_send_done entering!!!");
     }
-    ASSERT(!conn->dnode_client && !conn->dnode_server);
-    log_debug(LOG_DEBUG, "DNODE REQ SEND %c %d dmsg->id %u",
-             conn->dnode_client ? 'c' : (conn->dnode_server ? 's' : 'p'),
-             conn->sd, msg->dmsg->id);
+    ASSERT(conn->type == CONN_DNODE_PEER_SERVER);
+    log_debug(LOG_DEBUG, "DNODE REQ SEND %s %d dmsg->id %u",
+              conn_get_type_string(conn), conn->sd, msg->dmsg->id);
     req_send_done(ctx, conn, msg);
 }
 
@@ -386,11 +369,12 @@ void dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
     rstatus_t status;
     /* enqueue message (request) into client outq, if response is expected */
     if (!msg->noreply && !msg->swallow) {
-        c_conn->enqueue_outq(ctx, c_conn, msg);
+        conn_enqueue_outq(ctx, c_conn, msg);
     }
 
-    ASSERT(!p_conn->dnode_client && !p_conn->dnode_server);
-    ASSERT(c_conn->client || c_conn->dnode_client);
+    ASSERT(p_conn->type == CONN_DNODE_PEER_SERVER);
+    ASSERT((c_conn->type == CONN_CLIENT) ||
+           (c_conn->type == CONN_DNODE_PEER_CLIENT));
 
     /* enqueue the message (request) into peer inq */
     status = event_add_out(ctx->evb, p_conn);
@@ -450,7 +434,7 @@ void dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
         msg_dump(msg);
     }
 
-    p_conn->enqueue_inq(ctx, p_conn, msg);
+    conn_enqueue_inq(ctx, p_conn, msg);
 
     dnode_peer_req_forward_stats(ctx, p_conn->owner, msg);
 
@@ -597,5 +581,5 @@ dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, int data_store
     //conn->enqueue_outq(ctx, conn, msg);
 
     msg->noreply = 1;
-    conn->enqueue_inq(ctx, conn, msg);
+    conn_enqueue_inq(ctx, conn, msg);
 }

--- a/src/dyn_dnode_server.c
+++ b/src/dyn_dnode_server.c
@@ -15,7 +15,7 @@ dnode_ref(struct conn *conn, void *owner)
 {
     struct server_pool *pool = owner;
 
-    ASSERT(conn->type == CONN_DNODE_SERVER);
+    ASSERT(conn->type == CONN_DNODE_PEER_PROXY);
     ASSERT(conn->owner == NULL);
 
     conn->family = pool->d_family;
@@ -36,7 +36,7 @@ dnode_unref(struct conn *conn)
 {
     struct server_pool *pool;
 
-    ASSERT(conn->type == CONN_DNODE_SERVER);
+    ASSERT(conn->type == CONN_DNODE_PEER_PROXY);
     ASSERT(conn->owner != NULL);
 
     pool = conn->owner;
@@ -53,7 +53,7 @@ dnode_close(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
     
-    ASSERT(conn->type == CONN_DNODE_SERVER);
+    ASSERT(conn->type == CONN_DNODE_PEER_PROXY);
 
     if (conn->sd < 0) {
         conn_unref(conn);
@@ -114,7 +114,7 @@ dnode_listen(struct context *ctx, struct conn *p)
     rstatus_t status;
     struct server_pool *pool = p->owner;
 
-    ASSERT(p->type == CONN_DNODE_SERVER);
+    ASSERT(p->type == CONN_DNODE_PEER_PROXY);
 
     p->sd = socket(p->family, SOCK_STREAM, 0);
     if (p->sd < 0) {
@@ -263,7 +263,7 @@ dnode_accept(struct context *ctx, struct conn *p)
     int client_len = 0;
     int sd = 0;
 
-    ASSERT(p->type == CONN_DNODE_SERVER);
+    ASSERT(p->type == CONN_DNODE_PEER_PROXY);
     ASSERT(p->sd > 0);
     ASSERT(p->recv_active && p->recv_ready);
 
@@ -353,7 +353,7 @@ dnode_recv(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
 
-    ASSERT(conn->type == CONN_DNODE_SERVER);
+    ASSERT(conn->type == CONN_DNODE_PEER_PROXY);
     ASSERT(conn->recv_active);
  
     conn->recv_ready = 1;

--- a/src/dyn_dnode_server.c
+++ b/src/dyn_dnode_server.c
@@ -15,7 +15,7 @@ dnode_ref(struct conn *conn, void *owner)
 {
     struct server_pool *pool = owner;
 
-    ASSERT(conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_SERVER);
     ASSERT(conn->owner == NULL);
 
     conn->family = pool->d_family;
@@ -36,7 +36,7 @@ dnode_unref(struct conn *conn)
 {
     struct server_pool *pool;
 
-    ASSERT(conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_SERVER);
     ASSERT(conn->owner != NULL);
 
     pool = conn->owner;
@@ -53,10 +53,10 @@ dnode_close(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
     
-    ASSERT(conn->dnode_server);
+    ASSERT(conn->type == CONN_DNODE_SERVER);
 
     if (conn->sd < 0) {
-        conn->unref(conn);
+        conn_unref(conn);
         conn_put(conn);
         return;
     }
@@ -66,7 +66,7 @@ dnode_close(struct context *ctx, struct conn *conn)
     ASSERT(TAILQ_EMPTY(&conn->imsg_q));
     ASSERT(TAILQ_EMPTY(&conn->omsg_q));
 
-    conn->unref(conn);
+    conn_unref(conn);
 
     status = close(conn->sd);
     if (status < 0) {
@@ -114,7 +114,7 @@ dnode_listen(struct context *ctx, struct conn *p)
     rstatus_t status;
     struct server_pool *pool = p->owner;
 
-    ASSERT(p->dnode_server);
+    ASSERT(p->type == CONN_DNODE_SERVER);
 
     p->sd = socket(p->family, SOCK_STREAM, 0);
     if (p->sd < 0) {
@@ -184,7 +184,7 @@ dnode_each_init(void *elem, void *data)
 
     status = dnode_listen(pool->ctx, p);
     if (status != DN_OK) {
-        p->close(pool->ctx, p);
+        conn_close(pool->ctx, p);
         return status;
     }
 
@@ -232,7 +232,7 @@ dnode_each_deinit(void *elem, void *data)
 
     p = pool->d_conn;
     if (p != NULL) {
-        p->close(pool->ctx, p);
+        conn_close(pool->ctx, p);
     }
 
     return DN_OK;
@@ -263,7 +263,7 @@ dnode_accept(struct context *ctx, struct conn *p)
     int client_len = 0;
     int sd = 0;
 
-    ASSERT(p->dnode_server);
+    ASSERT(p->type == CONN_DNODE_SERVER);
     ASSERT(p->sd > 0);
     ASSERT(p->recv_active && p->recv_ready);
 
@@ -322,7 +322,7 @@ dnode_accept(struct context *ctx, struct conn *p)
     if (status < 0) {
         log_error("dyn: set nonblock on c %d from p %d failed: %s", c->sd, p->sd,
                   strerror(errno));
-        c->close(ctx, c);
+        conn_close(ctx, c);
         return status;
     }
 
@@ -338,7 +338,7 @@ dnode_accept(struct context *ctx, struct conn *p)
     if (status < 0) {
         log_error("dyn: event add conn from p %d failed: %s", p->sd,
                   strerror(errno));
-        c->close(ctx, c);
+        conn_close(ctx, c);
         return status;
     }
 
@@ -353,7 +353,7 @@ dnode_recv(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
 
-    ASSERT(conn->dnode_server && !conn->dnode_client);
+    ASSERT(conn->type == CONN_DNODE_SERVER);
     ASSERT(conn->recv_active);
  
     conn->recv_ready = 1;

--- a/src/dyn_mbuf.c
+++ b/src/dyn_mbuf.c
@@ -271,7 +271,7 @@ mbuf_copy(struct mbuf *mbuf, uint8_t *pos, size_t n)
  * Return new mbuf t, if the split was successful.
  */
 struct mbuf *
-mbuf_split(struct mhdr *h, uint8_t *pos, mbuf_copy_t cb, void *cbarg)
+mbuf_split(struct mhdr *h, uint8_t *pos, func_mbuf_copy_t cb, void *cbarg)
 {
     struct mbuf *mbuf, *nbuf;
     size_t size;

--- a/src/dyn_mbuf.h
+++ b/src/dyn_mbuf.h
@@ -26,7 +26,7 @@
 
 
 
-typedef void (*mbuf_copy_t)(struct mbuf *, void *);
+typedef void (*func_mbuf_copy_t)(struct mbuf *, void *);
 
 struct mbuf {
     uint32_t           magic;   /* mbuf magic (const) */
@@ -77,7 +77,7 @@ void mbuf_insert_head(struct mhdr *mhdr, struct mbuf *mbuf);
 void mbuf_insert_after(struct mhdr *mhdr, struct mbuf *mbuf, struct mbuf *nbuf);
 void mbuf_remove(struct mhdr *mhdr, struct mbuf *mbuf);
 void mbuf_copy(struct mbuf *mbuf, uint8_t *pos, size_t n);
-struct mbuf *mbuf_split(struct mhdr *h, uint8_t *pos, mbuf_copy_t cb, void *cbarg);
+struct mbuf *mbuf_split(struct mhdr *h, uint8_t *pos, func_mbuf_copy_t cb, void *cbarg);
 
 void mbuf_write_char(struct mbuf *mbuf, char ch);
 void mbuf_write_string(struct mbuf *mbuf,  struct string *s);

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -33,13 +33,13 @@
 #define MAX_ALLOWABLE_PROCESSED_MSGS  500
 #define MAX_REPLICAS_PER_DC           3
 
-typedef void (*msg_parse_t)(struct msg *);
-typedef rstatus_t (*msg_post_splitcopy_t)(struct msg *);
-typedef void (*msg_coalesce_t)(struct msg *r);
+typedef void (*func_msg_parse_t)(struct msg *);
+typedef rstatus_t (*func_msg_post_splitcopy_t)(struct msg *);
+typedef void (*func_msg_coalesce_t)(struct msg *r);
 typedef rstatus_t (*msg_response_handler_t)(struct msg *req, struct msg *rsp);
 typedef uint64_t msgid_t;
-typedef rstatus_t (*msg_reply_t)(struct msg *r);
-typedef bool (*msg_failure_t)(struct msg *r);
+typedef rstatus_t (*func_msg_reply_t)(struct msg *r);
+typedef bool (*func_msg_failure_t)(struct msg *r);
 
 
 typedef enum msg_parse_result {
@@ -274,17 +274,15 @@ struct msg {
     uint8_t              *pos;            /* parser position marker */
     uint8_t              *token;          /* token marker */
 
-    msg_parse_t          parser;          /* message parser */
+    func_msg_parse_t     parser;          /* message parser */
     msg_parse_result_t   result;          /* message parsing result */
 
-    mbuf_copy_t          pre_splitcopy;   /* message pre-split copy */
-    msg_post_splitcopy_t post_splitcopy;  /* message post-split copy */
-    msg_coalesce_t       pre_coalesce;    /* message pre-coalesce */
-    msg_coalesce_t       post_coalesce;   /* message post-coalesce */
+    func_mbuf_copy_t     pre_splitcopy;   /* message pre-split copy */
+    func_msg_post_splitcopy_t post_splitcopy;  /* message post-split copy */
+    func_msg_coalesce_t  pre_coalesce;    /* message pre-coalesce */
+    func_msg_coalesce_t  post_coalesce;   /* message post-coalesce */
 
     msg_type_t           type;            /* message type */
-    msg_reply_t          reply;           /* generate message reply (example: ping) */
-    msg_failure_t        failure;         /* transient failure response? */
 
     uint8_t              *key_start;      /* key start */
     uint8_t              *key_end;        /* key end */
@@ -394,8 +392,6 @@ void rsp_send_done(struct context *ctx, struct conn *conn, struct msg *msg);
 
 /* for dynomite  */
 struct msg *dnode_req_get(struct conn *conn);
-bool dnode_req_done(struct conn *conn, struct msg *msg);
-bool dnode_req_error(struct conn *conn, struct msg *msg);
 void dnode_req_peer_enqueue_imsgq(struct context *ctx, struct conn *conn, struct msg *msg);
 void dnode_req_peer_dequeue_imsgq(struct context *ctx, struct conn *conn, struct msg *msg);
 void dnode_req_client_enqueue_omsgq(struct context *ctx, struct conn *conn, struct msg *msg);
@@ -426,5 +422,8 @@ void dnode_peer_req_forward(struct context *ctx, struct conn *c_conn, struct con
 
 //void peer_gossip_forward(struct context *ctx, struct conn *conn, int data_store, struct string *data);
 void dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, int data_store, struct mbuf *data);
+
+rstatus_t client_handle_response(struct conn *conn, msgid_t msg, struct msg *rsp);
+rstatus_t dnode_client_handle_response(struct conn *conn, msgid_t msg, struct msg *rsp);
 
 #endif

--- a/src/dyn_proxy.c
+++ b/src/dyn_proxy.c
@@ -31,7 +31,7 @@ proxy_ref(struct conn *conn, void *owner)
 {
     struct server_pool *pool = owner;
 
-    ASSERT(!conn->client && conn->proxy);
+    ASSERT(conn->type == CONN_PROXY);
     ASSERT(conn->owner == NULL);
 
     conn->family = pool->family;
@@ -52,7 +52,7 @@ proxy_unref(struct conn *conn)
 {
     struct server_pool *pool;
 
-    ASSERT(!conn->client && conn->proxy);
+    ASSERT(conn->type == CONN_PROXY);
     ASSERT(conn->owner != NULL);
 
     pool = conn->owner;
@@ -69,10 +69,10 @@ proxy_close(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
 
-    ASSERT(!conn->client && conn->proxy);
+    ASSERT(conn->type == CONN_PROXY);
 
     if (conn->sd < 0) {
-        conn->unref(conn);
+        conn_unref(conn);
         conn_put(conn);
         return;
     }
@@ -82,7 +82,7 @@ proxy_close(struct context *ctx, struct conn *conn)
     ASSERT(TAILQ_EMPTY(&conn->imsg_q));
     ASSERT(TAILQ_EMPTY(&conn->omsg_q));
 
-    conn->unref(conn);
+    conn_unref(conn);
 
     status = close(conn->sd);
     if (status < 0) {
@@ -130,7 +130,7 @@ proxy_listen(struct context *ctx, struct conn *p)
     rstatus_t status;
     struct server_pool *pool = p->owner;
 
-    ASSERT(p->proxy);
+    ASSERT(p->type == CONN_PROXY);
 
     p->sd = socket(p->family, SOCK_STREAM, 0);
     if (p->sd < 0) {
@@ -200,7 +200,7 @@ proxy_each_init(void *elem, void *data)
 
     status = proxy_listen(pool->ctx, p);
     if (status != DN_OK) {
-        p->close(pool->ctx, p);
+        conn_close(pool->ctx, p);
         return status;
     }
 
@@ -250,7 +250,7 @@ proxy_each_deinit(void *elem, void *data)
 
     p = pool->p_conn;
     if (p != NULL) {
-        p->close(pool->ctx, p);
+        conn_close(pool->ctx, p);
     }
 
     return DN_OK;
@@ -279,7 +279,7 @@ proxy_accept(struct context *ctx, struct conn *p)
     struct conn *c;
     int sd;
 
-    ASSERT(p->proxy && !p->client);
+    ASSERT(p->type == CONN_PROXY);
     ASSERT(p->sd > 0);
     ASSERT(p->recv_active && p->recv_ready);
 
@@ -327,7 +327,7 @@ proxy_accept(struct context *ctx, struct conn *p)
     if (status < 0) {
         log_error("set nonblock on c %d from p %d failed: %s", c->sd, p->sd,
                   strerror(errno));
-        c->close(ctx, c);
+        conn_close(ctx, c);
         return status;
     }
 
@@ -343,7 +343,7 @@ proxy_accept(struct context *ctx, struct conn *p)
     if (status < 0) {
         log_error("event add conn from p %d failed: %s", p->sd,
                   strerror(errno));
-        c->close(ctx, c);
+        conn_close(ctx, c);
         return status;
     }
 
@@ -358,7 +358,7 @@ proxy_recv(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
 
-    ASSERT(conn->proxy && !conn->client);
+    ASSERT(conn->type == CONN_PROXY);
     ASSERT(conn->recv_active);
 
     conn->recv_ready = 1;

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -2354,53 +2354,6 @@ error:
 }
 
 /*
- * Return true, if redis replies with a transient server failure response,
- * otherwise return false
- *
- * Transient failures on redis are scenarios when it is temporarily
- * unresponsive and responds with the following protocol specific error
- * reply:
- * -OOM, when redis is out-of-memory
- * -BUSY, when redis is busy
- * -LOADING when redis is loading dataset into memory
- *
- */
-bool
-redis_failure(struct msg *r)
-{
-    ASSERT(!r->request);
-
-    switch (r->type) {
-    case MSG_RSP_REDIS_ERROR_OOM:
-    case MSG_RSP_REDIS_ERROR_BUSY:
-    case MSG_RSP_REDIS_ERROR_LOADING:
-        return true;
-
-    default:
-        break;
-    }
-
-    return false;
-}
-
-rstatus_t
-redis_reply(struct msg *r)
-{
-    struct msg *response = r->peer;
-
-    ASSERT(response != NULL && response->owner != NULL);
-
-    switch (r->type) {
-    case MSG_REQ_REDIS_PING:
-        return msg_append(response, rsp_pong.data, rsp_pong.len);
-
-    default:
-        NOT_REACHED();
-        return DN_ERROR;
-    }
-}
-
-/*
  * Pre-split copy handler invoked when the request is a multi vector -
  * 'mget' or 'del' request and is about to be split into two requests
  */


### PR DESCRIPTION
    o Introduce a connection interface and have different connection types
      implement it. Also reduces connection structure footprint
    o Remove the flag variables in connection so that code is more readable.
    o Remove unused variables from message. Rename typedefs to indicate its
      a func
    o Remove dead code in Redis.