### PR TITLE
Fix the missing units place in seconds of the log

### DIFF
--- a/src/dyn_log.c
+++ b/src/dyn_log.c
@@ -147,7 +147,7 @@ _log(const char *file, int line, int panic, const char *fmt, ...)
     strftime(buffer, 80, "%Y-%m-%d %H:%M:%S", localtime(&curTime.tv_sec));
 
     len += dn_scnprintf(buf + len, size - len, "[%.*s.%03d] %s:%d ",
-                        strlen(buffer) - 1, buffer, (int64_t)curTime.tv_usec / 1000,
+                        strlen(buffer), buffer, (int64_t)curTime.tv_usec / 1000,
                         file, line);
 
     va_start(args, fmt);


### PR DESCRIPTION
before the fix:

[2015-12-03 23:53:4.360] core_dump_conn_stats:296 PEER_SERVER: Average read time spent 1.33 49165278

After the fix:

[2015-12-03 14:56:28.531] stats_listen:1261 m 4 listening on '0.0.0.0:22222'