### PR TITLE
add mac macro for NULL. fixes build on mac

### DIFF
--- a/src/dyn_dict_msg_id.c
+++ b/src/dyn_dict_msg_id.c
@@ -1,4 +1,12 @@
-#include <libio.h> // For NULL
+#ifdef __APPLE__
+// http://clc-wiki.net/wiki/C_standard_library:string.h:NULL
+// Portable C90 version: NULL ((void*)0)
+# ifndef NULL
+#  define NULL 0
+# endif
+#else
+# include <libio.h> // For NULL
+#endif
 #include "dyn_types.h"
 #include "dyn_dict_msg_id.h"
 


### PR DESCRIPTION
The `src/dyn_dict_msg_id.c` file was created approx. 10 days ago and it uses `NULL` from `libio.h`. 

It appears that `libio.h` is no longer available on the Mac. As a result, Dynomite builds on Mac were failing.

I fixed the Mac build by adding a macro for `NULL` when building dynomite on a Mac.