### PR TITLE
fix verbosity long option (source code change); add new doxygen comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,22 @@ To build Dynomite in _debug mode_:
                       [-M max alloc messages]
 
     Options:
-      -h, --help             : this help
-      -V, --version          : show version and exit
-      -t, --test-conf        : test configuration for syntax errors and exit
-      -d, --daemonize        : run as a daemon
-      -D, --describe-stats   : print stats description and exit
-      -v, --verbosity=N      : set logging level (default: 5, min: 0, max: 11)
-      -o, --output=S         : set logging file (default: stderr)
-      -c, --conf-file=S      : set configuration file (default: conf/dynomite.yml)
-      -s, --stats-port=N     : set stats monitoring port (default: 22222)
-      -a, --stats-addr=S     : set stats monitoring ip (default: 0.0.0.0)
-      -i, --stats-interval=N : set stats aggregation interval in msec (default: 30000 msec)
-      -p, --pid-file=S       : set pid file (default: off)
-      -m, --mbuf-size=N      : set size of mbuf chunk in bytes (default: 16384 bytes)
-      -M, --max-msgs=N       : set max number of messages to allocate (default: 200000)
+      -h, --help              : this help
+      -V, --version           : show version and exit
+      -t, --test-conf         : test configuration for syntax errors and exit
+      -g, --gossip            : enable gossip (default: disabled)
+      -d, --daemonize         : run as a daemon
+      -D, --describe-stats    : print stats description and exit
+      -v, --verbosity=N       : set logging level (default: 5, min: 0, max: 11)
+      -o, --output=S          : set logging file (default: stderr)
+      -c, --conf-file=S       : set configuration file (default: conf/dynomite.yml)
+      -s, --stats-port=N      : set stats monitoring port (default: 22222)
+      -a, --stats-addr=S      : set stats monitoring ip (default: 0.0.0.0)
+      -i, --stats-interval=N  : set stats aggregation interval in msec (default: 30000 msec)
+      -p, --pid-file=S        : set pid file (default: off)
+      -m, --mbuf-size=N       : set size of mbuf chunk in bytes (default: 16384 bytes)
+      -M, --max-msgs=N        : set max number of messages to allocate (default: 200000)
+      -x, --admin-operation=N : set size of admin operation (default: 0)
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To build Dynomite in _debug mode_:
       -i, --stats-interval=N : set stats aggregation interval in msec (default: 30000 msec)
       -p, --pid-file=S       : set pid file (default: off)
       -m, --mbuf-size=N      : set size of mbuf chunk in bytes (default: 16384 bytes)
-      -M, --max-msgs=N       : set max number of messages to allocate (default: 2000000)
+      -M, --max-msgs=N       : set max number of messages to allocate (default: 200000)
 
 
 ## Configuration

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -775,6 +775,12 @@ request_send_to_all_dcs(struct msg *msg)
     return false;
 }
 
+/**
+ * Determine if a request should be forwarded to all replicas within the local
+ * DC.
+ * @param[in] msg Message.
+ * @return bool True if message should be forwarded to all local replicas, else false
+ */
 static bool
 request_send_to_all_local_racks(struct msg *msg)
 {

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -4,7 +4,6 @@
  * Copyright (C) 2014 Netflix, Inc.
  */ 
 
-
 /*
  * twemproxy - A fast and lightweight proxy for memcached protocol.
  * Copyright (C) 2011 Twitter, Inc.
@@ -22,6 +21,13 @@
  * limitations under the License.
  */
 
+/**
+ * @file dyn_conf.c
+ * @brief Dynomite configuration.
+ *
+ * Set default configuration values, parse dynomite.yaml, and update the various
+ * configuration structs including connections and server pool.
+ */
 #include "dyn_core.h"
 #include "dyn_conf.h"
 #include "dyn_server.h"
@@ -185,7 +191,12 @@ conf_datastore_transform(struct datastore *s, struct conf_server *cs)
     return DN_OK;
 }
 
-// Copy seed struct conf_server to struct server
+/**
+ * Copy seed struct conf_server to struct server
+ * @param elem conf_server
+ * @param data server
+ * @return rstatus_t Return status code.
+ */
 rstatus_t
 conf_seed_each_transform(void *elem, void *data)
 {
@@ -390,6 +401,13 @@ get_secure_server_option(struct string option)
     return SECURE_OPTION_NONE;
 }
 
+/**
+ * Copy connection pool configuration parsed from dynomite.yaml into the server
+ * pool.
+ * @param[in,out] sp Server pool.
+ * @param cp
+ * @return
+ */
 rstatus_t
 conf_pool_transform(struct server_pool *sp, struct conf_pool *cp)
 {

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -19,6 +19,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/**
+ * @file dyn_conf.h
+ * @brief Dynomite configuration (header).
+ *
+ * Set default configuration values, parse dynomite.yaml, and update the various
+ * configuration structs including connections and server pool.
+ */
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/un.h>
@@ -111,7 +119,7 @@ struct conf {
     char          *fname;           /* file name (ref in argv[]) */
     FILE          *fh;              /* file handle */
     struct array  arg;              /* string[] (parsed {key, value} pairs) */
-    struct conf_pool pool;             /* conf_pool[] (parsed pools) */
+    struct conf_pool pool;          /* conf_pool[] (parsed pools) */
     uint32_t      depth;            /* parsed tree depth */
     yaml_parser_t parser;           /* yaml parser */
     yaml_event_t  event;            /* yaml event */

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -200,6 +200,14 @@ struct conn *conn_get_peer(void *owner, bool client);
 struct conn *conn_get_dnode(void *owner);
 void conn_put(struct conn *conn);
 rstatus_t conn_listen(struct context *ctx, struct conn *p);
+
+/**
+ * Open an outgoing socket connection to either another Dynomite node or to a
+ * backend data store (such as Redis or ARDB).
+ * @param[in] ctx Dynomite server context.
+ * @param[in,out] conn Outbound socket connection.
+ * @return rstatus_t Return status code.
+ */
 rstatus_t conn_connect(struct context *ctx, struct conn *conn);
 
 ssize_t conn_recv_data(struct conn *conn, void *buf, size_t size);

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -173,7 +173,7 @@ core_stats_create(struct context *ctx)
 
 /**
  * Initialize crypto and create the Dynomite server performance statistics.
- * @param[in,out] ctx Context.
+ * @param[in,out] ctx Dynomite server context.
  * @return rstatus_t Return status code.
  */
 static rstatus_t
@@ -560,6 +560,9 @@ core_process_messages(void)
 		// Get an element from the beginning of the circular buffer
 		struct ring_msg *msg = (struct ring_msg *) CBUF_Pop(C2G_OutQ);
 		if (msg != NULL && msg->cb != NULL) {
+			// CBUF_Push
+			// ./src/dyn_dnode_msg.c
+			// ./src/dyn_gossip.c
 			msg->cb(msg);
 			core_debug(msg->sp->ctx);
 			ring_msg_deinit(msg);

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -185,10 +185,10 @@ struct instance {
     int             stats_interval;              /* stats aggregation interval */
     char            *stats_addr;                 /* stats monitoring addr */
     char            hostname[DN_MAXHOSTNAMELEN]; /* hostname */
-    uint16_t        entropy_port;                  /* send reconciliation port */
-    char            *entropy_addr;                 /* send reconciliation addr */
+    uint16_t        entropy_port;                /* send reconciliation port */
+    char            *entropy_addr;               /* send reconciliation addr */
     size_t          mbuf_chunk_size;             /* mbuf chunk size */
-    size_t			alloc_msgs_max;			 /* allocated messages buffer size */
+    size_t          alloc_msgs_max;              /* allocated messages buffer size */
     pid_t           pid;                         /* process id */
     char            *pid_filename;               /* pid filename */
     unsigned        pidfile:1;                   /* pid file created? */

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -966,7 +966,6 @@ dmsg_parse(struct dmsg *dmsg)
 
    struct server_pool *sp = (struct server_pool *) dmsg->owner->owner->owner;
    ring_msg->sp = sp;
-    // ASA 2nd potential callback dnode_peer_add()
 
    ring_msg->cb = gossip_msg_peer_update;
 

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -966,6 +966,8 @@ dmsg_parse(struct dmsg *dmsg)
 
    struct server_pool *sp = (struct server_pool *) dmsg->owner->owner->owner;
    ring_msg->sp = sp;
+    // ASA 2nd potential callback dnode_peer_add()
+
    ring_msg->cb = gossip_msg_peer_update;
 
    count = 0;

--- a/src/dyn_gossip.c
+++ b/src/dyn_gossip.c
@@ -551,7 +551,6 @@ gossip_add_node(struct server_pool *sp, struct string *dc, struct gossip_rack *g
     node_count++;
     gnode->state = state;
 
-    // ASA: 3rd param is callback
     status = gossip_msg_to_core(sp, gnode, dnode_peer_add);
     return status;
 }

--- a/src/dyn_gossip.c
+++ b/src/dyn_gossip.c
@@ -551,6 +551,7 @@ gossip_add_node(struct server_pool *sp, struct string *dc, struct gossip_rack *g
     node_count++;
     gnode->state = state;
 
+    // ASA: 3rd param is callback
     status = gossip_msg_to_core(sp, gnode, dnode_peer_add);
     return status;
 }

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -574,7 +574,7 @@ server_pool_init(struct server_pool *sp, struct conf_pool *cp, struct context *c
 	THROW_STATUS(conf_pool_transform(sp, cp));
 	sp->ctx = ctx;
     THROW_STATUS(server_pool_run(sp));
-	log_debug(LOG_DEBUG, "inited server pool");
+	log_debug(LOG_DEBUG, "Initialized server pool");
 	return DN_OK;
 }
 

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -74,7 +74,7 @@ static struct option long_options[] = {
     { "daemonize",            no_argument,        NULL,   'd' },
     { "describe-stats",       no_argument,        NULL,   'D' },
     { "gossip",               no_argument,        NULL,   'g' },
-    { "verbose",              required_argument,  NULL,   'v' },
+    { "verbosity",            required_argument,  NULL,   'v' },
     { "output",               required_argument,  NULL,   'o' },
     { "conf-file",            required_argument,  NULL,   'c' },
     { "stats-port",           required_argument,  NULL,   's' },
@@ -305,8 +305,8 @@ dn_remove_pidfile(struct instance *nci)
 }
 
 /**
- * Set the dynomite instance properties to the default values and get the
- * hostname.
+ * Set the dynomite instance properties to the default values, except the
+ * hostname which is set via gethostname().
  * @param nci dynomite instance
  */
 static void


### PR DESCRIPTION
- `verbosity` long option was `verbose` which did not match README. Updated long option to match documentation: https://github.com/DynomiteDB/dynomite/commit/6ccd73f5fd86413090f9abaacdf01af079542d4e
- `README`: `max-msgs` in README had an extra `0` in default value.
- `README`: was missing the `-g` and `-x` options.
- other updates are all code comments or minor reformatting, plus removed some of my reminder comments
