### PR TITLE
Standardize binary names, increment version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE
+.idea
+
 # Compiled Object files
 *.lo
 *.o
@@ -37,6 +40,8 @@ TODO
 core*
 nutcracker
 dynomite
+dynomite-test
+dyno-hash-tool
 
 # extracted yaml
 !/contrib/yaml-0.1.4.tar.gz

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,4 +6,4 @@ SUBDIRS = contrib src
 
 dist_man_MANS = man/dynomite.8
 
-EXTRA_DIST = README.md NOTICE LICENSE ChangeLog conf scripts notes
+EXTRA_DIST = README.md NOTICE LICENSE conf scripts notes

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ m4_ifndef([m4_esyscmd_s], [m4_define([m4_esyscmd_s], [m4_chomp_all(m4_esyscmd([$
 # Define the package version numbers and the bug reporting address
 m4_define([DN_MAJOR], 0)
 m4_define([DN_MINOR], 5)
-m4_define([DN_PATCH], 6)
+m4_define([DN_PATCH], 7)
 m4_define([DN_BUGS], [dynomite@netflix.com])
 m4_define([DN_VERSION_STRING], m4_esyscmd_s([git describe --dirty --always --tags]))
 

--- a/configure.ac
+++ b/configure.ac
@@ -2,10 +2,7 @@
 m4_ifndef([m4_esyscmd_s], [m4_define([m4_chomp_all], [m4_format([[%.*s]], m4_bregexp(m4_translit([[$1]], [/], [/ ]), [/*$]), [$1])])])
 m4_ifndef([m4_esyscmd_s], [m4_define([m4_esyscmd_s], [m4_chomp_all(m4_esyscmd([$1]))])])
 
-# Define the package version numbers and the bug reporting address
-m4_define([DN_MAJOR], 0)
-m4_define([DN_MINOR], 5)
-m4_define([DN_PATCH], 7)
+# Define the bug reporting address and package version
 m4_define([DN_BUGS], [dynomite@netflix.com])
 m4_define([DN_VERSION_STRING], m4_esyscmd_s([git describe --dirty --always --tags]))
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,7 +29,7 @@ endif
 
 SUBDIRS = hashkit proto event seedsprovider tools
 
-sbin_PROGRAMS = dynomite test
+sbin_PROGRAMS = dynomite dynomite-test
 
 dynomite_SOURCES =			                          \
         dyn_cbuf.h                                                \
@@ -41,12 +41,12 @@ dynomite_SOURCES =			                          \
         dyn_dnode_msg.c dyn_dnode_msg.h                           \
         dyn_dnode_peer.c  dyn_dnode_peer.h                        \
         dyn_dnode_request.c                                       \
-        dyn_dnode_proxy.c dyn_dnode_proxy.h                     \
+        dyn_dnode_proxy.c dyn_dnode_proxy.h                       \
         dyn_histogram.c dyn_histogram.h                           \
-        dyn_server.c dyn_server.h		                          \
-        dyn_proxy.c dyn_proxy.h		                              \
-        dyn_message.c dyn_message.h	                              \
-        dyn_request.c dyn_response_mgr.c	                      \
+        dyn_server.c dyn_server.h		                  \
+        dyn_proxy.c dyn_proxy.h		                          \
+        dyn_message.c dyn_message.h	                          \
+        dyn_request.c dyn_response_mgr.c	                  \
         dyn_response.c			                          \
         dyn_ring_queue.h dyn_ring_queue.c                         \
         dyn_mbuf.c dyn_mbuf.h		                          \
@@ -61,7 +61,7 @@ dynomite_SOURCES =			                          \
         dyn_string.c dyn_string.h		                  \
         dyn_array.c dyn_array.h		                          \
         dyn_util.c dyn_util.h		                          \
-        dyn_queue.h			                                      \
+        dyn_queue.h			                          \
         dyn_gossip.c dyn_gossip.h                                 \
         dyn_dict.c dyn_dict.h                                     \
         dyn_asciilogo.h                                           \
@@ -75,7 +75,7 @@ dynomite_LDADD += $(top_builddir)/contrib/yaml-0.1.4/src/.libs/libyaml.a
 
 
 
-test_SOURCES =                                                \
+dynomite_test_SOURCES =                                           \
         dyn_cbuf.h                                                \
         dyn_crypto.c dyn_crypto.h                                 \
         dyn_core.c dyn_core.h                                     \
@@ -85,12 +85,12 @@ test_SOURCES =                                                \
         dyn_dnode_msg.c dyn_dnode_msg.h                           \
         dyn_dnode_peer.c  dyn_dnode_peer.h                        \
         dyn_dnode_request.c                                       \
-        dyn_dnode_proxy.c dyn_dnode_proxy.h                     \
+        dyn_dnode_proxy.c dyn_dnode_proxy.h                       \
         dyn_histogram.c dyn_histogram.h                           \
         dyn_server.c dyn_server.h                                 \
         dyn_proxy.c dyn_proxy.h                                   \
         dyn_message.c dyn_message.h                               \
-        dyn_request.c dyn_response_mgr.c	                      \
+        dyn_request.c dyn_response_mgr.c	                  \
         dyn_response.c                                            \
         dyn_ring_queue.h dyn_ring_queue.c                         \
         dyn_mbuf.c dyn_mbuf.h                                     \
@@ -112,19 +112,18 @@ test_SOURCES =                                                \
         dyn_test.c
 
 
-test_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
-test_LDADD += $(top_builddir)/src/proto/libproto.a
-test_LDADD += $(top_builddir)/src/event/libevent.a
-test_LDADD +=  $(top_builddir)/src/seedsprovider/libseedsprovider.a -lresolv
-test_LDADD += $(top_builddir)/contrib/yaml-0.1.4/src/.libs/libyaml.a
+dynomite_test_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
+dynomite_test_LDADD += $(top_builddir)/src/proto/libproto.a
+dynomite_test_LDADD += $(top_builddir)/src/event/libevent.a
+dynomite_test_LDADD +=  $(top_builddir)/src/seedsprovider/libseedsprovider.a -lresolv
+dynomite_test_LDADD += $(top_builddir)/contrib/yaml-0.1.4/src/.libs/libyaml.a
 
 if OS_BSD
 dynomite_SOURCES +=                                               \
 	$(top_builddir)/contrib/fmemopen.c                        \
 	$(top_builddir)/contrib/fmemopen.h
-test_SOURCES +=                                                   \
+dynomite_test_SOURCES +=                                          \
 	$(top_builddir)/contrib/fmemopen.c                        \
 	$(top_builddir)/contrib/fmemopen.h
 endif
-
 

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -25,7 +25,11 @@ endif
 
 bin_PROGRAMS = dynomite-hash-tool
 
-dyno_hash_tool_SOURCES =                                                \
-        dyn_hash_tool.c ../dyn_token.c ../dyn_log.c ../dyn_util.c ../dyn_array.c
+dynomite_hash_tool_SOURCES = \
+        dyn_hash_tool.c \
+	../dyn_token.c \
+	../dyn_log.c \
+	../dyn_util.c \
+	../dyn_array.c
 
-dyno_hash_tool_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
+dynomite_hash_tool_LDADD = $(top_builddir)/src/hashkit/libhashkit.a

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -23,7 +23,7 @@ if OS_SOLARIS
 AM_LDFLAGS += -lnsl -lsocket
 endif
 
-bin_PROGRAMS = dyno-hash-tool
+bin_PROGRAMS = dynomite-hash-tool
 
 dyno_hash_tool_SOURCES =                                                \
         dyn_hash_tool.c ../dyn_token.c ../dyn_log.c ../dyn_util.c ../dyn_array.c

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -23,9 +23,9 @@ if OS_SOLARIS
 AM_LDFLAGS += -lnsl -lsocket
 endif
 
-sbin_PROGRAMS = dyn_hash_tool
+bin_PROGRAMS = dyno-hash-tool
 
-dyn_hash_tool_SOURCES =                                                \
+dyno_hash_tool_SOURCES =                                                \
         dyn_hash_tool.c ../dyn_token.c ../dyn_log.c ../dyn_util.c ../dyn_array.c
 
-dyn_hash_tool_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
+dyno_hash_tool_LDADD = $(top_builddir)/src/hashkit/libhashkit.a

--- a/src/tools/dyn_hash_tool.c
+++ b/src/tools/dyn_hash_tool.c
@@ -17,15 +17,20 @@ char * token_filename = NULL;
 static void
 print_usage()
 {
-    printf("Usage:\n\n\thash_tool -h -i <filename> -o <output filename>\n");
-    printf("                -i <filename> or '-' for stdin(default)\n");
-    printf("                -o <filename> or '-' for stdout(default)\n");
-    printf("                -k also output keys in the output file\n\n");
-    printf("\tReads a key from the input file and outputs the token to the output"\
-           " file.\n\tUses stdin and stdout by default for input and output.\n"\
-           "\tExpects one key per line in the input and outputs one token per line in the output\n"\
-           "\tif -k is specified, it will output keys and tokens alternately. The Keys are prepended\n"\
-           "\twith 'KEY:'\n\n\tWARN: CURRENTLY IT USES MURMUR HASH ONLY\n\n");
+    printf("Usage: dyno-hash-tool [-hk] -i <filename> -o <output filename>\n");
+    printf("Read a key from input, hash key to create token, then output token to output.\n");
+    printf("  -i <filename> or '-' for stdin (default)\n");
+    printf("  -o <filename> or '-' for stdout (default)\n\n");
+    printf("Options:\n");
+    printf("  -h, --help             : this help\n");
+    printf("  -k                     : include key in output\n\n");
+    printf("Read a key from the input file and output the token to the output file. Default\n");
+    printf("input and output are stdin and stdout, respectively. Input file must list one\n");
+    printf("key per line. Output file will list one token per line that matches the line\n");
+    printf("number of the input key.\n\n"); 
+    printf("If the '-k' option is specified, then keys and tokens will output on alternating\n");
+    printf("rows. Each key has 'KEY:' appended to the beginning of the line\n\n");
+    printf("WARNING: dyno-hash-tool ONLY SUPPORTS MURMUR HASH (CURRENTLY)\n\n");
 }
 
 static int 


### PR DESCRIPTION
I noticed that the current binary names do not have a consistent pattern (i.e. `dynomite`, `test`, `dyno_hash_tool`). This pull request creates a standard naming convention of `dynomite-` for server-related binaries in the `sbin` directory, and `dyno-` for client-related binaries in the `bin` directory.

With the new names, a user can type `dyno` + `tab tab` and view all Dynomite related commands.

- Increment version in `configure.am` (was 0.5.6, now 0.5.7)
- Rename binaries to naming standard/convention
    - `dynomite-` = server-related binaries
    - `dyno-` = client-related binaries
    - Use '-' not '_' as easier/faster for admins to type (i.e. better UX). SysAdmins type commands repeatedly and dash is a single key whereas underscore is two keys.
- Rename binary `test` to `dynomite-test`
- Rename binary `dyn_hash_tool` to `dyno-hash-tool`
- Move `dyno-hash-tool` to `bin` directory
- Update help message for `dyno-hash-tool`