### PR TITLE
use git tags in the binary version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,12 +1,10 @@
 # Define the package version numbers and the bug reporting address
-m4_define([DN_MAJOR], 0)
-m4_define([DN_MINOR], 5)
-m4_define([DN_PATCH], 6)
 m4_define([DN_BUGS], [dynomite@netflix.com])
+m4_define([DN_VERSION_STRING], m4_esyscmd_s([git describe --dirty --always --tags]))
 
 # Initialize autoconf
 AC_PREREQ([2.63])
-AC_INIT([dynomite], [DN_MAJOR.DN_MINOR.DN_PATCH], [DN_BUGS])
+AC_INIT([dynomite], [DN_VERSION_STRING], [DN_BUGS])
 AC_CONFIG_SRCDIR([src/dynomite.c])
 AC_CONFIG_AUX_DIR([config])
 AC_CONFIG_HEADERS([config.h:config.h.in])
@@ -14,12 +12,6 @@ AC_CONFIG_MACRO_DIR([m4])
 
 # Initialize automake
 AM_INIT_AUTOMAKE([1.11 foreign])
-
-# Define macro variables for the package version numbers
-AC_DEFINE(DN_VERSION_MAJOR, DN_MAJOR, [Define the major version number])
-AC_DEFINE(DN_VERSION_MINOR, DN_MINOR, [Define the minor version number])
-AC_DEFINE(DN_VERSION_PATCH, DN_PATCH, [Define the patch version number])
-AC_DEFINE(DN_VERSION_STRING, "DN_MAJOR.DN_MINOR.DN_PATCH", [Define the version string])
 
 # Checks for language
 AC_LANG([C])

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1358,7 +1358,7 @@ stats_create(uint16_t stats_port, char *stats_ip, int stats_interval,
     string_set_raw(&st->source, source);
 
     string_set_text(&st->version_str, "version");
-    string_set_text(&st->version, DN_VERSION_STRING);
+    string_set_text(&st->version, VERSION);
 
     string_set_text(&st->uptime_str, "uptime");
     string_set_text(&st->timestamp_str, "timestamp");

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -197,10 +197,10 @@ dn_print_run(struct instance *nci)
 
     status = uname(&name);
     if (status < 0) {
-        loga("dynomite-%s started on pid %d", DN_VERSION_STRING, nci->pid);
+        loga("dynomite-%s started on pid %d", VERSION, nci->pid);
     } else {
         loga("dynomite-%s built for %s %s %s started on pid %d",
-             DN_VERSION_STRING, name.sysname, name.release, name.machine,
+             VERSION, name.sysname, name.release, name.machine,
              nci->pid);
     }
 
@@ -627,7 +627,7 @@ main(int argc, char **argv)
     }
 
     if (show_version) {
-        log_stderr("This is dynomite-%s" CRLF, DN_VERSION_STRING);
+        log_stderr("This is dynomite-%s" CRLF, VERSION);
         if (show_help) {
             dn_show_usage();
         }


### PR DESCRIPTION
No more double work of creating git tags and manually editing configure.ac