### PR TITLE
rspmgr_is_quorum_achieved: it's quorum when there's only one quorum node

### DIFF
--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -666,6 +666,7 @@ msg_empty(struct msg *msg)
 uint32_t
 msg_payload_crc32(struct msg *msg)
 {
+    ASSERT(msg != NULL);
     // take a continous buffer crc
     uint32_t crc = 0;
     struct mbuf *mbuf;

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -16,8 +16,10 @@ init_response_mgr(struct response_mgr *rspmgr, struct msg *msg, bool is_read,
 }
 
 static bool
-rspmgr_is_quourm_achieved(struct response_mgr *rspmgr)
+rspmgr_is_quorum_achieved(struct response_mgr *rspmgr)
 {
+    if (rspmgr->good_responses == rspmgr->quorum_responses == 1)
+        return true;
     if (rspmgr->good_responses < rspmgr->quorum_responses)
         return false;
 
@@ -58,7 +60,7 @@ rspmgr_check_is_done(struct response_mgr *rspmgr)
     // do the required calculation and tell if we are done here
     if (rspmgr->good_responses >= rspmgr->quorum_responses) {
         // We received enough good responses but do their checksum match?
-        if (rspmgr_is_quourm_achieved(rspmgr)) {
+        if (rspmgr_is_quorum_achieved(rspmgr)) {
             log_info("req %lu quorum achieved", rspmgr->msg->id);
             rspmgr->done = true;
         } else if (pending_responses) {


### PR DESCRIPTION
While here, add a NULL check to msg_payload_crc32.

I'm afraid my quorum assertion might be wrong here, as `rspmgr_is_quorum_achieved` seems to compare three messages — does this mean a quorum is hardcoded to 3?

Stack trace from the crash, does not reproduce when compiled with gcc 4.9.3 and `-O0`, nixpkgs use `-O2` by default iirc:

```
(gdb) bt
#0  msg_payload_crc32 (msg=0x0) at dyn_message.c:678
#1  0x0000000000419995 in rspmgr_is_quourm_achieved (rspmgr=0x21f3630) at dyn_response_mgr.c:26
#2  rspmgr_check_is_done (rspmgr=rspmgr@entry=0x21f3630) at dyn_response_mgr.c:61
#3  0x00000000004183fb in msg_quorum_rsp_handler (req=0x21f34a0, rsp=<optimized out>) at dyn_request.c:1082
#4  0x000000000040f4a6 in msg_handle_response (rsp=0x21f7930, req=0x21f34a0) at dyn_message.h:335
#5  client_handle_response (conn=0x21e09e0, reqid=1, rsp=0x21f7930) at dyn_client.c:285
#6  0x0000000000417f22 in msg_parsed (msg=0x21f7930, conn=0x21f7830, ctx=0x21d8030) at dyn_message.c:709
#7  msg_parse (msg=0x21f7930, conn=0x21f7830, ctx=0x21d8030) at dyn_message.c:876
#8  msg_recv_chain (msg=0x21f7930, conn=0x21f7830, ctx=0x21d8030) at dyn_message.c:1014
#9  msg_recv (ctx=0x21d8030, conn=0x21f7830) at dyn_message.c:1047
#10 0x000000000040dffc in core_recv (conn=0x21f7830, ctx=0x21d8030) at dyn_core.c:253
#11 core_core (arg=0x21f7830, events=255) at dyn_core.c:413
#12 0x000000000042dcee in event_wait (evb=0x21ea5a0, timeout=499) at dyn_epoll.c:278
#13 0x000000000040e8ac in core_loop (ctx=ctx@entry=0x21d8030) at dyn_core.c:525
#14 0x000000000040cd48 in dn_run (nci=0x7fff9bf4e9d0) at dynomite.c:597
#15 main (argc=<optimized out>, argv=0x7fff9bf4edc8) at dynomite.c:655

(gdb) p (*rspmgr)
$2 = {is_read = true, done = false, responses = {0x21f7930, 0x0, 0x0}, good_responses = 1 '\001', max_responses = 1 '\001', quorum_responses = 1 '\001', 
  error_responses = 0 '\000', err_rsp = 0x0, conn = 0x21e09e0, msg = 0x21f34a0}
(gdb) p (*rspmgr->responses[0])
$4 = {c_tqe = {tqe_next = 0xfbad240c, tqe_prev = 0x0}, s_tqe = {tqe_next = 0x0, tqe_prev = 0x0}, m_tqe = {tqe_next = 0x0, tqe_prev = 0x0}, id = 2, peer = 0x0, 
  owner = 0x21f7830, stime_in_microsec = 0, remote_region_send_time = 0, awaiting_rsps = 0 '\000', selected_rsp = 0x0, tmo_rbe = {left = 0x0, right = 0x0, 
    parent = 0x0, key = 0, data = 0x0, color = 255 '\377'}, mhdr = {stqh_first = 0x21fbae0, stqh_last = 0x21fbae8}, mlen = 5, state = 0, pos = 0x21f7b15 "", 
  token = 0x0, parser = 0x42c8b0 <redis_parse_rsp>, result = MSG_PARSE_OK, pre_splitcopy = 0x42d410 <redis_pre_splitcopy>, 
  post_splitcopy = 0x42d4a0 <redis_post_splitcopy>, pre_coalesce = 0x42d510 <redis_pre_coalesce>, post_coalesce = 0x42d610 <redis_post_coalesce>, 
  type = MSG_RSP_REDIS_BULK, key_start = 0x0, key_end = 0x0, vlen = 0, end = 0x0, narg_start = 0x0, narg_end = 0x0, narg = 0, rnarg = 0, rlen = 0, integer = 0, 
  frag_owner = 0x0, nfrag = 0, frag_id = 0, err = 0, error = 0, ferror = 0, request = 0, quit = 0, noreply = 0, done = 0, fdone = 0, first_fragment = 0, 
  last_fragment = 0, swallow = 0, rsp_sent = 0, data_store = 0, dmsg = 0x0, dyn_state = 0, dyn_error = UNKNOWN_ERROR, msg_type = 0 '\000', is_read = 1, 
  rsp_handler = 0x4169a0 <msg_cant_handle_response>, consistency = DC_ONE, parent_id = 0, rspmgr = {is_read = false, done = false, responses = {0x0, 0x0, 0x0}, 
    good_responses = 0 '\000', max_responses = 0 '\000', quorum_responses = 0 '\000', error_responses = 0 '\000', err_rsp = 0x0, conn = 0x0, msg = 0x0}}
```

`responses[0]` also mentions `consistency = DC_ONE` which is strange.

Meant to resolve #221.

After applying this the crash doesn't appear however I didn't run any multi-node cluster tests yet (is there a default harness I can use?)