### PR TITLE
Fix latency spike during connection failures

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -656,57 +656,84 @@ static void
 admin_local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
                         struct rack *rack, uint8_t *key, uint32_t keylen)
 {
-    struct conn *p_conn;
-
     ASSERT((c_conn->type == CONN_CLIENT) ||
            (c_conn->type == CONN_DNODE_PEER_CLIENT));
 
-    p_conn = dnode_peer_pool_conn(ctx, c_conn->owner, rack, key, keylen, msg->msg_type);
+    struct server *peer = dnode_peer_pool_server(ctx, c_conn->owner, rack, key, keylen, msg->msg_type);
+    if (!peer->is_local) {
+        send_rsp_integer(ctx, c_conn, msg);
+        return;
+    }
+
+    struct conn *p_conn = dnode_peer_pool_server_conn(ctx, peer);
     if (p_conn == NULL) {
         c_conn->err = EHOSTDOWN;
         req_forward_error(ctx, c_conn, msg, c_conn->err);
         return;
     }
 
-    struct server *peer = p_conn->owner;
-
-    if (peer->is_local) {
-        send_rsp_integer(ctx, c_conn, msg);
-    } else {
-        log_debug(LOG_NOTICE, "Need to delete [%.*s] ", keylen, key);
-        local_req_forward(ctx, c_conn, msg, key, keylen);
-    }
+    log_debug(LOG_NOTICE, "Need to delete [%.*s] ", keylen, key);
+    local_req_forward(ctx, c_conn, msg, key, keylen);
 }
 
 void
 remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg, 
-                        struct rack *rack, uint8_t *key, uint32_t keylen)
+                   struct rack *rack, uint8_t *key, uint32_t keylen)
 {
-    struct conn *p_conn;
-
     ASSERT((c_conn->type == CONN_CLIENT) ||
            (c_conn->type == CONN_DNODE_PEER_CLIENT));
 
-    p_conn = dnode_peer_pool_conn(ctx, c_conn->owner, rack, key, keylen, msg->msg_type);
-    if (p_conn == NULL) {
-        c_conn->err = EHOSTDOWN;
-        req_forward_error(ctx, c_conn, msg, c_conn->err);
-        return;
-    }
-
-    //jeb - check if s_conn is _this_ node, and if so, get conn from server_pool_conn instead
-    struct server *peer = p_conn->owner;
-
+    struct server * peer = dnode_peer_pool_server(ctx, c_conn->owner, rack, key,
+                                                  keylen, msg->msg_type);
     if (peer->is_local) {
         log_debug(LOG_VERB, "c_conn: %p forwarding %d:%d is local", c_conn,
                   msg->id, msg->parent_id);
         local_req_forward(ctx, c_conn, msg, key, keylen);
         return;
-    } else {
-        log_debug(LOG_VERB, "c_conn: %p forwarding %d:%d to p_conn %p", c_conn,
-                  msg->id, msg->parent_id, p_conn);
-        dnode_peer_req_forward(ctx, c_conn, p_conn, msg, rack, key, keylen);
     }
+
+    // now get a peer connection
+    struct conn *p_conn = dnode_peer_pool_server_conn(ctx, peer);
+    if ((p_conn == NULL) || (p_conn->connecting)) {
+        if (p_conn) {
+            int64_t now = dn_usec_now();
+            static int64_t next_log = 0; // Log every 1 sec
+            if (now > next_log) {
+                log_warn("still connecting");
+                next_log = now + 1000 * 1000;
+            }
+        }
+        // No response for DC_ONE & swallow
+        if ((msg->consistency == DC_ONE) && (msg->swallow)) {
+            msg_put(msg);
+            return;
+        }
+        // No response for remote dc
+        struct server_pool *pool = c_conn->owner;
+        bool same_dc = is_same_dc(pool, peer)? 1 : 0;
+        if (!same_dc) {
+            msg_put(msg);
+            return;
+        }
+        // All other cases return a response
+        //log_warn("Directly sending a response");
+        struct msg *rsp = msg_get(c_conn, false, c_conn->data_store, __FUNCTION__);
+        msg->done = 1;
+        rsp->error = msg->error = 1;
+        rsp->err = msg->err = PEER_HOST_DOWN;
+        rsp->dyn_error = msg->dyn_error = PEER_HOST_DOWN;
+        rsp->dmsg = dmsg_get();
+        rsp->dmsg->id =  msg->id;
+        client_handle_response(c_conn, msg->parent_id ? msg->parent_id : msg->id,
+                               rsp);
+        if (msg->swallow)
+            msg_put(msg);
+        return;
+    }
+
+    log_debug(LOG_VERB, "c_conn: %p forwarding %d:%d to p_conn %p", c_conn,
+            msg->id, msg->parent_id, p_conn);
+    dnode_peer_req_forward(ctx, c_conn, p_conn, msg, rack, key, keylen);
 }
 
 static void

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -699,7 +699,8 @@ remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
             int64_t now = dn_usec_now();
             static int64_t next_log = 0; // Log every 1 sec
             if (now > next_log) {
-                log_warn("still connecting");
+                log_warn("still connecting to peer '%.*s'......",
+                         peer->pname.len, peer->pname.data);
                 next_log = now + 1000 * 1000;
             }
         }

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -249,6 +249,7 @@ conf_server_each_transform(void *elem, void *data)
     TAILQ_INIT(&s->s_conn_q);
 
     s->next_retry = 0LL;
+    s->reconnect_backoff_factor = 1LL;
     s->failure_count = 0;
 
     log_debug(LOG_VERB, "transform to server %"PRIu32" '%.*s'",
@@ -298,6 +299,7 @@ conf_seed_each_transform(void *elem, void *data)
     TAILQ_INIT(&s->s_conn_q);
 
     s->next_retry = 0LL;
+    s->reconnect_backoff_factor = 1LL;
     s->failure_count = 0;
 
     s->processed = 0;

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -236,6 +236,7 @@ struct server {
     struct conn_tqh    s_conn_q;      /* server connection q */
 
     int64_t            next_retry;    /* next retry time in usec */
+    int64_t            reconnect_backoff_factor; /* backoff mulitplier */
     uint32_t           failure_count; /* # consecutive failures */
 
     struct string      rack;          /* logical rack */

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -397,7 +397,7 @@ dnode_peer_connect(struct context *ctx, struct server *server, struct conn *conn
         status = DN_ERROR;
         goto error;
     }
-    log_debug(LOG_WARN, "dnode: connected to peer '%.*s' on p %d", server->pname.len,
+    log_debug(LOG_WARN, "dnode: connecting to peer '%.*s' on p %d", server->pname.len,
             server->pname.data, conn->sd);
 
 
@@ -1277,7 +1277,7 @@ dnode_peer_pool_server_conn(struct context *ctx, struct server *server)
         } else {
             if (now > next_log) {
                 log_warn("Detecting peer '%.*s' is set with state Down",
-                         server->name.len, server->name.data);
+                         server->pname.len, server->pname.data);
                 next_log = now + 1000 * 1000;
             }
             return NULL;

--- a/src/dyn_dnode_peer.h
+++ b/src/dyn_dnode_peer.h
@@ -17,10 +17,12 @@ rstatus_t dnode_peer_init(struct array *server_pool, struct context *ctx);
 void dnode_peer_deinit(struct array *nodes);
 void dnode_peer_connected(struct context *ctx, struct conn *conn);
 
-struct conn *dnode_peer_pool_conn(struct context *ctx, struct server_pool *pool, struct rack *rack, uint8_t *key, uint32_t keylen, uint8_t msg_type);
+struct server *dnode_peer_pool_server(struct context *ctx, struct server_pool *pool, struct rack *rack, uint8_t *key, uint32_t keylen, uint8_t msg_type);
+struct conn *dnode_peer_pool_server_conn(struct context *ctx, struct server *server);
 rstatus_t dnode_peer_pool_preconnect(struct context *ctx);
 //rstatus_t dnode_peer_pool_init(struct array *server_pool, struct array *conf_pool, struct context *ctx);
 //void dnode_peer_pool_deinit(struct array *server_pool);
+bool is_same_dc(struct server_pool *sp, struct server *peer_node);
 
 
 rstatus_t dnode_peer_forward_state(void *rmsg);

--- a/src/dyn_dnode_peer.h
+++ b/src/dyn_dnode_peer.h
@@ -9,7 +9,8 @@
 #ifndef _DYN_DNODE_PEER_H_
 #define _DYN_DNODE_PEER_H_
 
-#define WAIT_BEFORE_RECONNECT_IN_MILLIS      30000
+#define WAIT_BEFORE_RECONNECT_IN_MILLIS      1000
+#define MAX_WAIT_BEFORE_RECONNECT_IN_MILLIS  10000
 #define WAIT_BEFORE_UPDATE_PEERS_IN_MILLIS   30000
 
 int dnode_peer_timeout(struct msg *msg, struct conn *conn);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -256,9 +256,9 @@ _msg_get(struct conn *conn, const char *const caller)
 
     alloc_msg_count++;
 
-
-    log_warn("alloc_msg_count: %lu caller: %s conn: %s sd: %d",
-             alloc_msg_count, caller, conn_get_type_string(conn), conn->sd);
+    if (alloc_msg_count % 1000 == 0)
+        log_warn("alloc_msg_count: %lu caller: %s conn: %s sd: %d",
+                 alloc_msg_count, caller, conn_get_type_string(conn), conn->sd);
 
     msg = dn_alloc(sizeof(*msg));
     if (msg == NULL) {

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -204,6 +204,7 @@ typedef enum msg_type {
 typedef enum dyn_error {
     UNKNOWN_ERROR,
     PEER_CONNECTION_REFUSE,
+    PEER_HOST_DOWN,
     STORAGE_CONNECTION_REFUSE,
     BAD_FORMAT,
     NO_QUORUM_ACHIEVED,
@@ -216,6 +217,8 @@ dn_strerror(dyn_error_t err)
     {
         case NO_QUORUM_ACHIEVED:
             return "Failed to achieve Quorum";
+        case PEER_HOST_DOWN:
+            return "Peer Node is down";
         default:
             return strerror(err);
     }
@@ -229,6 +232,7 @@ dyn_error_source(dyn_error_t err)
         case NO_QUORUM_ACHIEVED:
             return "Dynomite:";
         case PEER_CONNECTION_REFUSE:
+        case PEER_HOST_DOWN:
             return "Peer:";
         case STORAGE_CONNECTION_REFUSE:
             return "Storage:";

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -565,15 +565,14 @@ server_ok(struct context *ctx, struct conn *conn)
     ASSERT(conn->type == CONN_SERVER);
 	ASSERT(conn->connected);
 
-	if (server->failure_count != 0) {
-           if (log_loggable(LOG_VERB)) {
-		   log_debug(LOG_VERB, "reset server '%.*s' failure count from %"PRIu32
-				 " to 0", server->pname.len, server->pname.data,
-				 server->failure_count);
-           }
-           server->failure_count = 0;
-           server->next_retry = 0LL;
-	}
+    if (log_loggable(LOG_VERB)) {
+        log_debug(LOG_VERB, "reset server '%.*s' failure count from %"PRIu32
+                " to 0", server->pname.len, server->pname.data,
+                server->failure_count);
+    }
+    server->failure_count = 0;
+    server->next_retry = 0LL;
+    server->reconnect_backoff_factor = 1LL;
 }
 
 static rstatus_t

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -284,10 +284,10 @@ server_failure(struct context *ctx, struct server *server)
 
 	next = now + pool->server_retry_timeout;
 
-	log_debug(LOG_INFO, "update pool %"PRIu32" '%.*s' to delete server '%.*s' "
-			"for next %"PRIu32" secs", pool->idx, pool->name.len,
-			pool->name.data, server->pname.len, server->pname.data,
-			pool->server_retry_timeout / 1000 / 1000);
+	log_info("update pool %"PRIu32" '%.*s' to delete server '%.*s' "
+			 "for next %"PRIu32" secs", pool->idx, pool->name.len,
+			 pool->name.data, server->pname.len, server->pname.data,
+			 pool->server_retry_timeout / 1000 / 1000);
 
 	stats_pool_incr(ctx, pool, server_ejects);
 

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -63,6 +63,7 @@
     ACTION( peer_request_bytes,           STATS_COUNTER,      "total peer request bytes")                                 \
     ACTION( peer_responses,               STATS_COUNTER,      "# peer respones")                                          \
     ACTION( peer_response_bytes,          STATS_COUNTER,      "total peer response bytes")                                \
+    ACTION( peer_ejected_at,              STATS_TIMESTAMP,    "timestamp when peer was ejected in usec since epoch")      \
     ACTION( peer_ejects,                  STATS_COUNTER,      "# times a peer was ejected")                               \
     ACTION( peer_in_queue,                STATS_GAUGE,        "# local dc peer requests in incoming queue")                        \
     ACTION( remote_peer_in_queue,         STATS_GAUGE,        "# remote dc peer requests in incoming queue")                        \


### PR DESCRIPTION
Fix latency spike during connection failures
    The issue was when a connection is not there, because a peer node is
down, we were queuing up the messages till they would timeout and fail
eventually. This would lead to higher overall average latency and much
higher 99th latencies. The solution is to not queue up messages and fail
the requests till there is a good connection
    o Drop the messages and respond with error immediately when a
connection is not available
    o Do the same when the connection is in a connecting state
    o Split the dnode_peer_conn into 2 functions to get the peer server
and then to get a connection to it
    o Mark the node as down after some failure attempts. Implement exponential backoff upto 10 secs to reconnect to peer