### PR TITLE
Fix crash in gossip

### DIFF
--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -159,6 +159,7 @@ dnode_peer_add_local(struct server_pool *pool, struct server *peer)
     peer->next_retry = 0LL;
     peer->failure_count = 0;
     peer->is_seed = 1;
+    peer->processed = 0;
     string_copy(&peer->dc, pool->dc.data, pool->dc.len);
     peer->owner = pool;
 

--- a/src/dyn_gossip.c
+++ b/src/dyn_gossip.c
@@ -915,7 +915,7 @@ gossip_pool_each_init(void *elem, void *data)
 
             struct gossip_dc *g_dc = dictFetchValue(gn_pool.dict_dc, rack->dc);
             if (dictFind(g_dc->dict_rack, rack->name) == NULL) {
-                log_debug(LOG_VERB, "What?? No rack in Dict for rack         : '%.*s'", g_dc->name);
+                log_debug(LOG_VERB, "What?? No rack in Dict for rack         : '%.*s'", *(rack->name));
                 struct gossip_rack *g_rack = array_push(&g_dc->racks);
                 gossip_rack_init(g_rack, rack->dc, rack->name);
                 dictAdd(g_dc->dict_rack, &g_rack->name, g_rack);


### PR DESCRIPTION
there was an uninitialized variable which sometimes made the processed variable as 1 and hence would skip initialization.