### PR TITLE
Florida REST URL by GCC Args + NodeJS Florida Script 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sudo autoreconf -fvi ; sudo ./configure --enable-debug=log ; sudo make
+

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-sudo autoreconf -fvi ; sudo ./configure --enable-debug=log ; sudo make
+sudo autoreconf -fvi ; sudo ./configure --enable-debug=log ; sudo make CFLAGS=-DFLORIDA_REQUEST='"\"GET /REST/v1/admin/get_seeds HTTP/1.0\r\nHost: 127.0.0.1\r\nUser-Agent: HTMLGET 1.0\r\n\r\n\""'
 

--- a/conf/dynomite_florida_single.yml
+++ b/conf/dynomite_florida_single.yml
@@ -1,0 +1,12 @@
+dyn_o_mite:
+  datacenter: dc
+  rack: rack1
+  dyn_listen: 0.0.0.0:8101
+  dyn_seed_provider: florida_provider
+  listen: 0.0.0.0:8102
+  servers:
+  - 127.0.0.1:6379:1
+  tokens: '0'
+  secure_server_option: datacenter
+  pem_key_file: dynomite.pem
+  data_store: 0

--- a/conf/dynomite_florida_single.yml
+++ b/conf/dynomite_florida_single.yml
@@ -8,5 +8,5 @@ dyn_o_mite:
   - 127.0.0.1:6379:1
   tokens: '0'
   secure_server_option: datacenter
-  pem_key_file: dynomite.pem
+  pem_key_file: conf/dynomite.pem
   data_store: 0

--- a/scripts/florida.js
+++ b/scripts/florida.js
@@ -13,7 +13,11 @@ if(typeof seeds_file_path_arg == 'undefined' || seeds_file_path_arg == null || s
 }
 
 var server = http.createServer(function(req, res) {
+  
   var path = url.parse(req.url).pathname;
+  console.log("Request: "+ path);
+
+
   res.writeHead(200, {"Content-Type": "application/json"});
   if (path == '/REST/v1/admin/get_seeds') {
     data = seeds_file.readFileSync(seeds_file_path).toString();

--- a/scripts/florida.js
+++ b/scripts/florida.js
@@ -1,0 +1,29 @@
+var http = require('http');
+var url = require('url');
+
+var seeds_file_path_arg = process.argv.slice(2);
+
+var seeds_file = require('fs');
+var seeds_file_path = '/etc/dynomite/seeds.list';
+
+if(typeof seeds_file_path_arg == 'undefined' || seeds_file_path_arg == null || seeds_file_path_arg  == ''){
+  seeds_file_path = '/etc/dynomite/seeds.list';
+} else{
+  seeds_file_path = seeds_file_path_arg;
+}
+
+var server = http.createServer(function(req, res) {
+  var path = url.parse(req.url).pathname;
+  res.writeHead(200, {"Content-Type": "application/json"});
+  if (path == '/REST/v1/admin/get_seeds') {
+    data = seeds_file.readFileSync(seeds_file_path).toString();
+    data_oneline = data.trim().replace(/\n/g, '|');
+    var now = new Date();
+    var jsonDate = now.toJSON();
+    console.log(jsonDate + " - get_seeds [" + data_oneline + "]");
+    res.write(data_oneline);
+  }
+  res.end();
+});
+server.listen(8080);
+

--- a/src/seedsprovider/dyn_florida.c
+++ b/src/seedsprovider/dyn_florida.c
@@ -107,7 +107,7 @@ florida_get_seeds(struct context * ctx, struct mbuf *seeds_buf) {
 	uint32_t sent = 0;
 	while(sent < dn_strlen(request))
 	{
-		tmpres = send(sock, request + sent, dn_strlen( request )-sent, 0);
+		tmpres = send(sock, request+sent, dn_strlen(request)-sent, 0);
 		if(tmpres == -1){
 			log_debug(LOG_VVERB, "Unable to send query");
                         close(sock);

--- a/src/seedsprovider/dyn_florida.c
+++ b/src/seedsprovider/dyn_florida.c
@@ -21,8 +21,10 @@
 #define FLORIDA_IP "127.0.0.1"
 #define FLORIDA_PORT 8080
 
-const char * request = "GET /REST/v1/admin/get_seeds HTTP/1.0\r\nHost: "\
-                       "127.0.0.1\r\nUser-Agent: HTMLGET 1.0\r\n\r\n";
+#define request "GET /REST/v1/admin/get_seeds HTTP/1.0\r\nHost: 127.0.0.1\r\nUser-Agent: HTMLGET 1.0\r\n\r\n"
+
+//const char * request = "GET /REST/v1/admin/get_seeds HTTP/1.0\r\nHost: "\
+//                       "127.0.0.1\r\nUser-Agent: HTMLGET 1.0\r\n\r\n";
 
 static uint32_t create_tcp_socket();
 static uint8_t *build_get_query(uint8_t *host, uint8_t *page);
@@ -181,3 +183,4 @@ uint32_t create_tcp_socket()
 	}
 	return sock;
 }
+

--- a/src/seedsprovider/dyn_florida.c
+++ b/src/seedsprovider/dyn_florida.c
@@ -21,14 +21,14 @@
 #define FLORIDA_IP "127.0.0.1"
 #define FLORIDA_PORT 8080
 
-#define request "GET /REST/v1/admin/get_seeds HTTP/1.0\r\nHost: 127.0.0.1\r\nUser-Agent: HTMLGET 1.0\r\n\r\n"
+#ifndef FLORIDA_REQUEST
+#define FLORIDA_REQUEST "GET /REST/v1/admin/get_seeds HTTP/1.0\r\nHost: 127.0.0.1\r\nUser-Agent: HTMLGET 1.0\r\n\r\n";
+#endif
 
-//const char * request = "GET /REST/v1/admin/get_seeds HTTP/1.0\r\nHost: "\
-//                       "127.0.0.1\r\nUser-Agent: HTMLGET 1.0\r\n\r\n";
+const char * request = FLORIDA_REQUEST;
 
 static uint32_t create_tcp_socket();
 static uint8_t *build_get_query(uint8_t *host, uint8_t *page);
-
 
 static int64_t last = 0; //storing last time for seeds check
 static uint32_t last_seeds_hash = 0;
@@ -103,11 +103,11 @@ florida_get_seeds(struct context * ctx, struct mbuf *seeds_buf) {
 	uint32_t sent = 0;
 	while(sent < dn_strlen(request))
 	{
-		tmpres = send(sock, request+sent, dn_strlen(request)-sent, 0);
+		tmpres = send(sock, request + sent, dn_strlen( request )-sent, 0);
 		if(tmpres == -1){
 			log_debug(LOG_VVERB, "Unable to send query");
-            close(sock);
-            dn_free(remote);
+                        close(sock);
+                        dn_free(remote);
 			return DN_ERROR;
 		}
 		sent += tmpres;
@@ -118,7 +118,7 @@ florida_get_seeds(struct context * ctx, struct mbuf *seeds_buf) {
 	memset(buf, 0, sizeof(buf));
 	uint32_t htmlstart = 0;
 	uint8_t * htmlcontent;
-    uint8_t *ok = NULL;
+        uint8_t *ok = NULL;
 
 	//assume that the respsone payload is under BUF_SIZE
 	while ((tmpres = recv(sock, buf, BUFSIZ, 0)) > 0) {

--- a/src/seedsprovider/dyn_florida.c
+++ b/src/seedsprovider/dyn_florida.c
@@ -17,9 +17,13 @@
  *   ec2-54-145-17-101.compute-1.amazonaws.com:8101:dyno_pds--useast1e:us-east-1:1383429731|ec2-54-101-51-17.eu-west-1.compute.amazonaws.com:8101:dyno_pds--euwest1c:eu-west-1:1383429731
  ****************************************************************************/
 
-
+#ifndef FLORIDA_IP
 #define FLORIDA_IP "127.0.0.1"
+#endif
+
+#ifndef FLORIDA_PORT
 #define FLORIDA_PORT 8080
+#endif
 
 #ifndef FLORIDA_REQUEST
 #define FLORIDA_REQUEST "GET /REST/v1/admin/get_seeds HTTP/1.0\r\nHost: 127.0.0.1\r\nUser-Agent: HTMLGET 1.0\r\n\r\n";


### PR DESCRIPTION
@timiblossom @ipapapa 

I transformed the request into a macro parameter called FLORIDA_REQUEST so we can pass by parameter to the compiler, i did this because i have this file into a server so i can expose the URL and dont need write a proxy, it gives more flexibility to users.

Also added a simple script showing how to pass the CFLAG spaced(with is tricky in C :-) and that NodeJS Script to run Florida. Also added a config file with Florida provider that could serve as sample to other developers.

Cheers,
Diego Pacheco