### PR TITLE
Cleanup dyn_conf

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -638,7 +638,7 @@ local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
 
     conn_enqueue_inq(ctx, s_conn, msg);
     req_forward_stats(ctx, s_conn->owner, msg);
-    if(msg->data_store==DATA_REDIS){
+    if(g_data_store == DATA_REDIS){
     	req_redis_stats(ctx, s_conn->owner, msg);
 	}
 
@@ -731,8 +731,7 @@ req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
         if (string_compare(rack->name, &pool->rack) == 0 ) {
             rack_msg = msg;
         } else {
-            rack_msg = msg_get(c_conn, msg->request, msg->data_store,
-                               __FUNCTION__);
+            rack_msg = msg_get(c_conn, msg->request, __FUNCTION__);
             if (rack_msg == NULL) {
                 log_debug(LOG_VERB, "whelp, looks like yer screwed "
                         "now, buddy. no inter-rack messages for "
@@ -790,7 +789,7 @@ req_forward_remote_dc(struct context *ctx, struct conn *c_conn, struct msg *msg,
     if (rack == NULL)
         rack = array_get(&dc->racks, 0);
 
-    struct msg *rack_msg = msg_get(c_conn, msg->request, msg->data_store, __FUNCTION__);
+    struct msg *rack_msg = msg_get(c_conn, msg->request, __FUNCTION__);
     if (rack_msg == NULL) {
         log_debug(LOG_VERB, "whelp, looks like yer screwed now, buddy. no inter-rack messages for you!");
         msg_put(rack_msg);

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -395,7 +395,6 @@ conf_pool_each_transform(void *elem, void *data)
     sp = array_push(server_pool);
     ASSERT(sp != NULL);
 
-    sp->idx = array_idx(server_pool, sp);
     sp->ctx = NULL;
 
     sp->p_conn = NULL;
@@ -466,8 +465,7 @@ conf_pool_each_transform(void *elem, void *data)
 
     set_msgs_per_sec(cp->conn_msg_rate);
 
-    log_debug(LOG_VERB, "transform to pool %"PRIu32" '%.*s'", sp->idx,
-              sp->name.len, sp->name.data);
+    log_debug(LOG_VERB, "transform to pool '%.*s'", sp->name.len, sp->name.data);
 
     return DN_OK;
 }

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -66,7 +66,7 @@ static struct string dist_strings[] = {
 #define CONF_DEFAULT_TIMEOUT                 5000
 #define CONF_DEFAULT_LISTEN_BACKLOG          512
 #define CONF_DEFAULT_CLIENT_CONNECTIONS      0
-#define CONF_DEFAULT_DATASTORE				 0
+#define CONF_DEFAULT_DATASTORE				 DATA_REDIS
 #define CONF_DEFAULT_PRECONNECT              true
 #define CONF_DEFAULT_AUTO_EJECT_HOSTS        true
 #define CONF_DEFAULT_SERVER_RETRY_TIMEOUT    10 * 1000      /* in msec */
@@ -98,6 +98,7 @@ static struct string dist_strings[] = {
 
 #define PEM_KEY_FILE  "conf/dynomite.pem"
 
+data_store_t g_data_store = CONF_DEFAULT_DATASTORE;
 struct command {
     struct string name;
     char          *(*set)(struct conf *cf, struct command *cmd, void *data);
@@ -397,7 +398,7 @@ conf_pool_transform(struct server_pool *sp, struct conf_pool *cp)
     sp->dist_type = cp->distribution;
     sp->hash_tag = cp->hash_tag;
 
-    sp->data_store = cp->data_store;
+    g_data_store = cp->data_store;
     sp->timeout = cp->timeout;
     sp->backlog = cp->backlog;
 
@@ -471,13 +472,13 @@ conf_dump(struct conf *cf)
     log_debug(LOG_VVERB, "  client_connections: %d",
             cp->client_connections);
     const char * temp_log = "unknown";
-    if(cp->data_store == DATA_REDIS){
+    if(g_data_store == DATA_REDIS){
         temp_log = "redis";
     }
-    else if(cp->data_store == DATA_MEMCACHE){
+    else if(g_data_store == DATA_MEMCACHE){
         temp_log = "memcache";
     }
-    log_debug(LOG_VVERB, "  data_store: %d (%s)", cp->data_store, temp_log);
+    log_debug(LOG_VVERB, "  data_store: %d (%s)", g_data_store, temp_log);
     log_debug(LOG_VVERB, "  preconnect: %d", cp->preconnect);
     log_debug(LOG_VVERB, "  auto_eject_hosts: %d", cp->auto_eject_hosts);
     log_debug(LOG_VVERB, "  server_connections: %d",

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -99,7 +99,7 @@ struct conf {
     char          *fname;           /* file name (ref in argv[]) */
     FILE          *fh;              /* file handle */
     struct array  arg;              /* string[] (parsed {key, value} pairs) */
-    struct array  pool;             /* conf_pool[] (parsed pools) */
+    struct conf_pool pool;             /* conf_pool[] (parsed pools) */
     uint32_t      depth;            /* parsed tree depth */
     yaml_parser_t parser;           /* yaml parser */
     yaml_event_t  event;            /* yaml event */
@@ -119,7 +119,7 @@ struct conf {
 rstatus_t conf_server_transform(struct server *datastore,
                                 struct conf_server *conf_datastore);
 // converts conf_pool to server_pool
-rstatus_t conf_pool_each_transform(void *elem, void *data);
+rstatus_t conf_pool_transform(struct server_pool *, struct conf_pool *);
 // converts conf_server to server ... except that this is for peers
 rstatus_t conf_seed_each_transform(void *elem, void *data);
 

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -31,64 +31,9 @@
 #ifndef _DYN_CONF_H_
 #define _DYN_CONF_H_
 
-
-#define CONF_OK             (void *) NULL
-#define CONF_ERROR          (void *) "has an invalid value"
-
-#define CONF_ROOT_DEPTH     1
-#define CONF_MAX_DEPTH      CONF_ROOT_DEPTH + 1
-
-#define CONF_DEFAULT_ARGS       3
-#define CONF_DEFAULT_POOL       8
-#define CONF_DEFAULT_SERVERS    8
-
-#define CONF_UNSET_NUM  -1
-#define CONF_UNSET_PTR  NULL
-#define CONF_UNSET_HASH (hash_type_t) -1
-#define CONF_UNSET_DIST (dist_type_t) -1
-
-#define CONF_DEFAULT_HASH                    HASH_MURMUR
-#define CONF_DEFAULT_DIST                    DIST_VNODE
-#define CONF_DEFAULT_TIMEOUT                 5000
-#define CONF_DEFAULT_LISTEN_BACKLOG          512
-#define CONF_DEFAULT_CLIENT_CONNECTIONS      0
-#define CONF_DEFAULT_DATASTORE				 0
-#define CONF_DEFAULT_PRECONNECT              true
-#define CONF_DEFAULT_AUTO_EJECT_HOSTS        true
-#define CONF_DEFAULT_SERVER_RETRY_TIMEOUT    10 * 1000      /* in msec */
-#define CONF_DEFAULT_SERVER_FAILURE_LIMIT    2
-#define CONF_DEFAULT_SERVER_CONNECTIONS      1
-#define CONF_DEFAULT_KETAMA_PORT             11211
-
-#define CONF_DEFAULT_SEEDS                   5
-#define CONF_DEFAULT_DYN_READ_TIMEOUT        10000
-#define CONF_DEFAULT_DYN_WRITE_TIMEOUT       10000
-#define CONF_DEFAULT_DYN_CONNECTIONS         100
-#define CONF_DEFAULT_VNODE_TOKENS            1
-#define CONF_DEFAULT_GOS_INTERVAL            30000  //in millisec
 #define CONF_DEFAULT_PEERS                   200
-
-#define CONF_DEFAULT_CONN_MSG_RATE           50000   //conn msgs per sec
-
-#define CONF_STR_NONE                        "none"
-#define CONF_STR_DC                          "datacenter"
-#define CONF_STR_RACK                        "rack"
-#define CONF_STR_ALL                         "all"
-
-#define CONF_STR_DC_QUORUM                   "dc_quorum"
-#define CONF_STR_DC_ONE                      "dc_one"
-
 #define CONF_DEFAULT_ENV                     "aws"
-
-#define CONF_DEFAULT_RACK                    "localrack"
-#define CONF_DEFAULT_DC                      "localdc"
-#define CONF_DEFAULT_SECURE_SERVER_OPTION    CONF_STR_NONE
-
-#define CONF_DEFAULT_SEED_PROVIDER           "simple_provider"
-
-#define PEM_KEY_FILE  "conf/dynomite.pem"
-
-
+#define CONF_DEFAULT_CONN_MSG_RATE           50000   //conn msgs per sec
 struct conf_listen {
     struct string   pname;   /* listen: as "name:port" */
     struct string   name;    /* name */
@@ -117,7 +62,7 @@ struct conf_pool {
     hash_type_t        hash;                  /* hash: */
     struct string      hash_tag;              /* hash_tag: */
     dist_type_t        distribution;          /* distribution: */
-    int                timeout;               /* timeout: */
+    msec_t             timeout;               /* timeout: */
     int                backlog;               /* backlog: */
     int                client_connections;    /* client_connections: */
     int                data_store;            /* data_store: */
@@ -146,7 +91,7 @@ struct conf_pool {
     struct string      pem_key_file;
     struct string      dc;                    /* this node's dc */
     struct string      env;                   /* aws, google, network, ... */
-    int                conn_msg_rate;         /* conn msg per sec */
+    uint32_t           conn_msg_rate;         /* conn msg per sec */
 };
 
 
@@ -168,28 +113,10 @@ struct conf {
     unsigned      valid:1;          /* valid? */
 };
 
-struct command {
-    struct string name;
-    char          *(*set)(struct conf *cf, struct command *cmd, void *data);
-    int           offset;
-};
-
 #define null_command { null_string, NULL, 0 }
-
-char *conf_set_string(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_listen(struct conf *cf, struct command *cmd, void *conf);
-char *conf_add_server(struct conf *cf, struct command *cmd, void *conf);
-char *conf_add_dyn_server(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_num(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_bool(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_hash(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_distribution(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_hashtag(struct conf *cf, struct command *cmd, void *conf);
-char *conf_set_tokens(struct conf *cf, struct command *cmd, void *conf);
 
 rstatus_t conf_server_each_transform(void *elem, void *data);
 rstatus_t conf_pool_each_transform(void *elem, void *data);
-
 rstatus_t conf_seed_each_transform(void *elem, void *data);
 
 struct conf *conf_create(char *filename);

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -115,8 +115,11 @@ struct conf {
 
 #define null_command { null_string, NULL, 0 }
 
+// converts conf_server to server
 rstatus_t conf_server_each_transform(void *elem, void *data);
+// converts conf_pool to server_pool
 rstatus_t conf_pool_each_transform(void *elem, void *data);
+// converts conf_server to server ... except that this is for peers
 rstatus_t conf_seed_each_transform(void *elem, void *data);
 
 struct conf *conf_create(char *filename);

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -71,7 +71,7 @@ struct conf_pool {
     int                server_connections;    /* server_connections: */
     msec_t             server_retry_timeout_ms;  /* server_retry_timeout: in msec */
     int                server_failure_limit;  /* server_failure_limit: */
-    struct conf_server *conf_datastore;
+    struct conf_server *conf_datastore;       /* This is the underlying datastore */
     unsigned           valid:1;               /* valid? */
     struct conf_listen dyn_listen;            /* dyn_listen  */
     int                dyn_read_timeout;      /* inter dyn nodes' read timeout in ms */

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -71,7 +71,7 @@ struct conf_pool {
     int                server_connections;    /* server_connections: */
     msec_t             server_retry_timeout_ms;  /* server_retry_timeout: in msec */
     int                server_failure_limit;  /* server_failure_limit: */
-    struct array       server;                /* servers: conf_server array */
+    struct conf_server *conf_datastore;
     unsigned           valid:1;               /* valid? */
     struct conf_listen dyn_listen;            /* dyn_listen  */
     int                dyn_read_timeout;      /* inter dyn nodes' read timeout in ms */
@@ -116,7 +116,8 @@ struct conf {
 #define null_command { null_string, NULL, 0 }
 
 // converts conf_server to server
-rstatus_t conf_server_each_transform(void *elem, void *data);
+rstatus_t conf_server_transform(struct server *datastore,
+                                struct conf_server *conf_datastore);
 // converts conf_pool to server_pool
 rstatus_t conf_pool_each_transform(void *elem, void *data);
 // converts conf_server to server ... except that this is for peers

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -190,7 +190,6 @@ _conn_get(void)
     conn->eof = 0;
     conn->done = 0;
     conn->waiting_to_unref = 0;
-    conn->data_store = DATA_REDIS;
 
     /* for dynomite */
     conn->dyn_mode = 0;
@@ -246,7 +245,7 @@ test_conn_get(void)
 }
 
 struct conn *
-conn_get_peer(void *owner, bool client, int data_store)
+conn_get_peer(void *owner, bool client)
 {
     struct conn *conn;
 
@@ -255,7 +254,6 @@ conn_get_peer(void *owner, bool client, int data_store)
         return NULL;
     }
 
-    conn->data_store = data_store;
     conn->dyn_mode = 1;
 
     if (client) {
@@ -281,7 +279,7 @@ conn_get_peer(void *owner, bool client, int data_store)
 }
 
 struct conn *
-conn_get(void *owner, bool client, int data_store)
+conn_get(void *owner, bool client)
 {
     struct conn *conn;
 
@@ -291,7 +289,6 @@ conn_get(void *owner, bool client, int data_store)
     }
 
     /* connection handles the data store messages (redis, memcached or other) */
-    conn->data_store = data_store;
 
     conn->dyn_mode = 0;
 
@@ -319,7 +316,6 @@ conn_get(void *owner, bool client, int data_store)
 struct conn *
 conn_get_dnode(void *owner)
 {
-    struct server_pool *pool = owner;
     struct conn *conn;
 
     conn = _conn_get();
@@ -327,7 +323,6 @@ conn_get_dnode(void *owner)
         return NULL;
     }
 
-    conn->data_store = pool->data_store;
     conn->dyn_mode = 1;
     init_dnode_proxy_conn(conn);
     conn_ref(conn, owner);
@@ -340,7 +335,6 @@ conn_get_dnode(void *owner)
 struct conn *
 conn_get_proxy(void *owner)
 {
-    struct server_pool *pool = owner;
     struct conn *conn;
 
     conn = _conn_get();
@@ -348,7 +342,6 @@ conn_get_proxy(void *owner)
         return NULL;
     }
 
-    conn->data_store = pool->data_store;
 
     conn->dyn_mode = 0;
     init_proxy_conn(conn);
@@ -510,7 +503,6 @@ void
 conn_print(struct conn *conn)
 {
 	log_debug(LOG_VERB, "sd %d", conn->sd);
-	log_debug(LOG_VERB, "data store %d", conn->data_store);
 	log_debug(LOG_VERB, "Type: %s", conn_get_type_string(conn));
 
 	log_debug(LOG_VERB, "dyn_mode %d", conn->dyn_mode);

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -128,8 +128,6 @@ struct conn {
     unsigned           dnode_secured:1;      /* is a secured connection? */
     unsigned           dnode_crypto_state:1; /* crypto state */
     unsigned char      aes_key[50]; //aes_key[34];              /* a place holder for AES key */
-
-    int				   data_store;
     unsigned           same_dc:1;            /* bit to indicate whether a peer conn is same DC */
     uint32_t           avail_tokens;          /* used to throttle the traffics */
     uint32_t           last_sent;             /* ts in sec used to determine the last sent time */
@@ -195,9 +193,9 @@ void conn_set_read_consistency(struct conn *conn, consistency_t cons);
 consistency_t conn_get_read_consistency(struct conn *conn);
 struct context *conn_to_ctx(struct conn *conn);
 struct conn *test_conn_get(void);
-struct conn *conn_get(void *owner, bool client, int data_store);
+struct conn *conn_get(void *owner, bool client);
 struct conn *conn_get_proxy(void *owner);
-struct conn *conn_get_peer(void *owner, bool client, int data_store);
+struct conn *conn_get_peer(void *owner, bool client);
 struct conn *conn_get_dnode(void *owner);
 void conn_put(struct conn *conn);
 ssize_t conn_recv_data(struct conn *conn, void *buf, size_t size);

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -464,7 +464,7 @@ core_debug(struct context *ctx)
 	uint32_t i, nelem;
 	for (i = 0, nelem = array_n(&ctx->pool); i < nelem; i++) {
 		struct server_pool *sp = (struct server_pool *) array_get(&ctx->pool, i);
-		log_debug(LOG_VERB, "Server pool          : %"PRIu32"", sp->idx);
+		log_debug(LOG_VERB, "Server pool          : '%.*s'", sp->name);
 		uint32_t j, n;
 		for (j = 0, n = array_n(&sp->peers); j < n; j++) {
 			log_debug(LOG_VERB, "==============================================");

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -32,8 +32,6 @@
 #include "dyn_gossip.h"
 
 
-static uint32_t ctx_id; /* context generation */
-
 static struct context *
 core_ctx_create(struct instance *nci)
 {
@@ -46,7 +44,6 @@ core_ctx_create(struct instance *nci)
 	if (ctx == NULL) {
 		return NULL;
 	}
-	ctx->id = ++ctx_id;
 	ctx->cf = NULL;
 	ctx->stats = NULL;
 	ctx->evb = NULL;
@@ -207,15 +204,12 @@ core_ctx_create(struct instance *nci)
     }
     preselect_remote_rack_for_replication(ctx);
 
-	log_debug(LOG_VVERB, "created ctx %p id %"PRIu32"", ctx, ctx->id);
-
 	return ctx;
 }
 
 static void
 core_ctx_destroy(struct context *ctx)
 {
-	log_debug(LOG_VVERB, "destroy ctx %p id %"PRIu32"", ctx, ctx->id);
 	proxy_deinit(ctx);
 	server_pool_disconnect(ctx);
 	event_base_destroy(ctx->evb);

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -120,6 +120,7 @@ struct dyn_ring;
 #include <sys/time.h>
 #include <netinet/in.h>
 
+#include "dyn_types.h"
 #include "dyn_array.h"
 #include "dyn_dict.h"
 #include "dyn_string.h"
@@ -165,7 +166,7 @@ typedef enum data_store {
 
 
 struct context {
-    uint32_t           id;          /* unique context id */
+    //uint32_t           id;          /* unique context id */
     struct conf        *cf;         /* configuration */
     struct stats       *stats;      /* stats */
 
@@ -304,7 +305,7 @@ struct server_pool {
     struct string      dc;                   /* server's dc */
     struct string      env;                  /* aws, network, ect */
     /* none | datacenter | rack | all in order of increasing number of connections. (default is datacenter) */
-    struct string      secure_server_option;
+    secure_server_option_t secure_server_option;
     struct string      pem_key_file;
     data_store_t	   data_store;	/* the backend data store */
 

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -257,7 +257,7 @@ struct server_pool {
     uint32_t           dn_conn_q;            /* # client connection */
     struct conn_tqh    c_conn_q;             /* client connection q */
 
-    struct array       server;               /* server[] */
+    struct server      *datastore;               /* server[] */
     struct array       datacenters;                /* racks info  */
     uint32_t           nlive_server;         /* # live server */
     uint64_t           next_rebuild;         /* next distribution rebuild time in usec */

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -295,6 +295,7 @@ struct server_pool {
 };
 
 struct context {
+    struct instance    *instance;   /* back pointer to instance */
     struct conf        *cf;         /* configuration */
     struct stats       *stats;      /* stats */
 
@@ -310,7 +311,7 @@ struct context {
 
 
 
-struct context *core_start(struct instance *nci);
+rstatus_t core_start(struct instance *nci);
 void core_stop(struct context *ctx);
 rstatus_t core_core(void *arg, uint32_t events);
 rstatus_t core_loop(struct context *ctx);

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -164,6 +164,7 @@ typedef enum data_store {
 	DATA_MEMCACHE	  = 1  /* Data store is Memcache */
 } data_store_t;
 
+extern data_store_t g_data_store;
 
 struct instance {
     struct context  *ctx;                        /* active context */
@@ -290,8 +291,6 @@ struct server_pool {
     /* none | datacenter | rack | all in order of increasing number of connections. (default is datacenter) */
     secure_server_option_t secure_server_option;
     struct string      pem_key_file;
-    data_store_t	   data_store;	/* the backend data store */
-
 };
 
 struct context {

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -165,21 +165,6 @@ typedef enum data_store {
 } data_store_t;
 
 
-struct context {
-    struct conf        *cf;         /* configuration */
-    struct stats       *stats;      /* stats */
-
-    struct array       pool;        /* server_pool[] */
-    struct event_base  *evb;        /* event base */
-    int                max_timeout; /* max timeout in msec */
-    int                timeout;     /* timeout in msec */
-    dyn_state_t        dyn_state;   /* state of the node.  Don't need volatile as
-                                       it is ok to eventually get its new value */
-    unsigned           enable_gossip:1;   /* enable/disable gossip */
-    unsigned           admin_opt;   /* admin mode */
-};
-
-
 struct instance {
     struct context  *ctx;                        /* active context */
     int             log_level;                   /* log level */
@@ -308,6 +293,21 @@ struct server_pool {
     data_store_t	   data_store;	/* the backend data store */
 
 };
+
+struct context {
+    struct conf        *cf;         /* configuration */
+    struct stats       *stats;      /* stats */
+
+    struct server_pool pool;        /* server_pool[] */
+    struct event_base  *evb;        /* event base */
+    int                max_timeout; /* max timeout in msec */
+    int                timeout;     /* timeout in msec */
+    dyn_state_t        dyn_state;   /* state of the node.  Don't need volatile as
+                                       it is ok to eventually get its new value */
+    unsigned           enable_gossip:1;   /* enable/disable gossip */
+    unsigned           admin_opt;   /* admin mode */
+};
+
 
 
 struct context *core_start(struct instance *nci);

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -166,7 +166,6 @@ typedef enum data_store {
 
 
 struct context {
-    //uint32_t           id;          /* unique context id */
     struct conf        *cf;         /* configuration */
     struct stats       *stats;      /* stats */
 
@@ -251,7 +250,6 @@ struct server {
 
 
 struct server_pool {
-    uint32_t           idx;                  /* pool index */
     struct context     *ctx;                 /* owner context */
     struct conf_pool   *conf_pool;           /* back reference to conf_pool */
 

--- a/src/dyn_crypto.c
+++ b/src/dyn_crypto.c
@@ -144,26 +144,13 @@ aes_init(void)
 }
 
 
-//only support loading one file at this time
-static rstatus_t
-crypto_pool_each_init(void *elem, void *data)
+rstatus_t
+crypto_init(struct server_pool *sp)
 {
-    struct server_pool *sp = elem;
-
     //init AES
     THROW_STATUS(aes_init());
-
     //init RSA
     THROW_STATUS(load_private_rsa_key(sp));
-
-    return DN_OK;
-}
-
-
-rstatus_t
-crypto_init(struct context *ctx)
-{
-    THROW_STATUS(array_each(&ctx->pool, crypto_pool_each_init, NULL));
     return DN_OK;
 }
 

--- a/src/dyn_crypto.h
+++ b/src/dyn_crypto.h
@@ -27,7 +27,7 @@
 #define AES_KEYLEN 32
 
 
-rstatus_t crypto_init(struct context *ctx);
+rstatus_t crypto_init(struct server_pool *sp);
 rstatus_t crypto_init_for_test(void);
 rstatus_t crypto_deinit(void);
 

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -283,7 +283,7 @@ dnode_req_forward(struct context *ctx, struct conn *conn, struct msg *msg)
             if (string_compare(rack->name, &pool->rack) == 0 ) {
                 rack_msg = msg;
             } else {
-                rack_msg = msg_get(conn, msg->request, msg->data_store, __FUNCTION__);
+                rack_msg = msg_get(conn, msg->request, __FUNCTION__);
                 if (rack_msg == NULL) {
                     log_debug(LOG_VERB, "whelp, looks like yer screwed now, buddy. no inter-rack messages for you!");
                     continue;

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -31,7 +31,7 @@ dyn_parse_core(struct msg *r)
 {
    struct dmsg *dmsg;
    struct mbuf *b;
-   uint8_t *p, *token;
+   uint8_t *p = r->pos, *token;
    uint8_t ch = ' ';
    uint64_t num = 0;
 

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -1093,10 +1093,10 @@ dmsg_process(struct context *ctx, struct conn *conn, struct dmsg *dmsg)
 void
 data_store_parse_req(struct msg *r)
 {
-	if (r->data_store == DATA_REDIS) {
+	if (g_data_store == DATA_REDIS) {
 		return redis_parse_req(r);
 	}
-	else if (r->data_store == DATA_MEMCACHE){
+	else if (g_data_store == DATA_MEMCACHE){
 		return memcache_parse_req(r);
 	}
 	else{
@@ -1110,10 +1110,10 @@ data_store_parse_req(struct msg *r)
 void
 data_store_parse_rsp(struct msg *r)
 {
-	if (r->data_store == DATA_REDIS) {
+	if (g_data_store == DATA_REDIS) {
 		return redis_parse_rsp(r);
 	}
-	else if (r->data_store == DATA_MEMCACHE){
+	else if (g_data_store == DATA_MEMCACHE){
 		return memcache_parse_rsp(r);
 	}
 	else{

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -1297,12 +1297,12 @@ dnode_peer_pool_preconnect(struct context *ctx)
     return DN_OK;
 }
 
-/*
-static rstatus_t
-dnode_peer_pool_each_disconnect(void *elem, void *data)
+
+void
+dnode_peer_pool_disconnect(struct context *ctx)
 {
     rstatus_t status;
-    struct server_pool *sp = elem;
+    struct server_pool *sp = &ctx->pool;
 
     status = array_each(&sp->peers, dnode_peer_each_disconnect, NULL);
     if (status != DN_OK) {
@@ -1312,12 +1312,7 @@ dnode_peer_pool_each_disconnect(void *elem, void *data)
     return DN_OK;
 }
 
-static void
-dnode_peer_pool_disconnect(struct context *ctx)
-{
-    array_each(&ctx->pool, dnode_peer_pool_each_disconnect, NULL);
-}
-
+/*
 static void
 dnode_peer_pool_deinit(struct array *server_pool)
 {

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -314,25 +314,24 @@ is_conn_secured(struct server_pool *sp, struct server *peer_node)
     //ASSERT(sp != NULL);
 
     // if dc-secured mode then communication only between nodes in different dc is secured
-    if (dn_strcmp(sp->secure_server_option.data, CONF_STR_DC) == 0) {
-        if (string_compare(&sp->dc, &peer_node->dc) != 0) {
+    switch (sp->secure_server_option)
+    {
+        case SECURE_OPTION_NONE:
+            return false;
+        case SECURE_OPTION_RACK:
+            if (string_compare(&sp->rack, &peer_node->rack) != 0
+                    || string_compare(&sp->dc, &peer_node->dc) != 0) {
+                return true;
+            }
+            return false;
+        case SECURE_OPTION_DC:
+            if (string_compare(&sp->dc, &peer_node->dc) != 0) {
+                return true;
+            }
+            return false;
+        case SECURE_OPTION_ALL:
             return true;
-        }
     }
-    // if rack-secured mode then communication only between nodes in different rack is secured.
-    // communication secured between nodes if they are in rack with same name across dcs.
-    else if (dn_strcmp(sp->secure_server_option.data, CONF_STR_RACK) == 0) {
-        // if not same rack nor dc
-        if (string_compare(&sp->rack, &peer_node->rack) != 0
-                || string_compare(&sp->dc, &peer_node->dc) != 0) {
-            return true;
-        }
-    }
-    // if all then all communication between nodes will be secured.
-    else if (dn_strcmp(sp->secure_server_option.data, CONF_STR_ALL) == 0) {
-        return true;
-    }
-
     return false;
 }
 

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -286,8 +286,8 @@ dnode_peer_each_pool_init(void *elem, void *context)
 
     dnode_peer_pool_run(sp);
 
-    log_debug(LOG_DEBUG, "init %"PRIu32" seeds and peers in pool %"PRIu32" '%.*s'",
-            nseed, sp->idx, sp->name.len, sp->name.data);
+    log_debug(LOG_DEBUG, "init %"PRIu32" seeds and peers in pool '%.*s'",
+              nseed, sp->name.len, sp->name.data);
 
     return DN_OK;
 }
@@ -525,8 +525,8 @@ dnode_peer_failure(struct context *ctx, struct server *server)
     }
 
     if (log_loggable(LOG_INFO)) {
-       log_debug(LOG_INFO, "dyn: update peer pool %"PRIu32" '%.*s' for peer '%.*s' "
-               "for next %"PRIu32" secs", pool->idx, pool->name.len,
+       log_debug(LOG_INFO, "dyn: update peer pool '%.*s' for peer '%.*s' "
+               "for next %"PRIu32" secs", pool->name.len,
                pool->name.data, server->pname.len, server->pname.data,
                pool->server_retry_timeout_ms/1000);
     }
@@ -538,7 +538,7 @@ dnode_peer_failure(struct context *ctx, struct server *server)
 
     status = dnode_peer_pool_run(pool);
     if (status != DN_OK) {
-        log_error("dyn: updating peer pool %"PRIu32" '%.*s' failed: %s", pool->idx,
+        log_error("dyn: updating peer pool '%.*s' failed: %s",
                 pool->name.len, pool->name.data, strerror(errno));
     }
 }
@@ -1909,7 +1909,7 @@ rack_name_cmp(const void *t1, const void *t2)
 
 // The idea here is to have a designated rack in each remote region to replicate
 // data to. This is used to replicate writes to remote regions
-static void
+static rstatus_t 
 preselect_remote_rack_for_replication_each(void *elem, void *data)
 {
     struct server_pool *sp = elem;
@@ -1959,6 +1959,7 @@ preselect_remote_rack_for_replication_each(void *elem, void *data)
                    dc->preselected_rack_for_replication->name->data,
                    dc->name->len, dc->name->data);
     }
+    return DN_OK;
 }
 
 void

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -331,7 +331,7 @@ dnode_peer_conn(struct server *server)
     pool = server->owner;
 
     if (server->ns_conn_q < 1) {
-        conn = conn_get_peer(server, false, pool->data_store);
+        conn = conn_get_peer(server, false);
         if (is_conn_secured(pool, server)) {
             conn->dnode_secured = 1;
             conn->dnode_crypto_state = 0; //need to do a encryption handshake
@@ -469,7 +469,7 @@ dnode_peer_ack_err(struct context *ctx, struct conn *conn, struct msg *req)
     // Create an appropriate response for the request so its propagated up;
     // This response gets dropped in rsp_make_error anyways. But since this is
     // an error path its ok with the overhead.
-    struct msg *rsp = msg_get(conn, false, conn->data_store, __FUNCTION__);
+    struct msg *rsp = msg_get(conn, false, __FUNCTION__);
     req->done = 1;
     rsp->error = req->error = 1;
     rsp->err = req->err = conn->err;
@@ -764,7 +764,7 @@ dnode_peer_forward_state(void *rmsg)
         return DN_ERROR;
     }
 
-    dnode_peer_gossip_forward(sp->ctx, conn, sp->data_store, mbuf);
+    dnode_peer_gossip_forward(sp->ctx, conn, mbuf);
 
     //free this as nobody else will do
     //mbuf_put(mbuf);
@@ -840,7 +840,7 @@ dnode_peer_handshake_announcing(void *rmsg)
 
         //conn->
 
-        dnode_peer_gossip_forward(sp->ctx, conn, sp->data_store, mbuf);
+        dnode_peer_gossip_forward(sp->ctx, conn, mbuf);
         //peer_gossip_forward1(sp->ctx, conn, sp->data_store, &data);
     }
 
@@ -1566,8 +1566,7 @@ dnode_rsp_forward(struct context *ctx, struct conn *peer_conn, struct msg *rsp)
         req->done = 1;
 
         // Create an appropriate response for the request so its propagated up;
-        struct msg *err_rsp = msg_get(peer_conn, false, peer_conn->data_store,
-                                      __FUNCTION__);
+        struct msg *err_rsp = msg_get(peer_conn, false, __FUNCTION__);
         err_rsp->error = req->error = 1;
         err_rsp->err = req->err = BAD_FORMAT;
         err_rsp->dyn_error = req->dyn_error = BAD_FORMAT;

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -319,12 +319,15 @@ is_conn_secured(struct server_pool *sp, struct server *peer_node)
         case SECURE_OPTION_NONE:
             return false;
         case SECURE_OPTION_RACK:
+            // if rack-secured mode then communication only between nodes in different rack is secured.
+            // communication secured between nodes if they are in rack with same name across dcs.
             if (string_compare(&sp->rack, &peer_node->rack) != 0
                     || string_compare(&sp->dc, &peer_node->dc) != 0) {
                 return true;
             }
             return false;
         case SECURE_OPTION_DC:
+            // if dc-secured mode then communication only between nodes in different dc is secured     
             if (string_compare(&sp->dc, &peer_node->dc) != 0) {
                 return true;
             }

--- a/src/dyn_dnode_peer.h
+++ b/src/dyn_dnode_peer.h
@@ -19,7 +19,7 @@ void dnode_peer_connected(struct context *ctx, struct conn *conn);
 
 struct conn *dnode_peer_pool_conn(struct context *ctx, struct server_pool *pool, struct rack *rack, uint8_t *key, uint32_t keylen, uint8_t msg_type);
 rstatus_t dnode_peer_pool_preconnect(struct context *ctx);
-
+void dnode_peer_pool_disconnect(struct context *ctx);
 rstatus_t dnode_peer_forward_state(void *rmsg);
 rstatus_t dnode_peer_add(void *rmsg);
 rstatus_t dnode_peer_replace(void *rmsg);

--- a/src/dyn_dnode_peer.h
+++ b/src/dyn_dnode_peer.h
@@ -13,7 +13,7 @@
 #define WAIT_BEFORE_UPDATE_PEERS_IN_MILLIS   30000
 
 msec_t dnode_peer_timeout(struct msg *msg, struct conn *conn);
-rstatus_t dnode_peer_init(struct array *server_pool, struct context *ctx);
+rstatus_t dnode_peer_init(struct context *ctx);
 void dnode_peer_deinit(struct array *nodes);
 void dnode_peer_connected(struct context *ctx, struct conn *conn);
 

--- a/src/dyn_dnode_proxy.c
+++ b/src/dyn_dnode_proxy.c
@@ -28,8 +28,7 @@ dnode_ref(struct conn *conn, void *owner)
     /* owner of the proxy connection is the server pool */
     conn->owner = owner;
 
-    log_debug(LOG_VVERB, "ref conn %p owner %p into pool %"PRIu32"", conn,
-              pool, pool->idx);
+    log_debug(LOG_VVERB, "ref conn %p owner %p", conn, pool);
 }
 
 static void
@@ -45,8 +44,7 @@ dnode_unref(struct conn *conn)
 
     pool->d_conn = NULL;
 
-    log_debug(LOG_VVERB, "unref conn %p owner %p from pool %"PRIu32"", conn,
-              pool, pool->idx);
+    log_debug(LOG_VVERB, "unref conn %p owner %p", conn, pool);
 }
 
 static void
@@ -197,12 +195,11 @@ dnode_each_init(void *elem, void *data)
     	log_datastore = "memcache";
     }
 
-    log_debug(LOG_NOTICE, "dyn: p %d listening on '%.*s' in %s pool %"PRIu32" '%.*s'"
+    log_debug(LOG_NOTICE, "dyn: p %d listening on '%.*s' in %s pool '%.*s'"
               " with %"PRIu32" servers", p->sd, pool->addrstr.len,
               pool->d_addrstr.data,
 			  log_datastore,
-              pool->idx, pool->name.len, pool->name.data,
-              array_n(&pool->server));
+              pool->name.len, pool->name.data );
     return DN_OK;
 }
 

--- a/src/dyn_dnode_proxy.c
+++ b/src/dyn_dnode_proxy.c
@@ -186,10 +186,10 @@ dnode_init(struct context *ctx)
     }
 
     const char * log_datastore = "not selected data store";
-    if (pool->data_store == DATA_REDIS){
+    if (g_data_store == DATA_REDIS){
     	log_datastore = "redis";
     }
-    else if (pool->data_store == DATA_MEMCACHE){
+    else if (g_data_store == DATA_MEMCACHE){
     	log_datastore = "memcache";
     }
 
@@ -262,7 +262,7 @@ dnode_accept(struct context *ctx, struct conn *p)
        loga("Unable to get client's address for accept on sd %d\n", sd);
     }
 
-    c = conn_get_peer(p->owner, true, p->data_store);
+    c = conn_get_peer(p->owner, true);
     if (c == NULL) {
         log_error("dyn: get conn client peer for PEER_CLIENT %d from %s %d failed: %s",
                   sd, conn_get_type_string(p), p->sd, strerror(errno));

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -195,10 +195,10 @@ peer_gossip_forward1(struct context *ctx, struct conn *conn, bool redis, struct 
  * Sending a mbuf of gossip data over the wire to a peer
  */
 void
-dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, int data_store, struct mbuf *data_buf)
+dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, struct mbuf *data_buf)
 {
     rstatus_t status;
-    struct msg *msg = msg_get(conn, 1, data_store, __FUNCTION__);
+    struct msg *msg = msg_get(conn, 1, __FUNCTION__);
 
     if (msg == NULL) {
         log_debug(LOG_DEBUG, "Unable to obtain a msg");

--- a/src/dyn_gossip.c
+++ b/src/dyn_gossip.c
@@ -878,7 +878,7 @@ gossip_pool_each_init(void *elem, void *data)
 
     gn_pool.ctx = sp->ctx;
     gn_pool.name = &sp->name;
-    gn_pool.idx = sp->idx;
+    gn_pool.idx = 0;
     gn_pool.g_interval = sp->g_interval;
 
     //dictDisableResize();

--- a/src/dyn_gossip.c
+++ b/src/dyn_gossip.c
@@ -870,11 +870,11 @@ gossip_set_seeds_provider(struct string * seeds_provider_str)
 }
 
 
-static rstatus_t
-gossip_pool_each_init(void *elem, void *data)
+rstatus_t
+gossip_pool_init(struct context *ctx)
 {
     rstatus_t status;
-    struct server_pool *sp = elem;
+    struct server_pool *sp = &ctx->pool;
 
     gn_pool.ctx = sp->ctx;
     gn_pool.name = &sp->name;
@@ -980,15 +980,6 @@ gossip_pool_each_init(void *elem, void *data)
     return DN_OK;
 
 }
-
-
-rstatus_t
-gossip_pool_init(struct context *ctx)
-{
-	THROW_STATUS(array_each(&ctx->pool, gossip_pool_each_init, NULL));
-    return DN_OK;
-}
-
 
 rstatus_t
 gossip_destroy(struct server_pool *sp)

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -296,7 +296,6 @@ struct msg {
     unsigned             swallow:1;       /* swallow response? */
     unsigned             rsp_sent:1;      /* is a response sent for this request?*/
 
-    int					 data_store;
     //dynomite
     struct dmsg          *dmsg;          /* dyn message */
     int                  dyn_state;
@@ -346,7 +345,7 @@ void msg_tmo_delete(struct msg *msg);
 void msg_init(struct instance *nci);
 rstatus_t msg_clone(struct msg *src, struct mbuf *mbuf_start, struct msg *target);
 void msg_deinit(void);
-struct msg *msg_get(struct conn *conn, bool request, int data_store, const char* const caller);
+struct msg *msg_get(struct conn *conn, bool request, const char* const caller);
 void msg_put(struct msg *msg);
 uint32_t msg_mbuf_size(struct msg *msg);
 uint32_t msg_length(struct msg *msg);
@@ -391,6 +390,6 @@ void local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg
 void dnode_peer_req_forward(struct context *ctx, struct conn *c_conn, struct conn *p_conn,
 		                struct msg *msg, struct rack *rack, uint8_t *key, uint32_t keylen);
 
-//void peer_gossip_forward(struct context *ctx, struct conn *conn, int data_store, struct string *data);
-void dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, int data_store, struct mbuf *data);
+//void peer_gossip_forward(struct context *ctx, struct conn *conn, struct string *data);
+void dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, struct mbuf *data);
 #endif

--- a/src/dyn_proxy.c
+++ b/src/dyn_proxy.c
@@ -211,12 +211,11 @@ proxy_each_init(void *elem, void *data)
     }
 
 
-    log_debug(LOG_NOTICE, "p %d listening on '%.*s' in %s pool '%.*s'"
-              " with %"PRIu32" servers", p->sd, pool->addrstr.len,
+    log_debug(LOG_NOTICE, "p %d listening on '%.*s' in %s pool '%.*s'",
+              p->sd, pool->addrstr.len,
               pool->addrstr.data,
 			  log_datastore,
-              pool->name.len, pool->name.data,
-              array_n(&pool->server));
+              pool->name.len, pool->name.data);
 
     return DN_OK;
 }

--- a/src/dyn_proxy.c
+++ b/src/dyn_proxy.c
@@ -202,10 +202,10 @@ proxy_init(struct context *ctx)
     }
 
     char * log_datastore = "not selected data store";
-    if (pool->data_store == DATA_REDIS){
+    if (g_data_store == DATA_REDIS){
     	log_datastore = "redis";
     }
-    else if (pool->data_store == DATA_MEMCACHE){
+    else if (g_data_store == DATA_MEMCACHE){
     	log_datastore = "memcache";
     }
 
@@ -269,7 +269,7 @@ proxy_accept(struct context *ctx, struct conn *p)
         break;
     }
 
-    c = conn_get(p->owner, true, p->data_store);
+    c = conn_get(p->owner, true);
     if (c == NULL) {
         log_error("get conn for CLIENT %d from %s %d failed: %s", sd,
                   conn_get_type_string(p), p->sd, strerror(errno));

--- a/src/dyn_proxy.c
+++ b/src/dyn_proxy.c
@@ -43,8 +43,7 @@ proxy_ref(struct conn *conn, void *owner)
     /* owner of the proxy connection is the server pool */
     conn->owner = owner;
 
-    log_debug(LOG_VVERB, "ref conn %p owner %p into pool %"PRIu32"", conn,
-              pool, pool->idx);
+    log_debug(LOG_VVERB, "ref conn %p owner %p", conn, pool);
 }
 
 static void
@@ -60,8 +59,7 @@ proxy_unref(struct conn *conn)
 
     pool->p_conn = NULL;
 
-    log_debug(LOG_VVERB, "unref conn %p owner %p from pool %"PRIu32"", conn,
-              pool, pool->idx);
+    log_debug(LOG_VVERB, "unref conn %p owner %p", conn, pool);
 }
 
 static void
@@ -213,11 +211,11 @@ proxy_each_init(void *elem, void *data)
     }
 
 
-    log_debug(LOG_NOTICE, "p %d listening on '%.*s' in %s pool %"PRIu32" '%.*s'"
+    log_debug(LOG_NOTICE, "p %d listening on '%.*s' in %s pool '%.*s'"
               " with %"PRIu32" servers", p->sd, pool->addrstr.len,
               pool->addrstr.data,
 			  log_datastore,
-              pool->idx, pool->name.len, pool->name.data,
+              pool->name.len, pool->name.data,
               array_n(&pool->server));
 
     return DN_OK;

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -32,7 +32,7 @@ req_get(struct conn *conn)
     ASSERT((conn->type == CONN_CLIENT) ||
            (conn->type == CONN_DNODE_PEER_CLIENT));
 
-    msg = msg_get(conn, true, conn->data_store, __FUNCTION__);
+    msg = msg_get(conn, true, __FUNCTION__);
     if (msg == NULL) {
         conn->err = errno;
     }

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -31,7 +31,7 @@ rsp_get(struct conn *conn)
     ASSERT((conn->type == CONN_DNODE_PEER_SERVER) ||
            (conn->type == CONN_SERVER));
 
-    msg = msg_get(conn, false, conn->data_store, __FUNCTION__);
+    msg = msg_get(conn, false, __FUNCTION__);
     if (msg == NULL) {
         conn->err = errno;
     }

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -138,7 +138,7 @@ server_conn(struct server *server)
 	 */
 
 	if (server->ns_conn_q < pool->server_connections) {
-		return conn_get(server, false, pool->data_store);
+		return conn_get(server, false);
 	}
 	ASSERT(server->ns_conn_q == pool->server_connections);
 
@@ -299,7 +299,7 @@ server_ack_err(struct context *ctx, struct conn *conn, struct msg *req)
     // Create an appropriate response for the request so its propagated up;
     // This response gets dropped in rsp_make_error anyways. But since this is
     // an error path its ok with the overhead.
-    struct msg *rsp = msg_get(conn, false, conn->data_store, __FUNCTION__);
+    struct msg *rsp = msg_get(conn, false, __FUNCTION__);
     if (rsp == NULL) {
         log_warn("Could not allocate msg.");
         return;

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -117,7 +117,10 @@ server_active(struct conn *conn)
 static void
 server_deinit(struct server **pdatastore)
 {
-    // TODO MT:
+    if (!pdatastore || !*pdatastore)
+        return;
+    struct server *s = *pdatastore;
+    ASSERT(TAILQ_EMPTY(&s->s_conn_q) && s->ns_conn_q == 0);
 }
 
 static struct conn *

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -169,8 +169,8 @@ server_init(struct array *servers, struct array *conf_server,
 		return status;
 	}
 
-	log_debug(LOG_DEBUG, "init %"PRIu32" servers in pool %"PRIu32" '%.*s'",
-			nserver, sp->idx, sp->name.len, sp->name.data);
+	log_debug(LOG_DEBUG, "init %"PRIu32" servers in pool '%.*s'",
+			  nserver, sp->name.len, sp->name.data);
 
 	return DN_OK;
 }
@@ -284,8 +284,8 @@ server_failure(struct context *ctx, struct server *server)
 
 	next = now + pool->server_retry_timeout_ms;
 
-	log_debug(LOG_INFO, "update pool %"PRIu32" '%.*s' to delete server '%.*s' "
-			"for next %"PRIu32" secs", pool->idx, pool->name.len,
+	log_debug(LOG_INFO, "update pool '%.*s' to delete server '%.*s' "
+			"for next %"PRIu32" secs", pool->name.len,
 			pool->name.data, server->pname.len, server->pname.data,
 			pool->server_retry_timeout_ms/1000);
 
@@ -296,7 +296,7 @@ server_failure(struct context *ctx, struct server *server)
 
 	status = server_pool_run(pool);
 	if (status != DN_OK) {
-		log_error("updating pool %"PRIu32" '%.*s' failed: %s", pool->idx,
+		log_error("updating pool '%.*s' failed: %s",
 				pool->name.len, pool->name.data, strerror(errno));
 	}
 }
@@ -608,13 +608,13 @@ server_pool_update(struct server_pool *pool)
 
 	status = server_pool_run(pool);
 	if (status != DN_OK) {
-		log_error("updating pool %"PRIu32" with dist %d failed: %s", pool->idx,
+		log_error("updating pool with dist %d failed: %s",
 				pool->dist_type, strerror(errno));
 		return status;
 	}
 
-	log_debug(LOG_INFO, "update pool %"PRIu32" '%.*s' to add %"PRIu32" servers",
-			pool->idx, pool->name.len, pool->name.data,
+	log_debug(LOG_INFO, "update pool '%.*s' to add %"PRIu32" servers",
+			pool->name.len, pool->name.data,
 			pool->nlive_server - pnlive_server);
 
 
@@ -826,8 +826,7 @@ server_pool_deinit(struct array *server_pool)
 
 		sp->nlive_server = 0;
 
-		log_debug(LOG_DEBUG, "deinit pool %"PRIu32" '%.*s'", sp->idx,
-				sp->name.len, sp->name.data);
+		log_debug(LOG_DEBUG, "deinit pool '%.*s'", sp->name.len, sp->name.data);
 	}
 
 	array_deinit(server_pool);
@@ -921,7 +920,7 @@ server_get_dc(struct server_pool *pool, struct string *dcname)
 	uint32_t i, len;
 
 	if (log_loggable(LOG_DEBUG)) {
-		log_debug(LOG_DEBUG, "server_get_dc pool  '%.*s'",
+		log_debug(LOG_DEBUG, "server_get_dc dc '%.*s'",
 				dcname->len, dcname->data);
 	}
 
@@ -940,7 +939,7 @@ server_get_dc(struct server_pool *pool, struct string *dcname)
 	string_copy(dc->name, dcname->data, dcname->len);
 
 	if (log_loggable(LOG_DEBUG)) {
-		log_debug(LOG_DEBUG, "server_get_dc pool about to exit  '%.*s'",
+		log_debug(LOG_DEBUG, "server_get_dc about to exit dc '%.*s'",
 				dc->name->len, dc->name->data);
 	}
 

--- a/src/dyn_server.h
+++ b/src/dyn_server.h
@@ -81,8 +81,8 @@ struct conn *server_pool_conn(struct context *ctx, struct server_pool *pool, uin
 rstatus_t server_pool_run(struct server_pool *pool);
 rstatus_t server_pool_preconnect(struct context *ctx);
 void server_pool_disconnect(struct context *ctx);
-rstatus_t server_pool_init(struct array *server_pool, struct array *conf_pool, struct context *ctx);
-void server_pool_deinit(struct array *server_pool);
+rstatus_t server_pool_init(struct server_pool *server_pool, struct conf_pool *conf_pool, struct context *ctx);
+void server_pool_deinit(struct server_pool *server_pool);
 void init_server_conn(struct conn *conn);
 
 #endif

--- a/src/dyn_server.h
+++ b/src/dyn_server.h
@@ -68,7 +68,7 @@
 
 
 msec_t server_timeout(struct conn *conn);
-rstatus_t server_init(struct array *server, struct array *conf_server, struct server_pool *sp);
+rstatus_t server_init(struct server_pool *sp, struct array *conf_server);
 rstatus_t server_connect(struct context *ctx, struct server *server, struct conn *conn);
 
 struct datacenter *server_get_dc(struct server_pool *pool, struct string *dcname);

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -199,23 +199,16 @@ stats_server_init(struct stats_server *sts, struct server *s)
 }
 
 static rstatus_t
-stats_server_map(struct array *stats_server, struct array *server)
+stats_server_map(struct array *stats_server, struct conf_server *datastore)
 {
-    uint32_t i, nserver;
+    ASSERT(datastore != NULL);
+    THROW_STATUS(array_init(stats_server, 1, sizeof(struct stats_server)));
 
-    nserver = array_n(server);
-    ASSERT(nserver != 0);
+    struct stats_server *sts = array_push(stats_server);
 
-    THROW_STATUS(array_init(stats_server, nserver, sizeof(struct stats_server)));
+    THROW_STATUS(stats_server_init(sts, datastore));
 
-    for (i = 0; i < nserver; i++) {
-        struct server *s = array_get(server, i);
-        struct stats_server *sts = array_push(stats_server);
-
-        THROW_STATUS(stats_server_init(sts, s));
-    }
-
-    log_debug(LOG_VVVERB, "map %"PRIu32" stats servers", nserver);
+    log_debug(LOG_VVVERB, "mappd 1 stats servers");
 
     return DN_OK;
 }
@@ -247,7 +240,7 @@ stats_pool_init(struct stats_pool *stp, struct server_pool *sp)
 
     THROW_STATUS(stats_pool_metric_init(&stp->metric));
 
-    status = stats_server_map(&stp->server, &sp->server);
+    status = stats_server_map(&stp->server, sp->datastore);
     if (status != DN_OK) {
         stats_metric_deinit(&stp->metric);
         return status;

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -287,9 +287,9 @@ stats_pool_map(struct array *stats_pool, struct array *server_pool)
     uint32_t i, npool;
 
     npool = array_n(server_pool);
-    ASSERT(npool != 0);
+    ASSERT(npool == 1);
 
-    THROW_STATUS(array_init(stats_pool, npool, sizeof(struct stats_pool)));
+    THROW_STATUS(array_init(stats_pool, 1, sizeof(struct stats_pool)));
 
     for (i = 0; i < npool; i++) {
         struct server_pool *sp = array_get(server_pool, i);
@@ -1598,9 +1598,8 @@ uint64_t _stats_pool_get_ts(struct context *ctx, struct server_pool *pool,
    struct stats *st = ctx->stats;
    struct stats_pool *stp;
    struct stats_metric *stm;
-   uint32_t pidx = pool->idx;
 
-   stp = array_get(&st->current, pidx);
+   stp = array_get(&st->current, 0);
    stm = array_get(&stp->metric, fidx);
 
    return stm->value.counter;
@@ -1612,9 +1611,8 @@ int64_t _stats_pool_get_val(struct context *ctx, struct server_pool *pool,
    struct stats *st = ctx->stats;
    struct stats_pool *stp;
    struct stats_metric *stm;
-   uint32_t pidx = pool->idx;
 
-   stp = array_get(&st->current, pidx);
+   stp = array_get(&st->current, 0);
    stm = array_get(&stp->metric, fidx);
 
    return stm->value.counter;
@@ -1630,10 +1628,8 @@ stats_pool_to_metric(struct context *ctx, struct server_pool *pool,
     struct stats_metric *stm;
     uint32_t pidx;
 
-    pidx = pool->idx;
-
     st = ctx->stats;
-    stp = array_get(&st->current, pidx);
+    stp = array_get(&st->current, 0);
     stm = array_get(&stp->metric, fidx);
 
     st->updated = 1;
@@ -1734,10 +1730,9 @@ uint64_t _stats_server_get_ts(struct context *ctx, struct server *server,
    uint32_t pidx, sidx;
 
    sidx = server->idx;
-   pidx = server->owner->idx;
 
    st = ctx->stats;
-   stp = array_get(&st->current, pidx);
+   stp = array_get(&st->current, 0);
    sts = array_get(&stp->server, sidx);
    stm = array_get(&sts->metric, fidx);
 
@@ -1769,10 +1764,9 @@ int64_t _stats_server_get_val(struct context *ctx, struct server *server,
    uint32_t pidx, sidx;
 
    sidx = server->idx;
-   pidx = server->owner->idx;
 
    st = ctx->stats;
-   stp = array_get(&st->current, pidx);
+   stp = array_get(&st->current, 0);
    sts = array_get(&stp->server, sidx);
    stm = array_get(&sts->metric, fidx);
 
@@ -1788,20 +1782,19 @@ stats_server_to_metric(struct context *ctx, struct server *server,
     struct stats_pool *stp;
     struct stats_server *sts;
     struct stats_metric *stm;
-    uint32_t pidx, sidx;
+    uint32_t sidx;
 
     sidx = server->idx;
-    pidx = server->owner->idx;
 
     st = ctx->stats;
-    stp = array_get(&st->current, pidx);
+    stp = array_get(&st->current, 0);
     sts = array_get(&stp->server, sidx);
     stm = array_get(&sts->metric, fidx);
 
     st->updated = 1;
 
-    log_debug(LOG_VVVERB, "metric '%.*s' in pool %"PRIu32" server %"PRIu32"",
-              stm->name.len, stm->name.data, pidx, sidx);
+    log_debug(LOG_VVVERB, "metric '%.*s' for server %"PRIu32"",
+              stm->name.len, stm->name.data, sidx);
 
     return stm;
 }

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -198,9 +198,9 @@ struct stats {
     struct stats_buffer       buf;            /* info buffer */
     struct stats_buffer       clus_desc_buf;  /* cluster_describe buffer */
 
-    struct array              current;        /* stats_pool[] (a) */
-    struct array              shadow;         /* stats_pool[] (b) */
-    struct array              sum;            /* stats_pool[] (c = a + b) */
+    struct stats_pool         current;        /* stats_pool[] (a) */
+    struct stats_pool         shadow;         /* stats_pool[] (b) */
+    struct stats_pool         sum;            /* stats_pool[] (c = a + b) */
 
     pthread_t                 tid;            /* stats aggregator thread */
     int                       sd;             /* stats descriptor */
@@ -412,7 +412,7 @@ void _stats_server_set_val(struct context *ctx, struct server *server, stats_ser
 int64_t _stats_server_get_val(struct context *ctx, struct server *server, stats_server_field_t fidx);
 
 struct stats *stats_create(uint16_t stats_port, char *stats_ip, int stats_interval, char *source,
-		                   struct array *server_pool, struct context *ctx);
+		                   struct server_pool *sp, struct context *ctx);
 void stats_destroy(struct stats *stats);
 void stats_swap(struct stats *stats);
 

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -179,7 +179,7 @@ struct stats_server {
 struct stats_pool {
     struct string name;   /* pool name (ref) */
     struct array  metric; /* stats_metric[] for pool codec */
-    struct array  server; /* stats_server[] */
+    struct stats_server server; /* stats for datastore */
 };
 
 struct stats_buffer {

--- a/src/dyn_test.c
+++ b/src/dyn_test.c
@@ -337,7 +337,7 @@ test_msg_recv_chain(struct conn *conn, struct msg *msg)
                 log_debug(LOG_VVERB, "Parsing MSG_PARSE_OK - more data but can't split!");
             }
 
-            nmsg = msg_get(msg->owner, msg->request, conn->data_store, __FUNCTION__);
+            nmsg = msg_get(msg->owner, msg->request, __FUNCTION__);
             mbuf_insert(&nmsg->mhdr, nbuf);
             nmsg->pos = nbuf->pos;
 
@@ -487,8 +487,8 @@ static rstatus_t
 aes_msg_test(struct server *server)
 {
     //unsigned char* aes_key = generate_aes_key();
-    struct conn *conn = conn_get_peer(server, false, true);
-    struct msg *msg = msg_get(conn, true, conn->data_store, __FUNCTION__);
+    struct conn *conn = conn_get_peer(server, false);
+    struct msg *msg = msg_get(conn, true, __FUNCTION__);
 
     struct mbuf *mbuf1 = mbuf_get();
     struct string s1 = string("abc");
@@ -525,7 +525,7 @@ aes_msg_test2(struct server *server)
 {
     unsigned char* aes_key = generate_aes_key();
     struct conn *conn = conn_get_peer(server, false, true);
-    struct msg *msg = msg_get(conn, true, conn->redis);
+    struct msg *msg = msg_get(conn, true, __FUNCTION__);
 
     struct mbuf *mbuf1 = mbuf_get();
     mbuf_write_bytes(mbuf1, data, mbuf_size(mbuf1));
@@ -586,8 +586,8 @@ main(int argc, char **argv)
     struct server *server = malloc(sizeof(struct server));
     init_server(server);
 
-    struct conn *conn = conn_get_peer(server, false, true);
-    struct msg *msg = msg_get(conn, true, conn->data_store, __FUNCTION__);
+    struct conn *conn = conn_get_peer(server, false);
+    struct msg *msg = msg_get(conn, true, __FUNCTION__);
 
     //test payload larger than mbuf_size
     rstatus_t ret = DN_OK;

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -1,3 +1,11 @@
+#pragma once
 typedef uint64_t msgid_t;
 typedef uint64_t msec_t;
 typedef uint64_t usec_t;
+
+typedef enum {
+    SECURE_OPTION_NONE,
+    SECURE_OPTION_RACK,
+    SECURE_OPTION_DC,
+    SECURE_OPTION_ALL,
+}secure_server_option_t;

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -575,17 +575,14 @@ dn_post_run(struct instance *nci)
     log_deinit();
 }
 
-static void
+static rstatus_t
 dn_run(struct instance *nci)
 {
     rstatus_t status;
-    struct context *ctx;
 
-    ctx = core_start(nci);
-    if (ctx == NULL) {
-        return;
-    }
+    THROW_STATUS(core_start(nci));
 
+    struct context *ctx = nci->ctx;
     ctx->enable_gossip = enable_gossip;
     ctx->admin_opt = (unsigned)admin_opt;
 
@@ -601,6 +598,7 @@ dn_run(struct instance *nci)
     }
 
     core_stop(ctx);
+    return DN_OK;
 }
 
 static void
@@ -652,7 +650,8 @@ main(int argc, char **argv)
         exit(1);
     }
 
-    dn_run(&nci);
+    status = dn_run(&nci);
+    IGNORE_RET_VAL(status);
 
     dn_post_run(&nci);
 

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -176,7 +176,6 @@ memcache_parse_req(struct msg *r)
     b = STAILQ_LAST(&r->mhdr, mbuf, next);
 
     ASSERT(r->request);
-    ASSERT(r->data_store==DATA_MEMCACHE);
     ASSERT(state >= SW_START && state < SW_SENTINEL);
     ASSERT(b != NULL);
     ASSERT(b->pos <= b->last);
@@ -782,7 +781,6 @@ memcache_parse_rsp(struct msg *r)
     b = STAILQ_LAST(&r->mhdr, mbuf, next);
 
     ASSERT(!r->request);
-    ASSERT(r->data_store==DATA_MEMCACHE);
     ASSERT(state >= SW_START && state < SW_SENTINEL);
     ASSERT(b != NULL);
     ASSERT(b->pos <= b->last);
@@ -1227,7 +1225,6 @@ memcache_pre_splitcopy(struct mbuf *mbuf, void *arg)
     struct string gets = string("gets "); /* 'gets ' string */
 
     ASSERT(r->request);
-    ASSERT(r->data_store==DATA_MEMCACHE);
     ASSERT(mbuf_empty(mbuf));
 
     switch (r->type) {
@@ -1255,7 +1252,6 @@ memcache_post_splitcopy(struct msg *r)
     struct string crlf = string(CRLF);
 
     ASSERT(r->request);
-    ASSERT(r->data_store==DATA_MEMCACHE);
     ASSERT(!STAILQ_EMPTY(&r->mhdr));
 
     mbuf = STAILQ_LAST(&r->mhdr, mbuf, next);


### PR DESCRIPTION
    o Mainly try to keep dyn_conf.h clean so its understood whats the
interface
    o Create a new enum type of secure server option and use that
    o reduce the warnings in dyn_conf.c
    o Get ride of ctx_id

Sorry about the messy diff. Its only because of function reordering