### PR TITLE
Fix Peer Dnode Mismatches

### DIFF
--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -307,7 +307,6 @@ dyn_parse_core(struct msg *r)
          }
          if (*p == LF) {
             dyn_state = DYN_DONE;
-            r->pos = p;
          } else {
             token = NULL;
             dyn_state = DYN_START;


### PR DESCRIPTION
There was an edge case in the dnode header parsing where we were dropping a
dnode message from a peer. This happens when the dnode header arrives in one
packet and rest of the message arrives in another packet. This fix will further
reduce inconsistencies in the database.

Yay!!