### PR TITLE
Add instructions to build Dynomite w/a Docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ To build Dynomite in _debug mode_:
     $ CFLAGS="-ggdb3 -O0" ./configure --enable-debug=full
     $ make
     $ sudo make install
+
+### Build with Docker
+
+Dynomite can be compiled inside of a Docker container. The container provides a clean build environment.
+
+```bash
+git clone https://github.com/Netflix/dynomite.git
+
+cd dynomite
+
+docker run -it --rm -v $PWD:/src dynomitedb/build-dynomite
+```
     
 ## Help
 


### PR DESCRIPTION
The Docker image used to compile Dynomite is now on DockerHub at https://hub.docker.com/r/dynomitedb/build-dynomite/. 

The README.md has been updated to include instructions on how to compile Dynomite using the container.