### PR TITLE
An important patch for a few things

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -728,10 +728,11 @@ remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
         rsp->dyn_error = msg->dyn_error = (p_conn ? PEER_HOST_NOT_CONNECTED:
                                                     PEER_HOST_DOWN);
         rsp->dmsg = dmsg_get();
+        rsp->peer = msg;
         rsp->dmsg->id =  msg->id;
         log_info("%lu:%lu <-> %lu:%lu Short circuit....", msg->id, msg->parent_id, rsp->id, rsp->parent_id);
-        client_handle_response(c_conn, msg->parent_id ? msg->parent_id : msg->id,
-                               rsp);
+        conn_handle_response(c_conn, msg->parent_id ? msg->parent_id : msg->id,
+                             rsp);
         if (msg->swallow)
             msg_put(msg);
         return;

--- a/src/dyn_crypto.c
+++ b/src/dyn_crypto.c
@@ -406,7 +406,7 @@ dyn_aes_encrypt_msg(struct msg *msg, unsigned char *aes_key)
             return DN_ERROR;
         }
 
-        int n = dyn_aes_encrypt(mbuf->start, mbuf->last - mbuf->start, nbuf, aes_key);
+        int n = dyn_aes_encrypt(mbuf->pos, mbuf->last - mbuf->pos, nbuf, aes_key);
         if (n > 0)
             count += n;
 

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -374,6 +374,52 @@ dnode_rsp_send_next(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
 
+    // SMB: There is some non trivial thing happening here. And I think it is very
+    // important to read this before anything is changed in here. There is also a
+    // bug that exists which I will mention briefly:
+    // A message is a structure that has a list of mbufs which hold the actual data.
+    // Each mbuf has start, pos, last as pointers (amongst others) which indicate start of the
+    // buffer, current read position and end of the buffer respectively.
+    //
+    // Every time a message is sent to a peer within dynomite, a DNODE header is
+    // prepended which is created using dmsg_write. A message remembers this case
+    // in dnode_header_prepended, so that if the messsage is sent in parts, the
+    // header is not prepended again for the subsequent parts.
+    //
+    // Like I said earlier there is a pos pointer in mbuf. If a message is sent
+    // partially (or it is parsed partially too I think) the pos reflects that
+    // case such that things can be resumed where it left off.
+    //
+    // dmsg_write has a parameter which reflects the payload length following the
+    // dnode header calculated by msg_length. msg_length is a summation of all
+    // mbuf sizes (last - start). Which I think is wrong.
+    //
+    // +------------+           +---------------+
+    // |    DC1N1   +---------> |     DC2N1     |
+    // +------------+           +-------+-------+
+    //                                  |
+    //                                  |
+    //                                  |
+    //                                  |
+    //                          +-------v-------+
+    //                          |    DC2N2      |
+    //                          +---------------+
+    //
+    // Consider the case where
+    // a node DC1N1 in region DC1 sends a request to DC2N1 which forwards it to
+    // to local token owner DC2N2. Now DC2N1 receives a response from DC2N2 which
+    // has to be relayed back to DC1N1. This response from DC2N2 already has a
+    // dnode header but for the link between DC2N1 and DC2N2. DC2N1 should strip
+    // this header and prepend its own header for sending it back to DC1N1. This
+    // gets handled in encryption case since we overwrite all mbufs in the response
+    // However if the encryption is off, the message length sent to dmsg_write
+    // consists of the header from DC2N2 also which is wrong. So this relaying
+    // of responses will not work for the case where encryption is disabled.
+    //
+    // So msg_length should really be from mbuf->pos and not mbuf->start. This
+    // is a problem only with remote region replication since that is the only
+    // case where we CAN have 2 hops to send the request/response. This is also
+    // not a problem if encryption is ON.
     ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
 
     struct msg *rsp = rsp_send_next(ctx, conn);

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -486,6 +486,7 @@ dnode_peer_ack_err(struct context *ctx, struct conn *conn, struct msg *req)
     // an error path its ok with the overhead.
     struct msg *rsp = msg_get(conn, false, conn->data_store, __FUNCTION__);
     req->done = 1;
+    rsp->peer = req;
     rsp->error = req->error = 1;
     rsp->err = req->err = conn->err;
     rsp->dyn_error = req->dyn_error = PEER_CONNECTION_REFUSE;

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -92,6 +92,10 @@ dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
     struct server_pool *pool = c_conn->owner;
     dmsg_type_t msg_type = (string_compare(&pool->dc, dc) != 0)? DMSG_REQ_FORWARD : DMSG_REQ;
 
+    // SMB: THere is some non trivial business happening here. Better refer to the
+    // comment in dnode_rsp_send_next to understand the stuff here.
+    // Note: THere MIGHT BE A NEED TO PORT THE dnode_header_prepended FIX FROM THERE
+    // TO HERE. especially when a message is being sent in parts
     if (p_conn->dnode_secured) {
         //Encrypting and adding header for a request
         if (log_loggable(LOG_VVERB)) {


### PR DESCRIPTION
    o Set peer pointers appropriately at multiple places
    o Call conn_handle_response instead of client_handle_response
directly
    o Fix Replication for 2 Hop case when we reroute replication to
remote DC to a different node