### PR TITLE
Implement Safe Quorum

### DIFF
--- a/conf/dynomite.yml.orig
+++ b/conf/dynomite.yml.orig
@@ -1,0 +1,7 @@
+dyn_o_mite:
+  listen: 127.0.0.1:8102
+  dyn_listen: 127.0.0.1:8101
+  tokens: '101134286'
+  servers:
+  - 127.0.0.1:22122:1
+  data_store: 0

--- a/conf/redis_rack1_node.yml
+++ b/conf/redis_rack1_node.yml
@@ -12,5 +12,5 @@ dyn_o_mite:
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem
   data_store: 0
-  read_consistency : DC_SAFE_QUORUM
-  write_consistency : DC_SAFE_QUORUM
+  read_consistency : DC_ONE
+  write_consistency : DC_ONE

--- a/conf/redis_rack2_node.yml
+++ b/conf/redis_rack2_node.yml
@@ -4,6 +4,7 @@ dyn_o_mite:
   dyn_listen: 127.0.0.2:8101
   dyn_seeds:
   - 127.0.0.1:8101:rack1:dc:1383429731
+  - 127.0.0.3:8101:rack3:dc:1383429731
   listen: 127.0.0.2:8102
   servers:
   - 127.0.0.1:22122:1
@@ -11,3 +12,5 @@ dyn_o_mite:
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem
   data_store: 0
+  read_consistency : DC_SAFE_QUORUM
+  write_consistency : DC_SAFE_QUORUM

--- a/conf/redis_rack2_node.yml
+++ b/conf/redis_rack2_node.yml
@@ -12,5 +12,5 @@ dyn_o_mite:
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem
   data_store: 0
-  read_consistency : DC_SAFE_QUORUM
-  write_consistency : DC_SAFE_QUORUM
+  read_consistency : DC_ONE
+  write_consistency : DC_ONE

--- a/conf/redis_rack3_node.yml
+++ b/conf/redis_rack3_node.yml
@@ -12,5 +12,5 @@ dyn_o_mite:
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem
   data_store: 0
-  read_consistency : DC_SAFE_QUORUM
-  write_consistency : DC_SAFE_QUORUM
+  read_consistency : DC_ONE
+  write_consistency : DC_ONE

--- a/conf/redis_rack3_node.yml
+++ b/conf/redis_rack3_node.yml
@@ -1,13 +1,13 @@
 dyn_o_mite:
   datacenter: dc
-  rack: rack1
-  dyn_listen: 127.0.0.1:8101
+  rack: rack3
+  dyn_listen: 127.0.0.3:8101
   dyn_seeds:
+  - 127.0.0.1:8101:rack1:dc:1383429731
   - 127.0.0.2:8101:rack2:dc:1383429731
-  - 127.0.0.3:8101:rack3:dc:1383429731
-  listen: 127.0.0.1:8102
+  listen: 127.0.0.3:8102
   servers:
-  - 127.0.0.1:22121:1
+  - 127.0.0.1:22123:1
   tokens: '1383429731'
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem

--- a/conf/temp.yml
+++ b/conf/temp.yml
@@ -1,0 +1,29 @@
+dyn_o_mite:
+    auto_eject_hosts: true
+    datacenter: us-east-1
+    distribution: vnode
+    dyn_listen: 0.0.0.0:8101
+    dyn_read_timeout: 200000
+    dyn_seed_provider: florida_provider
+    dyn_seeds:
+        - ec2-54-155-253-128.eu-west-1.compute.amazonaws.com:8101:dyno_sh_dev--euwest1a:eu-west-1:1383429731
+        - ec2-54-224-161-182.compute-1.amazonaws.com:8101:dyno_sh_dev--useast1d:us-east-1:1383429731
+        - ec2-54-87-58-146.compute-1.amazonaws.com:8101:dyno_sh_dev--useast1c:us-east-1:1383429731
+        - ec2-54-216-119-225.eu-west-1.compute.amazonaws.com:8101:dyno_sh_dev--euwest1c:eu-west-1:1383429731
+        - ec2-54-170-250-137.eu-west-1.compute.amazonaws.com:8101:dyno_sh_dev--euwest1b:eu-west-1:1383429731
+    dyn_write_timeout: 200000
+    gos_interval: 10000
+    hash: murmur
+    listen: 0.0.0.0:8102
+    preconnect: true
+    server_retry_timeout: 30000
+    servers:
+        - 127.0.0.1:22122:1
+    timeout: 5000
+    tokens: '1383429731'
+    rack: dyno_sh_dev--useast1e
+    secure_server_option: datacenter
+    read_consistency: DC_QUORUM
+    write_consistency: DC_QUORUM
+    pem_key_file: /apps/dynomite/conf/dynomite.pem
+    data_store: 0

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -773,7 +773,8 @@ request_send_to_all_local_racks(struct msg *msg)
     if ((msg->type == MSG_REQ_REDIS_PING) ||
         (msg->type == MSG_REQ_REDIS_INFO))
         return false;
-    if (msg->consistency == DC_QUORUM)
+    if ((msg->consistency == DC_QUORUM) ||
+        (msg->consistency == DC_SAFE_QUORUM))
         return true;
     return false;
 }

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -1586,19 +1586,23 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
 
     if (!dn_strcasecmp(cp->read_consistency.data, CONF_STR_DC_ONE))
         g_read_consistency = DC_ONE;
+    else if (!dn_strcasecmp(cp->read_consistency.data, CONF_STR_DC_SAFE_QUORUM))
+        g_read_consistency = DC_SAFE_QUORUM;
     else if (!dn_strcasecmp(cp->read_consistency.data, CONF_STR_DC_QUORUM))
         g_read_consistency = DC_QUORUM;
     else {
-        log_error("conf: directive \"read_consistency:\"must be one of 'DC_ONE' 'DC_QUORUM'");
+        log_error("conf: directive \"read_consistency:\"must be one of 'DC_ONE' 'DC_QUORUM' 'DC_SAFE_QUORUM'");
         return DN_ERROR;
     }
 
     if (!dn_strcasecmp(cp->write_consistency.data, CONF_STR_DC_ONE))
         g_write_consistency = DC_ONE;
-    else if (!dn_strcasecmp(cp->write_consistency.data, CONF_STR_DC_QUORUM))
+    else if (!dn_strcasecmp(cp->write_consistency.data, CONF_STR_DC_SAFE_QUORUM))
+        g_write_consistency = DC_SAFE_QUORUM;
+    else if (!dn_strcasecmp(cp->read_consistency.data, CONF_STR_DC_QUORUM))
         g_write_consistency = DC_QUORUM;
     else {
-        log_error("conf: directive \"write_consistency:\"must be one of 'DC_ONE' 'DC_QUORUM'");
+        log_error("conf: directive \"write_consistency:\"must be one of 'DC_ONE' 'DC_QUORUM' 'DC_SAFE_QUORUM'");
         return DN_ERROR;
     }
 

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -75,8 +75,9 @@
 #define CONF_STR_RACK                        "rack"
 #define CONF_STR_ALL                         "all"
 
-#define CONF_STR_DC_QUORUM                   "dc_quorum"
 #define CONF_STR_DC_ONE                      "dc_one"
+#define CONF_STR_DC_QUORUM                   "dc_quorum"
+#define CONF_STR_DC_SAFE_QUORUM              "dc_safe_quorum"
 
 #define CONF_DEFAULT_ENV                     "aws"
 

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -1460,7 +1460,7 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
         //log_warn("req %d:%d with DC_ONE consistency is not being swallowed");
     }
 
-    /* if client consistency is dc_quorum, forward the response from only the
+    /* if client consistency is dc_quorum or dc_safe_quorum, forward the response from only the
        local region/DC. */
     if (((req->consistency == DC_QUORUM) || (req->consistency == DC_SAFE_QUORUM))
         && !peer_conn->same_dc) {

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -463,11 +463,12 @@ msg_get_error(struct conn *conn, dyn_error_t dyn_err, err_t err)
     struct msg *msg;
     struct mbuf *mbuf;
     int n;
-    char *errstr = err ? strerror(err) : "unknown";
+    char *errstr = err ? dn_strerror(err) : "unknown";
     char *protstr = conn->data_store == DATA_REDIS ? "-ERR" : "SERVER_ERROR";
     char *source;
 
-    if (dyn_err == PEER_CONNECTION_REFUSE) {
+    if ((dyn_err == PEER_CONNECTION_REFUSE) ||
+        (dyn_err == NO_QUORUM_ACHIEVED)) {
         source = "Peer:";
     } else if (dyn_err == STORAGE_CONNECTION_REFUSE) {
         source = "Storage:";

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -465,14 +465,7 @@ msg_get_error(struct conn *conn, dyn_error_t dyn_err, err_t err)
     int n;
     char *errstr = err ? dn_strerror(err) : "unknown";
     char *protstr = conn->data_store == DATA_REDIS ? "-ERR" : "SERVER_ERROR";
-    char *source;
-
-    if ((dyn_err == PEER_CONNECTION_REFUSE) ||
-        (dyn_err == NO_QUORUM_ACHIEVED)) {
-        source = "Peer:";
-    } else if (dyn_err == STORAGE_CONNECTION_REFUSE) {
-        source = "Storage:";
-    }
+    char *source = dyn_error_source(dyn_err);
 
     msg = _msg_get(conn, __FUNCTION__);
     if (msg == NULL) {

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -205,15 +205,28 @@ typedef enum dyn_error {
     UNKNOWN_ERROR,
     PEER_CONNECTION_REFUSE,
     STORAGE_CONNECTION_REFUSE,
-    BAD_FORMAT
+    BAD_FORMAT,
+    NO_QUORUM_ACHIEVED,
 } dyn_error_t;
 
+static inline char *
+dn_strerror(dyn_error_t err)
+{
+    switch(err)
+    {
+        case NO_QUORUM_ACHIEVED:
+            return "Failed to achieve Quorum";
+        default:
+            return strerror(err);
+    }
+}
 /* This is a wrong place for this typedef. But adding to core has some
  * dependency issues - FixIt someother day :(
  */
 typedef enum consistency {
     DC_ONE = 0,
-    DC_QUORUM = 1
+    DC_QUORUM,
+    DC_SAFE_QUORUM,
 } consistency_t;
 
 static inline char*
@@ -223,6 +236,7 @@ get_consistency_string(consistency_t cons)
     {
         case DC_ONE: return "DC_ONE";
         case DC_QUORUM: return "DC_QUORUM";
+        case DC_SAFE_QUORUM: return "DC_SAFE_QUORUM";
     }
     return "INVALID CONSISTENCY";
 }

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -220,6 +220,22 @@ dn_strerror(dyn_error_t err)
             return strerror(err);
     }
 }
+
+static inline char *
+dyn_error_source(dyn_error_t err)
+{
+    switch(err)
+    {
+        case NO_QUORUM_ACHIEVED:
+            return "Dynomite:";
+        case PEER_CONNECTION_REFUSE:
+            return "Peer:";
+        case STORAGE_CONNECTION_REFUSE:
+            return "Storage:";
+        default:
+            return "unknown:";
+    }
+}
 /* This is a wrong place for this typedef. But adding to core has some
  * dependency issues - FixIt someother day :(
  */

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -22,13 +22,13 @@ rspmgr_is_quourm_achieved(struct response_mgr *rspmgr)
         return false;
 
     uint32_t chk0, chk1, chk2;
-    chk0 = msg_payload_crc32(rspmgr->responses[0]);
-    chk1 = msg_payload_crc32(rspmgr->responses[1]);
+    chk0 = rspmgr->checksums[0];
+    chk1 = rspmgr->checksums[1];
     if (chk0 == chk1)
         return true;
     if (rspmgr->good_responses < 3)
         return false;
-    chk2 = msg_payload_crc32(rspmgr->responses[2]);
+    chk2 = rspmgr->checksums[2];
     if ((chk1 == chk2) || (chk0 == chk2))
         return true;
     return false;
@@ -88,6 +88,7 @@ rspmgr_incr_non_quorum_responses_stats(struct response_mgr *rspmgr)
                         client_non_quorum_w_responses);
 
 }
+
 struct msg*
 rspmgr_get_response(struct response_mgr *rspmgr)
 {
@@ -103,31 +104,24 @@ rspmgr_get_response(struct response_mgr *rspmgr)
         return rspmgr->err_rsp;
     }
 
-    if (rspmgr->good_responses < 3) {
-        log_debug(LOG_VERB, "req:%lu only %d responses, returning first",
-                  rspmgr->msg->id, rspmgr->good_responses);
-        return rspmgr->responses[0];
-    }
-
     ASSERT_LOG(rspmgr->good_responses == 3, "rspmgr req: %lu has %d good responses",
                rspmgr->msg->id, rspmgr->good_responses);
 
     uint32_t chk0, chk1, chk2;
-    chk0 = msg_payload_crc32(rspmgr->responses[0]);
-    chk1 = msg_payload_crc32(rspmgr->responses[1]);
+    chk0 = rspmgr->checksums[0];
+    chk1 = rspmgr->checksums[1];
     if (chk0 == chk1) {
         return rspmgr->responses[0];
-    } else {
-        chk2 = msg_payload_crc32(rspmgr->responses[2]);
+    } else if (rspmgr->good_responses == 3) {
+        chk2 = rspmgr->checksums[2];
         if (chk1 == chk2)
             return rspmgr->responses[1];
         else if (chk0 == chk2)
             return rspmgr->responses[0];
     }
     rspmgr_incr_non_quorum_responses_stats(rspmgr);
-    log_info("none of the responses match, returning first");
     if (log_loggable(LOG_DEBUG)) {
-        log_error("Message: ");
+        log_error("Request: ");
         msg_dump(rspmgr->msg);
     }
     if (log_loggable(LOG_VVERB)) {
@@ -135,10 +129,26 @@ rspmgr_get_response(struct response_mgr *rspmgr)
         msg_dump(rspmgr->responses[0]);
         log_error("Respone 1: ");
         msg_dump(rspmgr->responses[1]);
-        log_error("Respone 2: ");
-        msg_dump(rspmgr->responses[2]);
+        if (rspmgr->good_responses == 3) {
+            log_error("Respone 2: ");
+            msg_dump(rspmgr->responses[2]);
+        }
     }
-    return rspmgr->responses[0];
+    if (rspmgr->msg->consistency == DC_QUORUM) {
+        log_info("none of the responses match, returning first");
+        return rspmgr->responses[0];
+    } else {
+        log_info("none of the responses match, returning error");
+        struct msg *rsp = msg_get(rspmgr->conn, false, rspmgr->conn->data_store,
+                                  __FUNCTION__);
+        rsp->error = 1;
+        rsp->err = NO_QUORUM_ACHIEVED;
+        rsp->dyn_error = NO_QUORUM_ACHIEVED;
+        ASSERT(rspmgr->err_rsp == NULL);
+        rspmgr->err_rsp = rsp;
+        rspmgr->error_responses++;
+        return rsp;
+    }
 }
 
 void
@@ -171,7 +181,9 @@ rspmgr_submit_response(struct response_mgr *rspmgr, struct msg*rsp)
         else
             rsp_put(rsp);
     } else {
-        log_debug(LOG_VERB, "Good response %d:%d", rsp->id, rsp->parent_id);
+        rspmgr->checksums[rspmgr->good_responses] = msg_payload_crc32(rsp);
+        log_debug(LOG_VERB, "Good response %d:%d checksum %u", rsp->id,
+                  rsp->parent_id, rspmgr->checksums[rspmgr->good_responses]);
         rspmgr->responses[rspmgr->good_responses++] =  rsp;
     }
     msg_decr_awaiting_rsps(rspmgr->msg);

--- a/src/dyn_response_mgr.h
+++ b/src/dyn_response_mgr.h
@@ -8,8 +8,9 @@ struct response_mgr {
     /* we could use the dynamic array
        here. But we have only 3 ASGs */
     struct msg  *responses[MAX_REPLICAS_PER_DC];
-    uint8_t     good_responses;     // non-error responses received
-    uint8_t     max_responses;      // max responses expected
+    uint32_t    checksums[MAX_REPLICAS_PER_DC];
+    uint8_t     good_responses;     // non-error responses received. (nil) is not an error
+    uint8_t     max_responses;      // max responses expected.
     uint8_t     quorum_responses;   // responses expected to form a quorum
     uint8_t     error_responses;    // error responses received
     struct msg  *err_rsp;           // first error response

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -340,7 +340,7 @@ server_ack_err(struct context *ctx, struct conn *conn, struct msg *req)
     //ASSERT_LOG(!req->swallow, "req %d:%d has swallow set??", req->id, req->parent_id);
     if ((req->swallow && req->noreply) ||
         (req->swallow && (req->consistency == DC_ONE)) ||
-        (req->swallow && (req->consistency == DC_QUORUM)
+        (req->swallow && ((req->consistency == DC_QUORUM) || (req->consistency == DC_SAFE_QUORUM))
                       && (!conn->same_dc))) {
         log_info("close %s %d swallow req %"PRIu64" len %"PRIu32
                  " type %d", conn_get_type_string(conn), conn->sd, req->id,

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1045,18 +1045,22 @@ parse_request(int sd, struct stats_cmd *st_cmd)
                         char* type = op + 5;
                         log_notice("op: %s", op);
                         log_notice("type: %s", type);
-                        if (strcmp(type, "/dc_one") == 0)
+                        if (!dn_strcasecmp(type, "/"CONF_STR_DC_ONE))
                             g_read_consistency = DC_ONE;
-                        else if (strcmp(type, "/dc_quorum") == 0)
+                        else if (!dn_strcasecmp(type, "/"CONF_STR_DC_QUORUM))
                             g_read_consistency = DC_QUORUM;
+                        else if (!dn_strcasecmp(type, "/"CONF_STR_DC_SAFE_QUORUM))
+                            g_read_consistency = DC_SAFE_QUORUM;
                         else
                             st_cmd->cmd = CMD_UNKNOWN;
                     } else if (strncmp(op, "/write", 6) == 0) {
                         char* type = op + 6;
-                        if (strcmp(type, "/dc_one") == 0)
+                        if (!dn_strcasecmp(type, "/"CONF_STR_DC_ONE))
                             g_write_consistency = DC_ONE;
-                        else if (strcmp(type, "/dc_quorum") == 0)
+                        else if (!dn_strcasecmp(type, "/"CONF_STR_DC_QUORUM))
                             g_write_consistency = DC_QUORUM;
+                        else if (!dn_strcasecmp(type, "/"CONF_STR_DC_SAFE_QUORUM))
+                            g_write_consistency = DC_SAFE_QUORUM;
                         else
                             st_cmd->cmd = CMD_UNKNOWN;
                     } else


### PR DESCRIPTION
    o Implement safe quorum which essentially means that we fail a
request if the quorum responses do not match in checksums
    o Store checksums in response manager and compute them as we receive
responses, this is avoid duplicate computation that we had
    o the new option is DC_SAFE_QUORUM instead of DC_QUORUM_SAFE so that string comparison is
less error prone
    o Add new conf file to create a 3 rack cluster in test
    o Implement dn_strerror to get error string for dynomite specific errors
    o Added command options in dyn_stats