### PR TITLE
Quorum Consistency Optimization

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -23,7 +23,7 @@
 /**
  * This is the client connection. It receives requests from the client, and
  * forwards it to the corresponding peers and local data store server (if this
- * node owns the token.
+ * node owns the token).
  * There is fair amount of machinery involved here mainly for consistency feature
  * It acts more of a co-ordinator than a mere client connection handler.
  * - outstanding_msgs_dict : This is a hash table (HT) of request id to request

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -118,6 +118,11 @@ client_active(struct conn *conn)
         return true;
     }
 
+    if (dictSize(conn->outstanding_msgs_dict) != 0) {
+        log_debug(LOG_WARN, "c %d is active, has outstanding messages", conn->sd);
+        return true;
+    }
+
     log_debug(LOG_VVERB, "c %d is inactive", conn->sd);
 
     return false;
@@ -246,6 +251,7 @@ client_handle_response(struct conn *conn, msgid_t reqid, struct msg *rsp)
         if (!req->awaiting_rsps) {
             if (req->rsp_sent) {
                 dictDelete(conn->outstanding_msgs_dict, &reqid);
+                log_warn("Putting req %d", req->id);
                 req_put(req);
             }
         }

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -20,6 +20,28 @@
  * limitations under the License.
  */
 
+/**
+ * This is the client connection. It receives requests from the client, and
+ * forwards it to the corresponding peers and local data store server (if this
+ * node owns the token.
+ * There is fair amount of machinery involved here mainly for consistency feature
+ * It acts more of a co-ordinator than a mere client connection handler.
+ * - outstanding_msgs_dict : This is a hash table (HT) of request id to request
+ *   mapping. When it receives a request, it adds the message to the HT, and
+ *   removes it when it finished responding. We need a hash table mainly for
+ *   implementing consistency. When a response is received from a peer, it is 
+ *   handed over to the client connection. It uses this HT to get the request &
+ *   calls the request's response handler.
+ * - waiting_to_unref: Now that we distribute messages to multiple nodes and that
+ *   we have consistency, there is a need for the responses to refer back to the
+ *   original requests. This makes cleaning up and connection tear down fairly
+ *   complex. The client connection has to wait for all responses (either a good
+ *   response or a error response due to timeout). Hence the client connection
+ *   should wait for the above HT outstanding_msgs_dict to get empty. This flag
+ *   waiting_to_unref indicates that the client connection is ready to close and
+ *   just waiting for the outstanding messages to finish.
+ */
+
 #include "dyn_core.h"
 #include "dyn_server.h"
 #include "dyn_client.h"

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -143,6 +143,7 @@ _conn_get(void)
         if (conn == NULL) {
             return NULL;
         }
+        memset(conn, 0, sizeof(*conn));
     }
 
     conn->owner = NULL;

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -180,6 +180,7 @@ _conn_get(void)
     conn->connected = 0;
     conn->eof = 0;
     conn->done = 0;
+    conn->waiting_to_unref = 0;
     conn->data_store = DATA_REDIS;
 
     /* for dynomite */

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -113,12 +113,10 @@ conn_to_ctx(struct conn *conn)
         pool = conn->owner;
     } else {
         struct server *server = conn->owner;
-        if (!server)
-            return NULL;
-        pool = server->owner;
+        pool = server ? server->owner : NULL;
     }
 
-    return pool->ctx;
+    return pool ? pool->ctx : NULL;
 }
 
 static rstatus_t

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -122,6 +122,7 @@ struct conn {
     unsigned           connecting:1;  /* connecting? */
     unsigned           connected:1;   /* connected? */
     unsigned           eof:1;         /* eof? aka passive close? */
+    unsigned           waiting_to_unref:1; /* eof? aka passive close? */
     unsigned           done:1;        /* done? aka close? */
     unsigned           dyn_mode:1;           /* is a dyn connection? */
     unsigned           dnode_secured:1;      /* is a secured connection? */

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -523,7 +523,10 @@ core_loop(struct context *ctx)
 	log_debug(LOG_VERB, "timeout = %d", ctx->timeout);
 
 	core_process_messages();
+	log_debug(LOG_VERB, "event_wait = %d", ctx->timeout);
+
 	nsd = event_wait(ctx->evb, ctx->timeout);
+	log_debug(LOG_VERB, "event_wait done ");
 	if (nsd < 0) {
 		return nsd;
 	}

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -523,10 +523,8 @@ core_loop(struct context *ctx)
 	log_debug(LOG_VERB, "timeout = %d", ctx->timeout);
 
 	core_process_messages();
-	log_debug(LOG_VERB, "event_wait = %d", ctx->timeout);
 
 	nsd = event_wait(ctx->evb, ctx->timeout);
-	log_debug(LOG_VERB, "event_wait done ");
 	if (nsd < 0) {
 		return nsd;
 	}

--- a/src/dyn_dict.c
+++ b/src/dyn_dict.c
@@ -243,7 +243,6 @@ int dictRehash(dict *d, int n) {
     if (!dictIsRehashing(d)) return 0;
 
     while(n--) {
-        log_warn("Rehashing: n %d", n);
         dictEntry *de, *nextde;
 
         /* Check if we already rehashed the whole table... */

--- a/src/dyn_dict.c
+++ b/src/dyn_dict.c
@@ -243,11 +243,13 @@ int dictRehash(dict *d, int n) {
     if (!dictIsRehashing(d)) return 0;
 
     while(n--) {
+        log_warn("Rehashing: n %d", n);
         dictEntry *de, *nextde;
 
         /* Check if we already rehashed the whole table... */
         if (d->ht[0].used == 0) {
-            dn_free(d->ht[0].table);
+            if (d->ht[0].table)
+                dn_free(d->ht[0].table);
             d->ht[0] = d->ht[1];
             _dictReset(&d->ht[1]);
             d->rehashidx = -1;

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -189,6 +189,8 @@ dnode_client_handle_response(struct conn *conn, msgid_t msg, struct msg *rsp)
     // Forward the response to the caller which is client connection.
     rstatus_t status = DN_OK;
     struct context *ctx = conn_to_ctx(conn);
+    ASSERT(rsp->peer);
+    rsp->peer->selected_rsp = rsp;
     status = event_add_out(ctx->evb, conn);
     if (status != DN_OK) {
         conn->err = errno;

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -189,7 +189,7 @@ dnode_client_handle_response(struct conn *conn, msgid_t msg, struct msg *rsp)
     // Forward the response to the caller which is client connection.
     rstatus_t status = DN_OK;
     struct context *ctx = conn_to_ctx(conn);
-    ASSERT(rsp->peer);
+    ASSERT_LOG(rsp->peer, "rsp %d:%d does not have a peer", rsp->id, rsp->parent_id);
     rsp->peer->selected_rsp = rsp;
     status = event_add_out(ctx->evb, conn);
     if (status != DN_OK) {

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -534,7 +534,9 @@ dnode_peer_ack_err(struct context *ctx, struct conn *conn, struct msg *req)
     }
     struct conn *c_conn = req->owner;
     // At other connections, these responses would be swallowed.
-    ASSERT(c_conn->type == CONN_CLIENT);
+    ASSERT_LOG(c_conn->type == CONN_CLIENT,
+               "conn:%s c_conn:%s, req %d:%d", conn_get_type_string(conn),
+               conn_get_type_string(c_conn), req->id, req->parent_id);
 
     // Create an appropriate response for the request so its propagated up;
     // This response gets dropped in rsp_make_error anyways. But since this is

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -598,6 +598,9 @@ dnode_peer_close(struct context *ctx, struct conn *conn)
 
         /* dequeue the message (request) from server inq */
         conn_dequeue_inq(ctx, conn, msg);
+        // We should also remove the msg from the timeout rbtree.
+        // for outq, its already taken care of
+        msg_tmo_delete(msg);
         dnode_peer_ack_err(ctx, conn, msg);
 
         stats_pool_incr(ctx, server->owner, peer_dropped_requests);

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -500,7 +500,8 @@ dnode_peer_attemp_reconnect_or_close(struct context *ctx, struct conn *conn)
     }
 }
 
-void dnode_peer_close_socket(struct context *ctx, struct conn *conn)
+static void
+dnode_peer_close_socket(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
         if (log_loggable(LOG_VERB)) {
@@ -518,11 +519,9 @@ void dnode_peer_close_socket(struct context *ctx, struct conn *conn)
     conn->sd = -1;
 }
 
-void
+static void
 dnode_peer_ack_err(struct context *ctx, struct conn *conn, struct msg *req)
 {
-    bool drop = false;
-
     if ((req->swallow && req->noreply) ||
         (req->swallow && (req->consistency == DC_ONE)) ||
         (req->swallow && (req->consistency == DC_QUORUM)

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -335,8 +335,9 @@ dnode_req_send_done(struct context *ctx, struct conn *conn, struct msg *msg)
        log_debug(LOG_VERB, "dnode_req_send_done entering!!!");
     }
     ASSERT(conn->type == CONN_DNODE_PEER_SERVER);
-    log_debug(LOG_DEBUG, "DNODE REQ SEND %s %d dmsg->id %u",
-              conn_get_type_string(conn), conn->sd, msg->dmsg->id);
+    // crashes because dmsg is NULL :(
+    /*log_debug(LOG_DEBUG, "DNODE REQ SEND %s %d dmsg->id %u",
+              conn_get_type_string(conn), conn->sd, msg->dmsg->id);*/
     req_send_done(ctx, conn, msg);
 }
 

--- a/src/dyn_dnode_response.c
+++ b/src/dyn_dnode_response.c
@@ -451,32 +451,32 @@ dnode_rsp_send_next(struct context *ctx, struct conn *conn)
 }
 
 void
-dnode_rsp_send_done(struct context *ctx, struct conn *conn, struct msg *msg)
+dnode_rsp_send_done(struct context *ctx, struct conn *conn, struct msg *rsp)
 {
     if (log_loggable(LOG_VVERB)) {
        log_debug(LOG_VVERB, "dnode_rsp_send_done entering");
    }
 
-    struct msg *pmsg; /* peer message (request) */
+    struct msg *req; /* peer message (request) */
 
     ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
     ASSERT(conn->smsg == NULL);
 
-    log_debug(LOG_VERB, "dyn: send done rsp %"PRIu64" on c %d", msg->id, conn->sd);
+    log_debug(LOG_VERB, "dyn: send done rsp %"PRIu64" on c %d", rsp->id, conn->sd);
 
-    pmsg = msg->peer;
+    req = rsp->peer;
 
-    ASSERT(!msg->request && pmsg->request);
-    ASSERT(pmsg->selected_rsp == msg);
-    ASSERT(pmsg->done && !pmsg->swallow);
+    ASSERT(!rsp->request && req->request);
+    ASSERT(req->selected_rsp == rsp);
+    ASSERT(req->done && !req->swallow);
     log_debug(LOG_DEBUG, "DNODE RSP SENT %s %d dmsg->id %u",
               conn_get_type_string(conn),
-             conn->sd, pmsg->dmsg->id);
+             conn->sd, req->dmsg->id);
 
     /* dequeue request from client outq */
-    conn_dequeue_outq(ctx, conn, pmsg);
+    conn_dequeue_outq(ctx, conn, req);
 
-    req_put(pmsg);
+    req_put(req);
 }
 
 

--- a/src/dyn_dnode_response.c
+++ b/src/dyn_dnode_response.c
@@ -149,7 +149,8 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
     conn_dequeue_outq(ctx, peer_conn, req);
     req->done = 1;
 
-    log_info("%d:%d <-> %d:%d", req->id, req->parent_id, rsp->id, rsp->parent_id);
+    log_info("c_conn:%p %d:%d <-> %d:%d", c_conn, req->id, req->parent_id,
+             rsp->id, rsp->parent_id);
     /* establish rsp <-> req (response <-> request) link */
     req->peer = rsp;
     rsp->peer = req;
@@ -161,14 +162,12 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
                "c_conn type %s", conn_get_type_string(c_conn));
 
     dnode_rsp_forward_stats(ctx, peer_conn->owner, rsp);
-    log_info("handle rsp %d:%d for req %d:%d conn %p",
-             rsp->id, rsp->parent_id, req->id, req->parent_id, c_conn);
     // c_conn owns respnse now
     status = conn_handle_response(c_conn, req->parent_id ? req->parent_id : req->id,
                                   rsp);
     IGNORE_RET_VAL(status);
     if (req->swallow) {
-        log_debug(LOG_INFO, "swallow request %d:%d", req->id, req->parent_id);
+        log_info("swallow request %d:%d", req->id, req->parent_id);
         req_put(req);
     }
 }

--- a/src/dyn_dnode_response.c
+++ b/src/dyn_dnode_response.c
@@ -466,7 +466,7 @@ dnode_rsp_send_done(struct context *ctx, struct conn *conn, struct msg *msg)
     pmsg = msg->peer;
 
     ASSERT(!msg->request && pmsg->request);
-    ASSERT(pmsg->peer == msg);
+    ASSERT(pmsg->selected_rsp == msg);
     ASSERT(pmsg->done && !pmsg->swallow);
     log_debug(LOG_DEBUG, "DNODE RSP SENT %s %d dmsg->id %u",
               conn_get_type_string(conn),

--- a/src/dyn_dnode_response.c
+++ b/src/dyn_dnode_response.c
@@ -149,7 +149,7 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
     conn_dequeue_outq(ctx, peer_conn, req);
     req->done = 1;
 
-    log_debug(LOG_VERB, "%p <-> %p", req, rsp);
+    log_warn("%d:%d <-> %d:%d", req->id, req->parent_id, rsp->id, rsp->parent_id);
     /* establish rsp <-> req (response <-> request) link */
     req->peer = rsp;
     rsp->peer = req;
@@ -161,17 +161,15 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
                "c_conn type %s", conn_get_type_string(c_conn));
 
     dnode_rsp_forward_stats(ctx, peer_conn->owner, rsp);
-    if (TAILQ_FIRST(&c_conn->omsg_q) != NULL && req_done(c_conn, req)) {
-        log_debug(LOG_INFO, "handle rsp %d:%d for req %d:%d conn %p",
-                rsp->id, rsp->parent_id, req->id, req->parent_id, c_conn);
-        // c_conn owns respnse now
-        rstatus_t status = conn_handle_response(c_conn,
-                req->parent_id ? req->parent_id : req->id,
-                rsp);
-        if (req->swallow) {
-            log_debug(LOG_INFO, "swallow request %d:%d", req->id, req->parent_id);
-            req_put(req);
-        }
+    log_debug(LOG_INFO, "handle rsp %d:%d for req %d:%d conn %p",
+            rsp->id, rsp->parent_id, req->id, req->parent_id, c_conn);
+    // c_conn owns respnse now
+    status = conn_handle_response(c_conn, req->parent_id ? req->parent_id : req->id,
+                                  rsp);
+    IGNORE_RET_VAL(status);
+    if (req->swallow) {
+        log_debug(LOG_INFO, "swallow request %d:%d", req->id, req->parent_id);
+        req_put(req);
     }
 }
 

--- a/src/dyn_dnode_response.c
+++ b/src/dyn_dnode_response.c
@@ -156,8 +156,9 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
 
     rsp->pre_coalesce(rsp);
 
-    ASSERT((c_conn->type == CONN_CLIENT) ||
-           (c_conn->type == CONN_DNODE_PEER_CLIENT));
+    ASSERT_LOG((c_conn->type == CONN_CLIENT) ||
+               (c_conn->type == CONN_DNODE_PEER_CLIENT),
+               "c_conn type %s", conn_get_type_string(c_conn));
 
     dnode_rsp_forward_stats(ctx, peer_conn->owner, rsp);
     if (TAILQ_FIRST(&c_conn->omsg_q) != NULL && req_done(c_conn, req)) {

--- a/src/dyn_dnode_response.c
+++ b/src/dyn_dnode_response.c
@@ -149,7 +149,7 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
     conn_dequeue_outq(ctx, peer_conn, req);
     req->done = 1;
 
-    log_warn("%d:%d <-> %d:%d", req->id, req->parent_id, rsp->id, rsp->parent_id);
+    log_info("%d:%d <-> %d:%d", req->id, req->parent_id, rsp->id, rsp->parent_id);
     /* establish rsp <-> req (response <-> request) link */
     req->peer = rsp;
     rsp->peer = req;
@@ -161,8 +161,8 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
                "c_conn type %s", conn_get_type_string(c_conn));
 
     dnode_rsp_forward_stats(ctx, peer_conn->owner, rsp);
-    log_debug(LOG_INFO, "handle rsp %d:%d for req %d:%d conn %p",
-            rsp->id, rsp->parent_id, req->id, req->parent_id, c_conn);
+    log_info("handle rsp %d:%d for req %d:%d conn %p",
+             rsp->id, rsp->parent_id, req->id, req->parent_id, c_conn);
     // c_conn owns respnse now
     status = conn_handle_response(c_conn, req->parent_id ? req->parent_id : req->id,
                                   rsp);

--- a/src/dyn_log.c
+++ b/src/dyn_log.c
@@ -84,7 +84,6 @@ void
 log_level_up(void)
 {
     struct logger *l = &logger;
-    l->level = 9;
 
     if (l->level < LOG_PVERB) {
         l->level++;
@@ -96,7 +95,6 @@ void
 log_level_down(void)
 {
     struct logger *l = &logger;
-    l->level = 5;
 
     if (l->level > LOG_EMERG) {
         l->level--;

--- a/src/dyn_log.c
+++ b/src/dyn_log.c
@@ -87,7 +87,7 @@ log_level_up(void)
     l->level = 9;
 
     if (l->level < LOG_PVERB) {
-        //l->level++;
+        l->level++;
         loga("up log level to %d", l->level);
     }
 }
@@ -99,7 +99,7 @@ log_level_down(void)
     l->level = 5;
 
     if (l->level > LOG_EMERG) {
-        //l->level--;
+        l->level--;
         loga("down log level to %d", l->level);
     }
 }
@@ -130,10 +130,8 @@ _log(const char *file, int line, int panic, const char *fmt, ...)
 {
     struct logger *l = &logger;
     int len, size, errno_save;
-    char buf[LOG_MAX_LEN], *timestr;
+    char buf[LOG_MAX_LEN];
     va_list args;
-    struct tm *local;
-    time_t t;
     ssize_t n;
 
     if (l->fd < 0) {
@@ -144,9 +142,6 @@ _log(const char *file, int line, int panic, const char *fmt, ...)
     len = 0;            /* length of output buffer */
     size = LOG_MAX_LEN; /* size of output buffer */
 
-    /*t = time(NULL);
-    local = localtime(&t);
-    timestr = asctime(local);*/
     struct timeval curTime;
     gettimeofday(&curTime, NULL);
 

--- a/src/dyn_log.c
+++ b/src/dyn_log.c
@@ -25,6 +25,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <sys/stat.h>
+#include <sys/time.h>
 #include <fcntl.h>
 
 #include "dyn_core.h"
@@ -83,9 +84,10 @@ void
 log_level_up(void)
 {
     struct logger *l = &logger;
+    l->level = 9;
 
     if (l->level < LOG_PVERB) {
-        l->level++;
+        //l->level++;
         loga("up log level to %d", l->level);
     }
 }
@@ -94,9 +96,10 @@ void
 log_level_down(void)
 {
     struct logger *l = &logger;
+    l->level = 5;
 
     if (l->level > LOG_EMERG) {
-        l->level--;
+        //l->level--;
         loga("down log level to %d", l->level);
     }
 }
@@ -141,12 +144,18 @@ _log(const char *file, int line, int panic, const char *fmt, ...)
     len = 0;            /* length of output buffer */
     size = LOG_MAX_LEN; /* size of output buffer */
 
-    t = time(NULL);
+    /*t = time(NULL);
     local = localtime(&t);
-    timestr = asctime(local);
+    timestr = asctime(local);*/
+    struct timeval curTime;
+    gettimeofday(&curTime, NULL);
 
-    len += dn_scnprintf(buf + len, size - len, "[%.*s] %s:%d ",
-                        strlen(timestr) - 1, timestr, file, line);
+    char buffer [80];
+    strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", localtime(&curTime.tv_sec));
+
+    len += dn_scnprintf(buf + len, size - len, "[%.*s.%03d] %s:%d ",
+                        strlen(buffer) - 1, buffer, (int64_t)curTime.tv_usec / 1000,
+                        file, line);
 
     va_start(args, fmt);
     len += dn_vscnprintf(buf + len, size - len, fmt, args);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -297,6 +297,7 @@ done:
     msg->first_fragment = 0;
     msg->last_fragment = 0;
     msg->swallow = 0;
+    msg->rsp_sent = 0;
     msg->data_store = DATA_REDIS;
 
     //dynomite
@@ -522,13 +523,15 @@ msg_free(struct msg *msg)
 void
 msg_put(struct msg *msg)
 {
-    if (msg->request && msg->awaiting_rsps != 0) {
-        log_error("freeing req %d, awaiting_rsps = %u",
-                  msg->id, msg->awaiting_rsps);
-    }
     if (msg == NULL) {
    	 log_debug(LOG_ERR, "Unable to put a null msg - probably due to memory hard-set limit");
    	 return;
+    }
+
+    if (msg->request && msg->awaiting_rsps != 0) {
+        log_error("Not freeing req %d, awaiting_rsps = %u",
+                  msg->id, msg->awaiting_rsps);
+        return;
     }
 
     if (log_loggable(LOG_VVERB)) {

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -247,6 +247,7 @@ done:
     msg->peer = NULL;
     msg->owner = NULL;
     msg->stime_in_microsec = 0L;
+    msg->awaiting_rsps = 0;
 
     rbtree_node_init(&msg->tmo_rbe);
 
@@ -520,6 +521,10 @@ msg_free(struct msg *msg)
 void
 msg_put(struct msg *msg)
 {
+    if (msg->request && msg->awaiting_rsps != 0) {
+        log_error("freeing req %d, awaiting_rsps = %u",
+                  msg->id, msg->awaiting_rsps);
+    }
     if (msg == NULL) {
    	 log_debug(LOG_ERR, "Unable to put a null msg - probably due to memory hard-set limit");
    	 return;

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -116,19 +116,19 @@
  */
 
 /* Changes to message for consistency:
- * Inorder to implement consistency, following changes have been made to message
+ * In order to implement consistency, following changes have been made to message
  * peer: Previously there was a one to one relation between request and a response
- *      both of which is struct messgae unfortunately. And due to the fact that
+ *      both of which is struct message unfortunately. And due to the fact that
  *      some requests are forwarded as is to the underlying server while some
  *      are copied, the notion of 'peer' gets complicated. hence I changed its
- *      meaning somewhat. response->peer is the request that this response belong
+ *      meaning somewhat. response->peer points to request that this response belongs
  *      to. Right now request->peer does not have any meaning other than some
  *      code in redis which does coalescing etc, and some other code just for
  *      the sake of it.
  * awaiting_rsps: This is a counter of the number of responses that a request is
  *      still expecting. For DC_ONE consistency this is immaterial. For DC_QUORUM,
  *      this is the total number of responses expected. We wait for them to arrive
- *      before we free the request. A client connection inturn waits for all the
+ *      before we free the request. A client connection in turn waits for all the
  *      requests to finish before freeing itself. (Look for waiting_to_unref).
  * selected_rsp : A request->selected_rsp is the response selected for a given
  *      request. All code related to sending response should look at selected_rsp.

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -248,6 +248,7 @@ done:
     msg->owner = NULL;
     msg->stime_in_microsec = 0L;
     msg->awaiting_rsps = 0;
+    msg->selected_rsp = NULL;
 
     rbtree_node_init(&msg->tmo_rbe);
 

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -264,6 +264,7 @@ struct msg {
     struct msg           *peer;           /* message peer */
     struct conn          *owner;          /* message owner - client | server */
     int64_t              stime_in_microsec;  /* start time in microsec */
+    uint8_t              awaiting_rsps;
 
     struct rbnode        tmo_rbe;         /* entry in rbtree */
 
@@ -333,6 +334,22 @@ struct msg {
 };
 
 TAILQ_HEAD(msg_tqh, msg);
+
+static inline void
+msg_incr_awaiting_rsps(struct msg *req)
+{
+    log_error("req %d awaiting_rsps:%u", req->awaiting_rsps);
+    req->awaiting_rsps++;
+    return;
+}
+
+static inline void
+msg_decr_awaiting_rsps(struct msg *req)
+{
+    log_error("req %d awaiting_rsps:%u", req->awaiting_rsps);
+    req->awaiting_rsps--;
+    return;
+}
 
 static inline rstatus_t
 msg_handle_response(struct msg *req, struct msg *rsp)

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -314,6 +314,7 @@ struct msg {
     unsigned             first_fragment:1;/* first fragment? */
     unsigned             last_fragment:1; /* last fragment? */
     unsigned             swallow:1;       /* swallow response? */
+    unsigned             rsp_sent:1;      /* is a response sent for this request?*/
 
     int					 data_store;
     //dynomite

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -340,7 +340,6 @@ TAILQ_HEAD(msg_tqh, msg);
 static inline void
 msg_incr_awaiting_rsps(struct msg *req)
 {
-    //log_error("req %d awaiting_rsps:%u", req->id, req->awaiting_rsps);
     req->awaiting_rsps++;
     return;
 }
@@ -348,7 +347,6 @@ msg_incr_awaiting_rsps(struct msg *req)
 static inline void
 msg_decr_awaiting_rsps(struct msg *req)
 {
-    //log_error("req %d awaiting_rsps:%u", req->id, req->awaiting_rsps);
     req->awaiting_rsps--;
     return;
 }

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -339,7 +339,7 @@ TAILQ_HEAD(msg_tqh, msg);
 static inline void
 msg_incr_awaiting_rsps(struct msg *req)
 {
-    log_error("req %d awaiting_rsps:%u", req->id, req->awaiting_rsps);
+    //log_error("req %d awaiting_rsps:%u", req->id, req->awaiting_rsps);
     req->awaiting_rsps++;
     return;
 }
@@ -347,7 +347,7 @@ msg_incr_awaiting_rsps(struct msg *req)
 static inline void
 msg_decr_awaiting_rsps(struct msg *req)
 {
-    log_error("req %d awaiting_rsps:%u", req->id, req->awaiting_rsps);
+    //log_error("req %d awaiting_rsps:%u", req->id, req->awaiting_rsps);
     req->awaiting_rsps--;
     return;
 }

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -265,6 +265,7 @@ struct msg {
     struct conn          *owner;          /* message owner - client | server */
     int64_t              stime_in_microsec;  /* start time in microsec */
     uint8_t              awaiting_rsps;
+    struct msg           *selected_rsp;
 
     struct rbnode        tmo_rbe;         /* entry in rbtree */
 
@@ -338,7 +339,7 @@ TAILQ_HEAD(msg_tqh, msg);
 static inline void
 msg_incr_awaiting_rsps(struct msg *req)
 {
-    log_error("req %d awaiting_rsps:%u", req->awaiting_rsps);
+    log_error("req %d awaiting_rsps:%u", req->id, req->awaiting_rsps);
     req->awaiting_rsps++;
     return;
 }
@@ -346,7 +347,7 @@ msg_incr_awaiting_rsps(struct msg *req)
 static inline void
 msg_decr_awaiting_rsps(struct msg *req)
 {
-    log_error("req %d awaiting_rsps:%u", req->awaiting_rsps);
+    log_error("req %d awaiting_rsps:%u", req->id, req->awaiting_rsps);
     req->awaiting_rsps--;
     return;
 }

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -1065,7 +1065,8 @@ swallow_extra_rsp(struct msg *req, struct msg *rsp)
     return DN_NOOPS;
 }
 
-static rstatus_t msg_quorum_rsp_handler(struct msg *req, struct msg *rsp)
+static rstatus_t
+msg_quorum_rsp_handler(struct msg *req, struct msg *rsp)
 {
     if (rspmgr_is_done(&req->rspmgr))
         return swallow_extra_rsp(req, rsp);

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -1236,7 +1236,8 @@ rstatus_t
 rspmgr_submit_response(struct response_mgr *rspmgr, struct msg*rsp)
 {
     if (rsp->error) {
-        log_debug(LOG_VERB, "Received error response %d:%d", rsp->id, rsp->parent_id);
+        log_debug(LOG_VERB, "Received error response %d:%d for req %d:%d",
+                  rsp->id, rsp->parent_id, rspmgr->msg->id, rspmgr->msg->parent_id);
         rspmgr->error_responses++;
         if (rspmgr->err_rsp == NULL)
             rspmgr->err_rsp = rsp;

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -1042,6 +1042,7 @@ msg_read_one_rsp_handler(struct msg *req, struct msg *rsp)
                  req->peer->id, req->peer->parent_id, rsp->id, rsp->parent_id);
     req->peer = rsp;
     rsp->peer = req;
+    req->selected_rsp = rsp;
     return DN_OK;
 }
 
@@ -1055,6 +1056,7 @@ msg_write_one_rsp_handler(struct msg *req, struct msg *rsp)
                  req->peer->id, req->peer->parent_id, rsp->id, rsp->parent_id);
     req->peer = rsp;
     rsp->peer = req;
+    req->selected_rsp = rsp;
     return DN_OK;
 }
 
@@ -1069,6 +1071,7 @@ msg_read_dc_quorum_rsp_handler(struct msg *req, struct msg *rsp)
     rspmgr_free_other_responses(&req->rspmgr, rsp);
     req->peer = rsp;
     rsp->peer = req;
+    req->selected_rsp = rsp;
     req->err = rsp->err;
     req->error = rsp->error;
     req->dyn_error = rsp->dyn_error;
@@ -1087,6 +1090,7 @@ msg_write_dc_quorum_rsp_handler(struct msg *req, struct msg *rsp)
     rspmgr_free_other_responses(&req->rspmgr, rsp);
     req->peer = rsp;
     rsp->peer = req;
+    req->selected_rsp = rsp;
     req->err = rsp->err;
     req->error = rsp->error;
     req->dyn_error = rsp->dyn_error;

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -1035,6 +1035,7 @@ msg_get_rsp_handler(struct msg *req)
 static rstatus_t
 msg_read_one_rsp_handler(struct msg *req, struct msg *rsp)
 {
+    req->awaiting_rsps = 0;
     if (req->peer)
         log_warn("Received more than one response for dc_one. req: %d:%d \
                  prev rsp %d:%d new rsp %d:%d", req->id, req->parent_id,
@@ -1047,6 +1048,7 @@ msg_read_one_rsp_handler(struct msg *req, struct msg *rsp)
 static rstatus_t
 msg_write_one_rsp_handler(struct msg *req, struct msg *rsp)
 {
+    req->awaiting_rsps = 0;
     if (req->peer)
         log_warn("Received more than one response for dc_one. req: %d:%d \
                  prev rsp %d:%d new rsp %d:%d", req->id, req->parent_id,
@@ -1101,6 +1103,7 @@ init_response_mgr(struct response_mgr *rspmgr, struct msg *msg, bool is_read,
     rspmgr->quorum_responses = max_responses/2 + 1;
     rspmgr->conn = conn;
     rspmgr->msg = msg;
+    msg->awaiting_rsps = max_responses;
 }
 
 static bool
@@ -1239,5 +1242,6 @@ rspmgr_submit_response(struct response_mgr *rspmgr, struct msg*rsp)
         log_debug(LOG_VERB, "Good response %d:%d", rsp->id, rsp->parent_id);
         rspmgr->responses[rspmgr->good_responses++] =  rsp;
     }
+    msg_decr_awaiting_rsps(rspmgr->msg);
     return DN_OK;
 }

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -764,8 +764,8 @@ req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
     uint8_t rack_index;
     msg->rsp_handler = msg_get_rsp_handler(msg);
     init_response_mgr(&msg->rspmgr, msg, msg->is_read, rack_cnt, c_conn);
-    log_debug(LOG_WARN, "msg %d:%d same DC racks:%d expect replies %d",
-              msg->id, msg->parent_id, rack_cnt, msg->rspmgr.max_responses);
+    log_info("msg %d:%d same DC racks:%d expect replies %d",
+             msg->id, msg->parent_id, rack_cnt, msg->rspmgr.max_responses);
     for(rack_index = 0; rack_index < rack_cnt; rack_index++) {
         struct rack *rack = array_get(&dc->racks, rack_index);
         //log_debug(LOG_DEBUG, "rack name '%.*s'",
@@ -785,8 +785,8 @@ req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
             }
 
             msg_clone(msg, orig_mbuf, rack_msg);
-            log_debug(LOG_WARN, "msg (%d:%d) clone to rack msg (%d:%d)",
-                    msg->id, msg->parent_id, rack_msg->id, rack_msg->parent_id);
+            log_info("msg (%d:%d) clone to rack msg (%d:%d)",
+                     msg->id, msg->parent_id, rack_msg->id, rack_msg->parent_id);
             rack_msg->swallow = true;
         }
 
@@ -1056,7 +1056,7 @@ msg_local_one_rsp_handler(struct msg *req, struct msg *rsp)
 static rstatus_t
 swallow_extra_rsp(struct msg *req, struct msg *rsp)
 {
-    log_error("req %d swallowing response %d", req->id, rsp->id);
+    log_info("req %d swallowing response %d", req->id, rsp->id);
     ASSERT_LOG(req->awaiting_rsps, "Req %d:%d already has no awaiting rsps, rsp %d",
                req->id, req->parent_id, rsp->id);
     // drop this response.
@@ -1233,7 +1233,7 @@ rspmgr_free_other_responses(struct response_mgr *rspmgr, struct msg *dont_free)
 rstatus_t
 rspmgr_submit_response(struct response_mgr *rspmgr, struct msg*rsp)
 {
-    log_error("req %d submitting response %d awaiting_rsps %d",
+    log_info("req %d submitting response %d awaiting_rsps %d",
               rspmgr->msg->id, rsp->id, rspmgr->msg->awaiting_rsps);
     if (rsp->error) {
         log_debug(LOG_VERB, "Received error response %d:%d for req %d:%d",

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -309,11 +309,11 @@ rsp_send_next(struct context *ctx, struct conn *conn)
 
         return NULL;
     }
-    //msg_dump(req);
 
     rsp = conn->smsg;
     if (rsp != NULL) {
-        ASSERT(!rsp->request && rsp->peer != NULL);
+        ASSERT(!rsp->request);
+        ASSERT(rsp->peer != NULL);
         ASSERT(req_done(conn, rsp->peer));
         req = TAILQ_NEXT(rsp->peer, c_tqe);
     }
@@ -323,7 +323,6 @@ rsp_send_next(struct context *ctx, struct conn *conn)
         return NULL;
     }
     ASSERT(req->request && !req->swallow);
-    //msg_dump(req);
 
     if (req_error(conn, req)) {
         rsp = rsp_make_error(ctx, conn, req);
@@ -335,7 +334,6 @@ rsp_send_next(struct context *ctx, struct conn *conn)
         req->peer = rsp;
         req->selected_rsp = rsp;
         log_error("creating new error rsp %p", rsp);
-        //msg_dump(rsp);
         if (conn->dyn_mode) {
       	  stats_pool_incr(ctx, conn->owner, peer_forward_error);
         } else {

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -241,7 +241,7 @@ server_rsp_forward(struct context *ctx, struct conn *s_conn, struct msg *rsp)
     req->done = 1;
 
     /* establish rsp <-> req (response <-> request) link */
-    log_warn("%d:%d <-> %d:%d", req->id, req->parent_id,
+    log_info("%d:%d <-> %d:%d", req->id, req->parent_id,
                rsp->id, rsp->parent_id);
     req->peer = rsp;
     rsp->peer = req;
@@ -257,8 +257,8 @@ server_rsp_forward(struct context *ctx, struct conn *s_conn, struct msg *rsp)
     // this should really be the message's response handler be doing it
     if (req_done(c_conn, req)) {
         // handler owns the response now
-        log_debug(LOG_INFO, "handle rsp %d:%d for req %d:%d conn %p", rsp->id,
-                   rsp->parent_id, req->id, req->parent_id, c_conn);
+        log_info("handle rsp %d:%d for req %d:%d conn %p", rsp->id,
+                 rsp->parent_id, req->id, req->parent_id, c_conn);
         status = conn_handle_response(c_conn, c_conn->type == CONN_CLIENT ?
                                       req->id : req->parent_id, rsp);
         IGNORE_RET_VAL(status);
@@ -382,7 +382,7 @@ rsp_send_done(struct context *ctx, struct conn *conn, struct msg *rsp)
         dictDelete(conn->outstanding_msgs_dict, &req->id);
         req_put(req);
     } else {
-        log_error("req %d:%d still awaiting rsps %d", req->id, req->parent_id,
+        log_info("req %d:%d still awaiting rsps %d", req->id, req->parent_id,
                   req->awaiting_rsps);
     }
 }

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -241,7 +241,7 @@ server_rsp_forward(struct context *ctx, struct conn *s_conn, struct msg *rsp)
     req->done = 1;
 
     /* establish rsp <-> req (response <-> request) link */
-    log_debug(LOG_VERB, "%d:%d <-> %d:%d", req->id, req->parent_id,
+    log_warn("%d:%d <-> %d:%d", req->id, req->parent_id,
                rsp->id, rsp->parent_id);
     req->peer = rsp;
     rsp->peer = req;

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -241,14 +241,14 @@ server_rsp_forward(struct context *ctx, struct conn *s_conn, struct msg *rsp)
     req->done = 1;
 
     /* establish rsp <-> req (response <-> request) link */
-    log_info("%d:%d <-> %d:%d", req->id, req->parent_id,
-               rsp->id, rsp->parent_id);
     req->peer = rsp;
     rsp->peer = req;
 
     rsp->pre_coalesce(rsp);
 
     c_conn = req->owner;
+    log_info("c_conn %p %d:%d <-> %d:%d", c_conn, req->id, req->parent_id,
+               rsp->id, rsp->parent_id);
     
     ASSERT((c_conn->type == CONN_CLIENT) ||
            (c_conn->type == CONN_DNODE_PEER_CLIENT));

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -318,7 +318,7 @@ rsp_send_next(struct context *ctx, struct conn *conn)
         req = TAILQ_NEXT(rsp->peer, c_tqe);
     }
 
-    if (req == NULL || !req_done(conn, req)) {
+    if (req == NULL || !req_done(conn, req) || !req->selected_rsp) {
         conn->smsg = NULL;
         return NULL;
     }

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -411,6 +411,8 @@ server_close(struct context *ctx, struct conn *conn)
 
 		/* dequeue the message (request) from server inq */
 		conn_dequeue_inq(ctx, conn, msg);
+        // We should also remove the msg from the timeout rbtree.
+        msg_tmo_delete(msg);
         server_ack_err(ctx, conn, msg);
 
 		stats_server_incr(ctx, conn->owner, server_dropped_requests);

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -331,7 +331,7 @@ server_close_stats(struct context *ctx, struct server *server, err_t err,
 	}
 }
 
-void
+static void
 server_ack_err(struct context *ctx, struct conn *conn, struct msg *req)
 {
     // I want to make sure we do not have swallow here.
@@ -401,7 +401,7 @@ server_close(struct context *ctx, struct conn *conn)
 		nmsg = TAILQ_NEXT(msg, s_tqe);
 
 		/* dequeue the message (request) from server outq */
-		conn_dequeue_outq(ctx, conn, msg);
+        conn_dequeue_outq(ctx, conn, msg);
         server_ack_err(ctx, conn, msg);
 	}
 	ASSERT(TAILQ_EMPTY(&conn->omsg_q));

--- a/src/dyn_util.h
+++ b/src/dyn_util.h
@@ -187,6 +187,13 @@ ssize_t _dn_recvn(int sd, void *vptr, size_t n);
     }                                           \
 } while (0)
 
+#define ASSERT_LOG(_x, _M, ...) do {            \
+    if (!(_x)) {                                \
+        log_error("Assertion Failed: "_M, ##__VA_ARGS__);            \
+        dn_assert(#_x, __FILE__, __LINE__, 1);  \
+    }                                           \
+} while (0)
+
 #define NOT_REACHED() ASSERT(0)
 
 #elif DN_ASSERT_LOG
@@ -197,11 +204,19 @@ ssize_t _dn_recvn(int sd, void *vptr, size_t n);
     }                                           \
 } while (0)
 
+#define ASSERT_LOG(_x, _M, ...) do {            \
+    if (!(_x)) {                                \
+        log_error("ASSERTION FAILED: "_M, ##__VA_ARGS__);            \
+        dn_assert(#_x, __FILE__, __LINE__, 0);  \
+    }                                           \
+} while (0)
+
 #define NOT_REACHED() ASSERT(0)
 
 #else
 
 #define ASSERT(_x)
+#define ASSERT_LOG(_x, _M, ...)
 
 #define NOT_REACHED()
 

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -37,7 +37,7 @@
 #define DN_CONF_PATH        "conf/dynomite.yml"
 
 #define DN_LOG_DEFAULT      LOG_NOTICE
-#define DN_LOG_MIN          LOG_EMERG
+#define DN_LOG_MIN          LOG_VVERB /*LOG_EMERG*/
 #define DN_LOG_MAX          LOG_PVERB
 #define DN_LOG_PATH         NULL
 
@@ -371,7 +371,7 @@ dn_get_options(int argc, char **argv, struct instance *nci)
                 log_stderr("dynomite: option -v requires a number");
                 return DN_ERROR;
             }
-            nci->log_level = value;
+            nci->log_level = 9;//value;
             break;
 
         case 'o':

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -37,7 +37,7 @@
 #define DN_CONF_PATH        "conf/dynomite.yml"
 
 #define DN_LOG_DEFAULT      LOG_NOTICE
-#define DN_LOG_MIN          LOG_VVERB /*LOG_EMERG*/
+#define DN_LOG_MIN          LOG_EMERG
 #define DN_LOG_MAX          LOG_PVERB
 #define DN_LOG_PATH         NULL
 
@@ -371,7 +371,7 @@ dn_get_options(int argc, char **argv, struct instance *nci)
                 log_stderr("dynomite: option -v requires a number");
                 return DN_ERROR;
             }
-            nci->log_level = 9;//value;
+            nci->log_level = value;
             break;
 
         case 'o':


### PR DESCRIPTION
These patches do the following:
o responds earlier to the requests as soon as quorum is achieved instead of waiting for all responses.
o Solves a bunch of crashes related to early closing of sockets, timeouts etc. These show up in quorum consistency
o Add ASSERT_LOG : here we can add extra information in case the assert fails.
o Logs will now show milliseconds. This can be helpful in debugging.
o Adds good comments on the new variables added

This patch could be the first step towards zero message copy in dynomite.