### PR TITLE
Updates on Consistency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Define the package version numbers and the bug reporting address
 m4_define([DN_MAJOR], 0)
 m4_define([DN_MINOR], 5)
-m4_define([DN_PATCH], 1)
+m4_define([DN_PATCH], 2)
 m4_define([DN_BUGS], [mdo@netflix.com])
 
 # Initialize autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Define the package version numbers and the bug reporting address
 m4_define([DN_MAJOR], 0)
 m4_define([DN_MINOR], 5)
-m4_define([DN_PATCH], 3)
+m4_define([DN_PATCH], 5)
 m4_define([DN_BUGS], [mdo@netflix.com])
 
 # Initialize autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Define the package version numbers and the bug reporting address
 m4_define([DN_MAJOR], 0)
 m4_define([DN_MINOR], 5)
-m4_define([DN_PATCH], 0)
+m4_define([DN_PATCH], 1)
 m4_define([DN_BUGS], [mdo@netflix.com])
 
 # Initialize autoconf

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 m4_define([DN_MAJOR], 0)
 m4_define([DN_MINOR], 5)
 m4_define([DN_PATCH], 5)
-m4_define([DN_BUGS], [mdo@netflix.com])
+m4_define([DN_BUGS], [dynomite@netflix.com])
 
 # Initialize autoconf
 AC_PREREQ([2.63])

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # Define the package version numbers and the bug reporting address
 m4_define([DN_MAJOR], 0)
 m4_define([DN_MINOR], 5)
-m4_define([DN_PATCH], 2)
+m4_define([DN_PATCH], 3)
 m4_define([DN_BUGS], [mdo@netflix.com])
 
 # Initialize autoconf

--- a/src/dyn_log.h
+++ b/src/dyn_log.h
@@ -64,11 +64,6 @@ struct logger {
     }                                                                       \
 } while (0)
 
-#define log_notice(...)                                                     \
-    log_debug(LOG_NOTICE, __VA_ARGS__);
-#define log_info(...)                                                     \
-    log_debug(LOG_INFO, __VA_ARGS__);
-
 #define log_hexdump(_level, _data, _datalen, ...) do {                      \
     if (log_loggable(_level) != 0) {                                        \
         _log(__FUNCTION__, __LINE__, 0, __VA_ARGS__);                           \
@@ -83,6 +78,11 @@ struct logger {
 #define log_hexdump(_level, _data, _datalen, ...)
 
 #endif
+
+#define log_notice(...)                                                     \
+    log_debug(LOG_NOTICE, __VA_ARGS__);
+#define log_info(...)                                                     \
+    log_debug(LOG_INFO, __VA_ARGS__);
 
 #define log_stderr(...) do {                                                \
     _log_stderr(__VA_ARGS__);                                               \

--- a/src/seedsprovider/dyn_florida.c
+++ b/src/seedsprovider/dyn_florida.c
@@ -123,7 +123,7 @@ florida_get_seeds(struct context * ctx, struct mbuf *seeds_buf) {
 
         // Look for a OK response  in the first buffer output.
         if (!ok)
-		    ok = (uint8_t *) strstr((char *)buf, "200 OK.\r\n");
+		    ok = (uint8_t *) strstr((char *)buf, "200 OK\r\n");
         if (ok == NULL) {
             log_error("Received Error from Florida while getting seeds");
             loga_hexdump(buf, tmpres, "Florida Response with %ld bytes of data", tmpres);


### PR DESCRIPTION
o responds earlier to the requests as soon as quorum is achieved instead of waiting for all responses.
o Solves a bunch of crashes related to early closing of sockets, timeouts etc. These show up in quorum consistency
o Add ASSERT_LOG : here we can add extra information in case the assert fails.
o Logs will now show milliseconds. This can be helpful in debugging.
o Adds good comments on the new variables added