### PR TITLE
New latency metrics

### DIFF
--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -720,7 +720,7 @@ dnode_peer_close_socket(struct context *ctx, struct conn *conn)
         log_debug(LOG_VERB, "In dnode_peer_close_socket");
     }
 
-    if ((conn != NULL) && (conn->sd != -1)) {
+    if (conn != NULL) {
         status = close(conn->sd);
         if (status < 0) {
             log_error("dyn: close s %d failed, ignored: %s", conn->sd, strerror(errno));

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -272,7 +272,8 @@ done:
     msg->peer = NULL;
     msg->owner = NULL;
     msg->stime_in_microsec = 0L;
-    msg->remote_region_send_time = 0L;
+    msg->request_send_time = 0L;
+    msg->request_inqueue_enqueue_time_us = 0L;
     msg->awaiting_rsps = 0;
     msg->selected_rsp = NULL;
 

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -272,7 +272,8 @@ struct msg {
     struct msg           *peer;           /* message peer */
     struct conn          *owner;          /* message owner - client | server */
     int64_t              stime_in_microsec;  /* start time in microsec */
-    int64_t              remote_region_send_time; /* time in microsec when message sent to remote region */
+    int64_t              request_inqueue_enqueue_time_us; /* when message was enqueued in inqueue, either to a redis server or remote region or cross rack */
+    int64_t              request_send_time; /* when message was sent: either to a redis server or remote region or cross rack */
     uint8_t              awaiting_rsps;
     struct msg           *selected_rsp;
 

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -272,8 +272,8 @@ struct msg {
     struct msg           *peer;           /* message peer */
     struct conn          *owner;          /* message owner - client | server */
     int64_t              stime_in_microsec;  /* start time in microsec */
-    int64_t              request_inqueue_enqueue_time_us; /* when message was enqueued in inqueue, either to a redis server or remote region or cross rack */
-    int64_t              request_send_time; /* when message was sent: either to a redis server or remote region or cross rack */
+    int64_t              request_inqueue_enqueue_time_us; /* when message was enqueued in inqueue, either to the data store or remote region or cross rack */
+    int64_t              request_send_time; /* when message was sent: either to the data store or remote region or cross rack */
     uint8_t              awaiting_rsps;
     struct msg           *selected_rsp;
 

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -458,9 +458,10 @@ stats_create_bufs(struct stats *st)
 
     /* footer */
     size += 2;
+    // Accomodate for new fields that are directly added using stats_add_num_str
+    size += 1024;
 
     size = DN_ALIGN(size, DN_ALIGNMENT);
-
     st->buf.data = dn_alloc(size);
     if (st->buf.data == NULL) {
         log_error("create stats buffer of size %zu failed: %s", size,
@@ -513,6 +514,25 @@ stats_add_string(struct stats_buffer *buf, struct string *key, struct string *va
 
     buf->len += (size_t)n;
 
+    return DN_OK;
+}
+
+static rstatus_t
+stats_add_num_str(struct stats_buffer *buf, const char *key, int64_t val)
+{
+    uint8_t *pos;
+    size_t room;
+    int n;
+
+    pos = buf->data + buf->len;
+    room = buf->size - buf->len - 1;
+
+    n = dn_snprintf(pos, room, "\"%s\":%"PRId64",\n", key, val);
+    if (n < 0 || n >= (int)room) {
+        log_debug(LOG_ERR, "no room size:%u len %u", buf->size, buf->len);
+        return DN_ERROR;
+    }
+    buf->len += (size_t)n;
     return DN_OK;
 }
 
@@ -580,8 +600,33 @@ stats_add_header(struct stats *st)
                  (int64_t)st->payload_size_histo.val_95th));
     THROW_STATUS(stats_add_num(&st->buf, &st->payload_size_mean_str,
                  (int64_t)st->payload_size_histo.mean));
-    THROW_STATUS(stats_add_num(&st->buf, &st->cross_region_avg_rtt,
-                 (int64_t)st->cross_region_histo.mean));
+
+    THROW_STATUS(stats_add_num_str(&st->buf, "average_cross_region_rtt",
+                                   (int64_t)st->cross_region_latency_histo.mean));
+    THROW_STATUS(stats_add_num_str(&st->buf, "99_cross_region_rtt",
+                                   (int64_t)st->cross_region_latency_histo.val_99th));
+    THROW_STATUS(stats_add_num_str(&st->buf, "average_cross_zone_latency",
+                                   (int64_t)st->cross_zone_latency_histo.mean));
+    THROW_STATUS(stats_add_num_str(&st->buf, "99_cross_zone_latency",
+                                   (int64_t)st->cross_zone_latency_histo.val_99th));
+    THROW_STATUS(stats_add_num_str(&st->buf, "average_server_latency",
+                                   (int64_t)st->server_latency_histo.mean));
+    THROW_STATUS(stats_add_num_str(&st->buf, "99_server_latency",
+                                   (int64_t)st->server_latency_histo.val_99th));
+
+    THROW_STATUS(stats_add_num_str(&st->buf, "average_cross_region_queue_wait",
+                                   (int64_t)st->cross_region_queue_wait_time_histo.mean));
+    THROW_STATUS(stats_add_num_str(&st->buf, "99_cross_region_queue_wait",
+                                   (int64_t)st->cross_region_queue_wait_time_histo.val_99th));
+    THROW_STATUS(stats_add_num_str(&st->buf, "average_cross_zone_queue_wait",
+                                   (int64_t)st->cross_zone_queue_wait_time_histo.mean));
+    THROW_STATUS(stats_add_num_str(&st->buf, "99_cross_zone_queue_wait",
+                                   (int64_t)st->cross_zone_queue_wait_time_histo.val_99th));
+    THROW_STATUS(stats_add_num_str(&st->buf, "average_server_queue_wait",
+                                   (int64_t)st->server_queue_wait_time_histo.mean));
+    THROW_STATUS(stats_add_num_str(&st->buf, "99_server_queue_wait",
+                                   (int64_t)st->server_queue_wait_time_histo.val_99th));
+
     THROW_STATUS(stats_add_num(&st->buf, &st->client_out_queue_99,
                  (int64_t)st->client_out_queue.val_99th));
     THROW_STATUS(stats_add_num(&st->buf, &st->server_in_queue_99,
@@ -598,8 +643,6 @@ stats_add_header(struct stats *st)
                  (int64_t)st->remote_peer_out_queue.val_99th));
     THROW_STATUS(stats_add_num(&st->buf, &st->remote_peer_in_queue_99,
                  (int64_t)st->remote_peer_in_queue.val_99th));
-    THROW_STATUS(stats_add_num(&st->buf, &st->cross_region_99_rtt,
-                 (int64_t)st->cross_region_histo.val_99th));
     THROW_STATUS(stats_add_num(&st->buf, &st->alloc_msgs_str,
                  (int64_t)st->alloc_msgs));
     THROW_STATUS(stats_add_num(&st->buf, &st->free_msgs_str,
@@ -767,7 +810,15 @@ stats_aggregate(struct stats *st)
         st->reset_histogram = 0;
         histo_reset(&st->latency_histo);
         histo_reset(&st->payload_size_histo);
-        histo_reset(&st->cross_region_histo);
+
+        histo_reset(&st->server_latency_histo);
+        histo_reset(&st->cross_zone_latency_histo);
+        histo_reset(&st->cross_region_latency_histo);
+
+        histo_reset(&st->server_queue_wait_time_histo);
+        histo_reset(&st->cross_zone_queue_wait_time_histo);
+        histo_reset(&st->cross_region_queue_wait_time_histo);
+
         histo_reset(&st->server_in_queue);
         histo_reset(&st->server_out_queue);
         histo_reset(&st->client_out_queue);
@@ -1478,7 +1529,15 @@ stats_create(uint16_t stats_port, char *stats_ip, int stats_interval,
 
     histo_init(&st->latency_histo);
     histo_init(&st->payload_size_histo);
-    histo_init(&st->cross_region_histo);
+
+    histo_init(&st->server_latency_histo);
+    histo_init(&st->cross_zone_latency_histo);
+    histo_init(&st->cross_region_latency_histo);
+
+    histo_init(&st->server_queue_wait_time_histo);
+    histo_init(&st->cross_zone_queue_wait_time_histo);
+    histo_init(&st->cross_region_queue_wait_time_histo);
+
     histo_init(&st->client_out_queue);
     histo_init(&st->server_in_queue);
     histo_init(&st->server_out_queue);
@@ -1567,7 +1626,14 @@ stats_swap(struct stats *st)
     histo_compute(&st->latency_histo);
 
     histo_compute(&st->payload_size_histo);
-    histo_compute(&st->cross_region_histo);
+
+    histo_compute(&st->server_latency_histo);
+    histo_compute(&st->cross_zone_latency_histo);
+    histo_compute(&st->cross_region_latency_histo);
+
+    histo_compute(&st->server_queue_wait_time_histo);
+    histo_compute(&st->cross_zone_queue_wait_time_histo);
+    histo_compute(&st->cross_region_queue_wait_time_histo);
 
     histo_compute(&st->client_out_queue);
     histo_compute(&st->server_in_queue);

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -253,7 +253,14 @@ struct stats {
     volatile bool             reset_histogram;
     volatile struct histogram latency_histo;
     volatile struct histogram payload_size_histo;
-    volatile struct histogram cross_region_histo;
+
+    volatile struct histogram server_latency_histo;
+    volatile struct histogram cross_zone_latency_histo;
+    volatile struct histogram cross_region_latency_histo;
+
+    volatile struct histogram server_queue_wait_time_histo;
+    volatile struct histogram cross_zone_queue_wait_time_histo;
+    volatile struct histogram cross_region_queue_wait_time_histo;
 
     volatile struct histogram client_out_queue;
     volatile struct histogram server_in_queue;


### PR DESCRIPTION
* New histograms to track time a message spends in queue of server,
local peer and remote peer
* Another set of histograms to track when a response is processed
for a given request. Note: this is not a network delay but the overall
processing delay