### PR TITLE
rspmgr_is_quorum_achieved: it's quorum when there's only one quorum node - fixed proger's pull request

### DIFF
--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -666,6 +666,7 @@ msg_empty(struct msg *msg)
 uint32_t
 msg_payload_crc32(struct msg *msg)
 {
+    ASSERT(msg != NULL);
     // take a continous buffer crc
     uint32_t crc = 0;
     struct mbuf *mbuf;

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -16,8 +16,10 @@ init_response_mgr(struct response_mgr *rspmgr, struct msg *msg, bool is_read,
 }
 
 static bool
-rspmgr_is_quourm_achieved(struct response_mgr *rspmgr)
+rspmgr_is_quorum_achieved(struct response_mgr *rspmgr)
 {
+    if (rspmgr->good_responses == rspmgr->quorum_responses == 1)
+        return true;
     if (rspmgr->good_responses < rspmgr->quorum_responses)
         return false;
 
@@ -58,7 +60,7 @@ rspmgr_check_is_done(struct response_mgr *rspmgr)
     // do the required calculation and tell if we are done here
     if (rspmgr->good_responses >= rspmgr->quorum_responses) {
         // We received enough good responses but do their checksum match?
-        if (rspmgr_is_quourm_achieved(rspmgr)) {
+        if (rspmgr_is_quorum_achieved(rspmgr)) {
             log_info("req %lu quorum achieved", rspmgr->msg->id);
             rspmgr->done = true;
         } else if (pending_responses) {

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -18,7 +18,8 @@ init_response_mgr(struct response_mgr *rspmgr, struct msg *msg, bool is_read,
 static bool
 rspmgr_is_quorum_achieved(struct response_mgr *rspmgr)
 {
-    if (rspmgr->good_responses == rspmgr->quorum_responses == 1)
+    if (rspmgr->quorum_responses == 1 &&
+            rspmgr->good_responses == rspmgr->quorum_responses)
         return true;
     if (rspmgr->good_responses < rspmgr->quorum_responses)
         return false;


### PR DESCRIPTION
This pull request is based on https://github.com/Netflix/dynomite/pull/223 and the only change is changed comparison of quorum_responses and good_responses with 1.
