### PR TITLE
fix URL to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The ultimate goal with Dynomite is to be able to implement high availability and
 
 The stable version of Dynomite is the [master]( https://github.com/Netflix/dynomite/tree/master ) branch. 
 
-For questions or contributions, please consider reading [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md).
+For questions or contributions, please consider reading [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Build
 


### PR DESCRIPTION
I noticed that I forgot to do a `grep -r CONTRIBUTING` before my earlier PR to find all references to the `CONTRIBUTING.md` file.

So, this is a micro-PR to fix the URL from `README.md` to `CONTRIBUTING.md`.