### PR TITLE
Hotfix/v0.5.8 2 local request by pass

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -895,6 +895,14 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
         }
     }
 
+    if (msg->msg_type) {
+        // Strictly local host only
+        msg->consistency = DC_ONE;
+        msg->rsp_handler = msg_local_one_rsp_handler;
+        local_req_forward(ctx, c_conn, msg, key, keylen);
+        return;
+    }
+
     if (msg->is_read) {
         msg->consistency = conn_get_read_consistency(c_conn);
     } else {


### PR DESCRIPTION
If the message is local, by pass all other logic of key hashing or consistency and just forward the request to local data storage