### PR TITLE
Remove round robin replication to remote regions

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -787,8 +787,9 @@ req_forward_remote_dc(struct context *ctx, struct conn *c_conn, struct msg *msg,
     if (rack_cnt == 0)
         return;
 
-    uint32_t ran_index = (uint32_t)rand() % rack_cnt;
-    struct rack *rack = array_get(&dc->racks, ran_index);
+    struct rack *rack = dc->preselected_rack_for_replication;
+    if (rack == NULL)
+        rack = array_get(&dc->racks, 0);
 
     struct msg *rack_msg = msg_get(c_conn, msg->request, msg->data_store, __FUNCTION__);
     if (rack_msg == NULL) {

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -192,6 +192,7 @@ core_ctx_create(struct instance *nci)
 	CBUF_Init(C2S_OutQ);
 
 	gossip_pool_init(ctx);
+    preselect_remote_rack_for_replication(ctx);
 
 	log_debug(LOG_VVERB, "created ctx %p id %"PRIu32"", ctx, ctx->id);
 

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -215,6 +215,7 @@ struct rack {
 struct datacenter {
 	struct string      *name;            /* datacenter name */
 	struct array       racks;           /* list of racks in a datacenter */
+    struct rack        *preselected_rack_for_replication;
 	dict               *dict_rack;
 };
 

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -1941,14 +1941,23 @@ preselect_remote_rack_for_replication_each(void *elem, void *data)
 
     for(dc_index = 0; dc_index < dc_cnt; dc_index++) {
         struct datacenter *dc = array_get(&sp->datacenters, dc_index);
+        dc->preselected_rack_for_replication = NULL;
+
+        // Nothing to do for local DC, continue;
         if (string_compare(dc->name, &sp->dc) == 0)
             continue;
+
+        // if no racks, keep preselected_rack_for_replication as NULL
+        uint32_t rack_cnt = array_n(&dc->racks);
+        if (rack_cnt == 0)
+            continue;
+
         // if the dc is a remote dc, get the rack at rack_idx
         // use that as preselected rack for replication
-        uint32_t rack_cnt = array_n(&dc->racks);
         uint32_t this_rack_index = my_rack_index % rack_cnt;
-        dc->preselected_rack_for_replication = array_get(&dc->racks, this_rack_index);
-        log_notice("Selected rack %.*s for remote region %.*s",
+        dc->preselected_rack_for_replication = array_get(&dc->racks,
+                                                         this_rack_index);
+        log_notice("Selected rack %.*s for replication to remote region %.*s",
                    dc->preselected_rack_for_replication->name->len,
                    dc->preselected_rack_for_replication->name->data,
                    dc->name->len, dc->name->data);

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -1901,3 +1901,62 @@ init_dnode_peer_conn(struct conn *conn)
     conn->type = CONN_DNODE_PEER_SERVER;
     conn->ops = &dnode_peer_ops;
 }
+
+static int
+rack_name_cmp(const void *t1, const void *t2)
+{
+    const struct rack *s1 = t1, *s2 = t2;
+
+    return string_compare(s1->name, s2->name);
+}
+
+// The idea here is to have a designated rack in each remote region to replicate
+// data to. This is used to replicate writes to remote regions
+static void
+preselect_remote_rack_for_replication_each(void *elem, void *data)
+{
+    struct server_pool *sp = elem;
+    uint32_t dc_cnt = array_n(&sp->datacenters);
+    uint32_t dc_index;
+    uint32_t my_rack_index = 0;
+    for(dc_index = 0; dc_index < dc_cnt; dc_index++) {
+        struct datacenter *dc = array_get(&sp->datacenters, dc_index);
+        // sort the racks.
+        array_sort(&dc->racks, rack_name_cmp);
+        if (string_compare(dc->name, &sp->dc) != 0)
+            continue;
+
+        // if the dc is a local dc, get the rack_idx
+        uint32_t rack_index;
+        uint32_t rack_cnt = array_n(&dc->racks);
+        for(rack_index = 0; rack_index < rack_cnt; rack_index++) {
+            struct rack *rack = array_get(&dc->racks, rack_index);
+            if (string_compare(rack->name, &sp->rack) == 0) {
+                my_rack_index = rack_index;
+                log_notice("my rack index %u", my_rack_index);
+                break;
+            }
+        }
+    }
+
+    for(dc_index = 0; dc_index < dc_cnt; dc_index++) {
+        struct datacenter *dc = array_get(&sp->datacenters, dc_index);
+        if (string_compare(dc->name, &sp->dc) == 0)
+            continue;
+        // if the dc is a remote dc, get the rack at rack_idx
+        // use that as preselected rack for replication
+        uint32_t rack_cnt = array_n(&dc->racks);
+        uint32_t this_rack_index = my_rack_index % rack_cnt;
+        dc->preselected_rack_for_replication = array_get(&dc->racks, this_rack_index);
+        log_notice("Selected rack %.*s for remote region %.*s",
+                   dc->preselected_rack_for_replication->name->len,
+                   dc->preselected_rack_for_replication->name->data,
+                   dc->name->len, dc->name->data);
+    }
+}
+
+void
+preselect_remote_rack_for_replication(struct context *ctx)
+{
+    array_each(&ctx->pool, preselect_remote_rack_for_replication_each, NULL);
+}

--- a/src/dyn_dnode_peer.h
+++ b/src/dyn_dnode_peer.h
@@ -29,4 +29,5 @@ rstatus_t dnode_peer_replace(void *rmsg);
 rstatus_t dnode_peer_handshake_announcing(void *rmsg);
 
 void init_dnode_peer_conn(struct conn *conn);
+void preselect_remote_rack_for_replication(struct context *ctx);
 #endif 

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -881,6 +881,7 @@ dc_init(struct datacenter *dc)
 	dc->dict_rack = dictCreate(&dc_string_dict_type, NULL);
 	dc->name = dn_alloc(sizeof(struct string));
 	string_init(dc->name);
+    dc->preselected_rack_for_replication = NULL;
 
 	status = array_init(&dc->racks, 3, sizeof(struct rack));
 


### PR DESCRIPTION
If you do round robin for every message to remote region, you end up the
messages reaching remote nodes in out of order since some can have extra hops.
Fix it by having a designated remote rack to send messages to.
Every rack in a local region have a designated remote region rack.