### PR TITLE
Further mset fixes

### DIFF
--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -528,7 +528,6 @@ dnode_rsp_send_done(struct context *ctx, struct conn *conn, struct msg *rsp)
 
     ASSERT(!rsp->request && req->request);
     ASSERT(req->selected_rsp == rsp);
-    ASSERT(req->done && !req->swallow);
     log_debug(LOG_DEBUG, "DNODE RSP SENT %s %d dmsg->id %u",
               conn_get_type_string(conn),
              conn->sd, req->dmsg->id);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -497,8 +497,8 @@ msg_get_error(struct conn *conn, dyn_error_t dyn_err, err_t err)
     msg->mlen = (uint32_t)n;
 
     if (log_loggable(LOG_VVERB)) {
-       log_debug(LOG_VVERB, "get msg %p id %"PRIu64" len %"PRIu32" error '%s'",
-              msg, msg->id, msg->mlen, errstr);
+       log_debug(LOG_VVERB, "get msg %p id %"PRIu64" len %"PRIu32" err %d error '%s'",
+                 msg, msg->id, msg->mlen, err, errstr);
     }
 
     return msg;
@@ -1074,7 +1074,7 @@ msg_send_chain(struct context *ctx, struct conn *conn, struct msg *msg)
     struct array sendv;                  /* send iovec */
     size_t nsend, nsent;                 /* bytes to send; bytes sent */
     size_t limit;                        /* bytes to send limit */
-    ssize_t n;                           /* bytes sent by sendv */
+    ssize_t n = 0;                       /* bytes sent by sendv */
 
     if (log_loggable(LOG_VVERB)) {
        loga("About to dump out the content of msg");
@@ -1130,11 +1130,10 @@ msg_send_chain(struct context *ctx, struct conn *conn, struct msg *msg)
         }
     }
 
-    ASSERT(!TAILQ_EMPTY(&send_msgq) && nsend != 0);
-
     conn->smsg = NULL;
 
-    n = conn_sendv_data(conn, &sendv, nsend);
+    if (nsend != 0)
+        n = conn_sendv_data(conn, &sendv, nsend);
 
     nsent = n > 0 ? (size_t)n : 0;
 


### PR DESCRIPTION
* redis post coalesce should take into account error messages for fragments and act accordingly.
* While returning error, proper error should be returned to a fragmented request
* Some asserts are no longer valid. Removing them
* msg_send_chain can have a list of requests with no response data when all the requests are remaining fragments of a already responded request. In such case it is ok to have nsend = 0
* In rsp_make_error we were not grabbing the error code of the current message which could potentially be the first fragment of the larger request