### PR TITLE
exponential backoff in removing fragmentation script

### DIFF
--- a/scripts/dyno_redis_bgrewriteaof.sh
+++ b/scripts/dyno_redis_bgrewriteaof.sh
@@ -97,7 +97,7 @@ if [[ ${FREE_MEMORY} -le ${THRESHOLD_MEMORY} ]]; then
              sleep $SLEEPING
              log "OK: sleeping $SLEEPING because BGREWRITEAOF is pending"
              REDIS_AOF_REWRITE_IN_PROGRESS=`redis-cli -p 22122 INFO | grep aof_rewrite_in_progress | awk -F ':' '{printf "%d\n",$2}'`
-             let SLEEPING=SLEEPING+5
+             let SLEEPING=2*SLEEPING
              if [[ ${SLEEPING} -ge 1800 ]]; then
                 log "ERROR: Redis BGREWRITEAOF takes more than 1800 seconds"
                 ((RESULT++))

--- a/scripts/dyno_redis_bgrewriteaof.sh
+++ b/scripts/dyno_redis_bgrewriteaof.sh
@@ -5,8 +5,10 @@
 
 # author: Ioannis Papapanagiotou
 
+# To be used for exit code
+declare -i RESULT
 
-#Handle arguments
+# Function to handle arguments
 function usage () {
     cat <<EOF
 Usage: $0 [options] [--] [file...]
@@ -30,6 +32,48 @@ function log() { printf '%s\n' "$*"; }
 function error() { log "ERROR: $*" >&2; }
 function fatal() { error "$*"; exit 1; }
 function usage_fatal() { error "$*"; usage >&2; exit 1; }
+
+
+function restart_redis(){
+   # take the pid of the redis-server.
+   pid=`ps -ef | grep  'redis-server' | awk ' {print $2}'`
+
+   # check number of Redis jobs
+   RUNNING_REDIS=`ps -ef | grep  'redis-server' | grep 22122 | awk ' {print $2}' | wc -l`
+   if [[ ${RUNNING_REDIS} -eq 1 ]]; then
+      log "OK: killing redis"
+      kill -9 $pid
+
+      # check if Redis is still running after killing it
+      REDIS_KILLED=`ps aux | grep redis-server | grep 22122 | wc -l`
+      if [[ ${REDIS_KILLED} -eq 0 ]]; then
+           log "OK: redis killed - sleeping 1 second"
+           sleep 2
+           log "OK: relaunching redis - sleeping 10 seconds"
+           redis-server --port 22122 &
+           sleep 10
+
+           # check if Redis running after relauncing it"
+           REDIS_RESTARTED=`ps aux | grep redis-server | grep 22122 | wc -l`
+           if [[ ${REDIS_RESTARTED} -eq 1 ]]; then
+               log "OK: redis launched - sleeping 20 seconds"
+               log "==================================================="
+               sleep 20
+               else
+                   log "ERROR: redis could not be relaunched"
+                   ((RESULT++))
+           fi
+         else
+             log "ERROR: redis could not be killed"
+             log "ERROR: process running: `ps aux | grep redis-server | grep 22122`"
+             ((RESULT++))
+         fi
+    else
+      ((RESULT++))
+      log "ERROR: $RUNNING_REDIS redis-servers running. Exiting ..."
+    fi
+}
+
 
 # Default values for threshold for available node memory in KB
 FREE_MIN_MEMORY=5000000
@@ -60,9 +104,6 @@ else
    log "INFO: memory threshold set to: $FREE_MIN_MEMORY KB and redis RSS ratio default value: $THRESHOLD_REDIS_RSS"
 fi
 
-
-declare -i RESULT
-
 REDIS_UP=`redis-cli -p 22122 ping | grep -c PONG`
 if [[ ${REDIS_UP} -ne 1 ]]; then
     ((RESULT++))
@@ -72,82 +113,75 @@ fi
 
 # Determine the available memory
 FREE_MEMORY=`cat /proc/meminfo | sed -n 2p | awk -F ':        ' '{print $2}' | awk -F ' kB' '{print $1}'`
-log "OK: Free memory in MB:  $(($FREE_MEMORY/1000)) "
-
+log "OK: Free memory in MB:  $(($FREE_MEMORY/1024)) "
 # Check if available < 5GB
 if [[ ${FREE_MEMORY} -le ${FREE_MIN_MEMORY} ]]; then
 
      # Determine the Redis RSS fragmentation ratio
      REDIS_RSS_FRAG=`redis-cli -p 22122 info | grep mem_fragmentation_ratio | awk -F ':' '{printf "%.2f\n",$2}'`
-     log "OK: Redis RSS fragmentation: $REDIS_RSS_FLAG"
+     log "OK: Redis RSS fragmentation: $REDIS_RSS_FRAG"
 
      # check if fragmentation is above threshold.
-     if (( $(echo "scale=2; $REDIS_RSS_FRAG > $THRESHOLD_REDIS_RSS;" | bc -l) )); then
-          log "OK: bgrewrite AOF starting"
-          redis-cli -p 22122 BGREWRITEAOF
-          SLEEPING=2
-          log "OK: sleeping initial $SLEEPING post bgrewriteaof"
-          sleep $SLEEPING
+     # note the >, this is because we compare strings - bash does not support floating numbers.
+      if (( $(echo "scale=2; $REDIS_RSS_FRAG > $THRESHOLD_REDIS_RSS;" | bc -l) )); then
+         log "OK: Redis BGREWRITEAOF starting"
+         REWRITEAOF=`redis-cli -p 22122 BGREWRITEAOF | grep ERR | wc -l`
+
+         # check if BGREWRITEAOF can be competed successfully; otherwise fall back to synchronous SAVE.
+         if (( $REWRITEAOF != 0)); then
+            log "INFO: Redis BGREWRITEAOF failed - falling back to synchronous SAVE"
+            log "OK: Starting Redis SAVE - Note: client is stalled during that process"
+            redis-cli -p 22122 save
+
+            log "OK: sleeping for 10 seconds post Redis SAVE"
+            sleep 10            
+            restart_redis
+
+            # check if BGREWRITEAOF can be completed, after restarting Redis.
+	    # eventually want to have an AOF file stored. According to Redis documantation,
+  	    # if both AOF and RDB have been saved, AOF is preferred when starting Redis.
+	    if [[ ${REDIS_UP} -ne 1 ]]; then
+		((RESULT++))
+         	log "INFO: REDIS is not running"
+		quit $RESULT
+	    fi
+
+            if [[ $REWRITEAOF -ne 0]]; then
+                log "ERROR: Redis BGREWRITEAOF failed again - post restarting Redis"
+                ((RESULT++))
+                quit $RESULT
+            fi
+         fi
+
+         SLEEPING=2
+         log "OK: sleeping initial $SLEEPING seconds post bgrewriteaof"
+         sleep $SLEEPING
 
           # If bgrewriteaof is still running, we iterate inside a loop that waits for bg_rewrite_aof to finish.
           # Exponential backoff adds 5 seconds to the sleeping time until the value aof_rewrite_in_progress is zero.
           # If the sleep takes too long (1800 seconds = 30 min), the process quits.  
           REDIS_AOF_REWRITE_IN_PROGRESS=`redis-cli -p 22122 INFO | grep aof_rewrite_in_progress | awk -F ':' '{printf "%d\n",$2}'`
           while [[  ${REDIS_AOF_REWRITE_IN_PROGRESS} -gt 0 ]]; do
-             sleep $SLEEPING
-             log "OK: sleeping $SLEEPING because BGREWRITEAOF is pending"
-             REDIS_AOF_REWRITE_IN_PROGRESS=`redis-cli -p 22122 INFO | grep aof_rewrite_in_progress | awk -F ':' '{printf "%d\n",$2}'`
-             let SLEEPING=2*SLEEPING
-             if [[ ${SLEEPING} -ge 1800 ]]; then
-                log "ERROR: Redis BGREWRITEAOF takes more than 1800 seconds"
-                ((RESULT++))
-                quit $RESULT
-             fi
-          done
-
-          pid=`ps -ef | grep  'redis-server' | awk ' {print $2}'`
-
- 	  # check number of Redis jobs
-          RUNNING_REDIS=`ps -ef | grep  'redis-server' | grep 22122 | awk ' {print $2}' | wc -l`
-          if [[ ${RUNNING_REDIS} -eq 1 ]]; then      
-                  log "OK: killing redis"
-                  kill -9 $pid
-        	  # check if Redis is still running after killing it
-        	  REDIS_KILLED=`ps aux | grep redis-server | grep 22122 | wc -l`
-        	  if [[ ${REDIS_KILLED} -eq 0 ]]; then
-        	     log "OK: redis killed - sleeping 1 second"
-        	     sleep 2
-        	     log "OK: relaunching redis - sleeping 10 seconds"
-        	     redis-server --port 22122 &
-        	     sleep 10      
-
-        	     # check if Redis running after relauncing it"
-        	     REDIS_RESTARTED=`ps aux | grep redis-server | grep 22122 | wc -l`
-        	     if [[ ${REDIS_RESTARTED} -eq 1 ]]; then
-        	        log "OK: redis launched - sleeping 20 seconds"
-        	        log "==================================================="
-        	        sleep 20
-        	     else
-        	         log "ERROR: redis could not be relaunched"
-        	          ((RESULT++))
-        	     fi
-        	 else
-        	     log "ERROR: redis could not be killed"
-        	     log "ERROR: process running: `ps aux | grep redis-server | grep 22122`"
-        	     ((RESULT++))
-        	 fi
-          else
-        	 ((RESULT++))
- 		 log "ERROR: $RUNNING_REDIS redis-servers running. Exiting ..."
-	  fi
+            sleep $SLEEPING
+            log "OK: sleeping $SLEEPING because BGREWRITEAOF is pending"
+            REDIS_AOF_REWRITE_IN_PROGRESS=`redis-cli -p 22122 INFO | grep aof_rewrite_in_progress | awk -F ':' '{printf "%d\n",$2}'`
+            let SLEEPING=2*SLEEPING
+            if [[ ${SLEEPING} -ge 1800 ]]; then
+               log "ERROR: Redis BGREWRITEAOF takes more than 1800 seconds"
+               ((RESULT++))
+               quit $RESULT
+            fi
+         done
+         restart_redis
+         log "==================================================="
      else
        log "INFO: Redis RSS fragmentation is $REDIS_RSS_RAM < $THRESHOLD_REDIS_RSS . Exiting..."
      fi
 else
-    if [[ ${FREE_MIN_MEMORY} -le 1000 ]]; then
+    if [[ ${FREE_MIN_MEMORY} -le 1024 ]]; then
        log "INFO: Available memory is $FREE_MEMORY KB more than $FREE_MIN_MEMORY KB. Exiting..."
     else
-       log "INFO: Available memory is $(($FREE_MEMORY/1000)) MB more than $(($FREE_MIN_MEMORY/1000)) MB. Exiting..."
+       log "INFO: Available memory is $(($FREE_MEMORY/1024)) MB more than $(($FREE_MIN_MEMORY/1024)) MB. Exiting..."
     fi
 fi
 exit $RESULT


### PR DESCRIPTION
Updated the script to add bigger sleep time when waiting for background AOF rewrite. Effectively, it checks if the flushing to disk has finished and adds 5 seconds to the previous time. The process will quit if background AOF takes more than 30 minutes.