### PR TITLE
Look at selected_rsp

### DIFF
--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -292,7 +292,7 @@ rsp_send_next(struct context *ctx, struct conn *conn)
                (conn->type = CONN_CLIENT), "conn %s", conn_get_type_string(conn));
 
     req = TAILQ_FIRST(&conn->omsg_q);
-    if (req == NULL || !req_done(conn, req)) {
+    if (req == NULL || !req->selected_rsp) {
         /* nothing is outstanding, initiate close? */
         if (req == NULL && conn->eof) {
             conn->done = 1;
@@ -311,12 +311,10 @@ rsp_send_next(struct context *ctx, struct conn *conn)
     if (rsp != NULL) {
         ASSERT(!rsp->request);
         ASSERT(rsp->peer != NULL);
-        ASSERT(req_done(conn, rsp->peer));
         req = TAILQ_NEXT(rsp->peer, c_tqe);
     }
 
     if (req == NULL || // no more requests to be responded
-        !req_done(conn, req) || // this request is not yet done.
         (!req_error(conn, req) && !req->selected_rsp) // req is neither error-ed nor a response is selected
         ) {
         conn->smsg = NULL;

--- a/src/event/dyn_epoll.c
+++ b/src/event/dyn_epoll.c
@@ -146,6 +146,7 @@ event_add_out(struct event_base *evb, struct conn *c)
     event.events = (uint32_t)(EPOLLIN | EPOLLOUT); // | EPOLLET);
     event.data.ptr = c;
 
+    log_debug(LOG_DEBUG, "adding conn %p(%s) to active", c, conn_get_type_string(c));
     status = epoll_ctl(ep, EPOLL_CTL_MOD, c->sd, &event);
     if (status < 0) {
         log_error("epoll ctl on e %d sd %d failed: %s", ep, c->sd,
@@ -176,6 +177,7 @@ event_del_out(struct event_base *evb, struct conn *c)
     event.events = (uint32_t)(EPOLLIN | EPOLLET);
     event.data.ptr = c;
 
+    log_debug(LOG_DEBUG, "removing conn %p(%s) from active", c, conn_get_type_string(c));
     status = epoll_ctl(ep, EPOLL_CTL_MOD, c->sd, &event);
     if (status < 0) {
         log_error("epoll ctl on e %d sd %d failed: %s", ep, c->sd,
@@ -201,6 +203,7 @@ event_add_conn(struct event_base *evb, struct conn *c)
     event.events = (uint32_t)(EPOLLIN | EPOLLOUT | EPOLLET);
     event.data.ptr = c;
 
+    log_debug(LOG_DEBUG, "adding conn %p(%s) to active", c, conn_get_type_string(c));
     status = epoll_ctl(ep, EPOLL_CTL_ADD, c->sd, &event);
     if (status < 0) {
         log_error("epoll ctl on e %d sd %d failed: %s", ep, c->sd,
@@ -223,6 +226,7 @@ event_del_conn(struct event_base *evb, struct conn *c)
     ASSERT(c != NULL);
     ASSERT(c->sd > 0);
 
+    log_debug(LOG_DEBUG, "removing conn %p(%s) from active", c, conn_get_type_string(c));
     status = epoll_ctl(ep, EPOLL_CTL_DEL, c->sd, NULL);
     if (status < 0) {
         log_error("epoll ctl on e %d sd %d failed: %s", ep, c->sd,


### PR DESCRIPTION
We should use selected_rsp everywhere to check if a request is done
Manually tested this on a local node with a 2 node cluster of which one node
is down. In quorum case, the client would hung.