### PR TITLE
Hash table in dnode client code

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,6 +37,7 @@ dynomite_SOURCES =			                          \
         dyn_core.c dyn_core.h                                     \
         dyn_connection.c dyn_connection.h                         \
         dyn_client.c dyn_client.h                                 \
+        dyn_dict_msg_id.h dyn_dict_msg_id.c                       \
         dyn_dnode_client.h dyn_dnode_client.c                     \
         dyn_dnode_msg.c dyn_dnode_msg.h                           \
         dyn_dnode_peer.c  dyn_dnode_peer.h                        \
@@ -82,6 +83,7 @@ dynomite_test_SOURCES =                                           \
         dyn_core.c dyn_core.h                                     \
         dyn_connection.c dyn_connection.h                         \
         dyn_client.c dyn_client.h                                 \
+        dyn_dict_msg_id.h dyn_dict_msg_id.c                       \
         dyn_dnode_client.h dyn_dnode_client.c                     \
         dyn_dnode_msg.c dyn_dnode_msg.h                           \
         dyn_dnode_peer.c  dyn_dnode_peer.h                        \

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -46,34 +46,11 @@
 #include "dyn_server.h"
 #include "dyn_client.h"
 #include "dyn_dnode_peer.h"
+#include "dyn_dict_msg_id.h"
 
 static rstatus_t msg_quorum_rsp_handler(struct msg *req, struct msg *rsp);
 static rstatus_t msg_local_one_rsp_handler(struct msg *req, struct msg *rsp);
 static msg_response_handler_t msg_get_rsp_handler(struct msg *req);
-
-static unsigned int
-dict_msg_id_hash(const void *key)
-{
-    msgid_t id = *(msgid_t*)key;
-    return dictGenHashFunction(key, sizeof(id));
-}
-
-static int
-dict_msg_id_cmp(void *privdata, const void *key1, const void *key2)
-{
-    msgid_t id1 = *(msgid_t*)key1;
-    msgid_t id2 = *(msgid_t*)key2;
-    return id1 == id2;
-}
-
-dictType msg_table_dict_type = {
-    dict_msg_id_hash,            /* hash function */
-    NULL,                        /* key dup */
-    NULL,                        /* val dup */
-    dict_msg_id_cmp,             /* key compare */
-    NULL,                        /* key destructor */
-    NULL                         /* val destructor */
-};
 
 
 static void

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -116,6 +116,13 @@ conn_get_type_string(struct conn *conn)
     return "INVALID";
 }
 
+bool
+conn_is_req_first_in_outqueue(struct conn *conn, struct msg *req)
+{
+    struct msg *first_req_in_outqueue = TAILQ_FIRST(&conn->omsg_q);
+    return req == first_req_in_outqueue;
+}
+
 /*
  * Return the context associated with this connection.
  */

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -208,4 +208,5 @@ void conn_init(void);
 void conn_deinit(void);
 void conn_print(struct conn *conn);
 
+bool conn_is_req_first_in_outqueue(struct conn *conn, struct msg *req);
 #endif

--- a/src/dyn_dict_msg_id.c
+++ b/src/dyn_dict_msg_id.c
@@ -1,0 +1,29 @@
+#include <libio.h> // For NULL
+#include "dyn_types.h"
+#include "dyn_dict_msg_id.h"
+
+static unsigned int
+dict_msg_id_hash(const void *key)
+{
+    msgid_t id = *(msgid_t*)key;
+    return dictGenHashFunction(key, sizeof(id));
+}
+
+static int
+dict_msg_id_cmp(void *privdata, const void *key1, const void *key2)
+{
+    msgid_t id1 = *(msgid_t*)key1;
+    msgid_t id2 = *(msgid_t*)key2;
+    return id1 == id2;
+}
+
+dictType msg_table_dict_type = {
+    dict_msg_id_hash,            /* hash function */
+    NULL,                        /* key dup */
+    NULL,                        /* val dup */
+    dict_msg_id_cmp,             /* key compare */
+    NULL,                        /* key destructor */
+    NULL                         /* val destructor */
+};
+
+

--- a/src/dyn_dict_msg_id.h
+++ b/src/dyn_dict_msg_id.h
@@ -1,0 +1,3 @@
+#include "dyn_dict.h"
+
+extern dictType msg_table_dict_type;

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -918,8 +918,7 @@ server_rsp_forward(struct context *ctx, struct conn *s_conn, struct msg *rsp)
     // this should really be the message's response handler be doing it
     if (req_done(c_conn, req)) {
         // handler owns the response now
-        status = conn_handle_response(c_conn, c_conn->type == CONN_CLIENT ?
-                                      req->id : req->parent_id, rsp);
+        status = conn_handle_response(c_conn, req->id, rsp);
         IGNORE_RET_VAL(status);
      }
 }

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdint.h>
 typedef uint64_t msgid_t;
 typedef uint64_t msec_t;
 typedef uint64_t usec_t;


### PR DESCRIPTION
* Like client, dnode client maintains a hash table of pending
requests. This helps in keeping the interface clean
* This will help removing the dependency on peer pointer etc and
simplify the code