### PR TITLE
Fix Duplicate dnode headers while sending response to peers

### DIFF
--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -383,6 +383,9 @@ dnode_rsp_send_next(struct context *ctx, struct conn *conn)
 
         //need to deal with multi-block later
         uint64_t msg_id = pmsg->dmsg->id;
+        if (rsp->dnode_header_prepended) {
+            return rsp;
+        }
 
         struct mbuf *header_buf = mbuf_get();
         if (header_buf == NULL) {
@@ -424,6 +427,7 @@ dnode_rsp_send_next(struct context *ctx, struct conn *conn)
             dmsg_write(header_buf, msg_id, msg_type, conn, msg_length(rsp));
         }
 
+        rsp->dnode_header_prepended = 1;
         mbuf_insert_head(&rsp->mhdr, header_buf);
 
         if (log_loggable(LOG_VVERB)) {

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -323,6 +323,7 @@ done:
     msg->first_fragment = 0;
     msg->last_fragment = 0;
     msg->swallow = 0;
+    msg->dnode_header_prepended = 0;
     msg->rsp_sent = 0;
     msg->data_store = DATA_REDIS;
 

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -323,6 +323,12 @@ struct msg {
     unsigned             first_fragment:1;/* first fragment? */
     unsigned             last_fragment:1; /* last fragment? */
     unsigned             swallow:1;       /* swallow response? */
+    /* A hack here: We need a way in dnode_rsp_send_next to remmeber if we already
+     * did a dmsg_write of a dnode header in this message. If we do not remember it,
+     * then if the same message gets attempted to be sent twice in msg_send_chain,
+     * (due to lack of space in the previous attempt), we will prepend another header
+     * and we will have corrupted message at the destination */
+    unsigned             dnode_header_prepended:1;       /* swallow response? */
     unsigned             rsp_sent:1;      /* is a response sent for this request?*/
 
     int					 data_store;

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -323,12 +323,12 @@ struct msg {
     unsigned             first_fragment:1;/* first fragment? */
     unsigned             last_fragment:1; /* last fragment? */
     unsigned             swallow:1;       /* swallow response? */
-    /* A hack here: We need a way in dnode_rsp_send_next to remmeber if we already
+    /* We need a way in dnode_rsp_send_next to remember if we already
      * did a dmsg_write of a dnode header in this message. If we do not remember it,
      * then if the same message gets attempted to be sent twice in msg_send_chain,
      * (due to lack of space in the previous attempt), we will prepend another header
      * and we will have corrupted message at the destination */
-    unsigned             dnode_header_prepended:1;       /* swallow response? */
+    unsigned             dnode_header_prepended:1;
     unsigned             rsp_sent:1;      /* is a response sent for this request?*/
 
     int					 data_store;


### PR DESCRIPTION
    o Add a field in message to remember if we prepended a dnode header
while sending a response to peer
    o Check for this field before prepending the header