### PR TITLE
Create a ready list of connections

### DIFF
--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -433,6 +433,7 @@ conf_pool_transform(struct server_pool *sp, struct conf_pool *cp)
     sp->p_conn = NULL;
     sp->dn_conn_q = 0;
     TAILQ_INIT(&sp->c_conn_q);
+    TAILQ_INIT(&sp->ready_conn_q);
 
     array_null(&sp->datacenters);
     /* sp->ncontinuum = 0; */

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -92,6 +92,7 @@ typedef enum connection_type {
 
 struct conn {
     TAILQ_ENTRY(conn)  conn_tqe;      /* link in server_pool / server / free q */
+    TAILQ_ENTRY(conn)  ready_tqe;     /* link in ready connection q */
     void               *owner;        /* connection owner - server_pool / server */
 
     int                sd;            /* socket descriptor */
@@ -217,4 +218,8 @@ void conn_deinit(void);
 void conn_print(struct conn *conn);
 
 bool conn_is_req_first_in_outqueue(struct conn *conn, struct msg *req);
+rstatus_t conn_event_add_conn(struct conn * conn);
+rstatus_t conn_event_add_out(struct conn * conn);
+rstatus_t conn_event_del_conn(struct conn * conn);
+rstatus_t conn_event_del_out(struct conn * conn);
 #endif

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -140,7 +140,6 @@ struct dyn_ring;
 
 
 #include "entropy/dyn_entropy.h"
-#include "event/dyn_event.h"
 
 #define ENCRYPTION 1
 
@@ -279,6 +278,7 @@ struct server_pool {
     struct conn        *p_conn;              /* proxy connection (listener) */
     uint32_t           dn_conn_q;            /* # client connection */
     struct conn_tqh    c_conn_q;             /* client connection q */
+    struct conn_tqh    ready_conn_q;         /* ready connection q */
 
     struct datastore   *datastore;           /* underlying datastore */
     struct array       datacenters;          /* racks info  */

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -43,6 +43,7 @@ dnode_client_unref(struct conn *conn)
     ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
     ASSERT(conn->owner != NULL);
 
+    conn_event_del_conn(conn);
     pool = conn->owner;
     conn->owner = NULL;
     dictRelease(conn->outstanding_msgs_dict);
@@ -217,7 +218,7 @@ dnode_client_handle_response(struct conn *conn, msgid_t reqid, struct msg *rsp)
     // If this request is first in the out queue, then the connection is ready,
     // add the connection to epoll for writing
     if (conn_is_req_first_in_outqueue(conn, req)) {
-        status = event_add_out(ctx->evb, conn);
+        status = conn_event_add_out(conn);
         if (status != DN_OK) {
             conn->err = errno;
         }

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -53,6 +53,7 @@ dnode_peer_unref(struct conn *conn)
 
     ASSERT(conn->type == CONN_DNODE_PEER_SERVER);
     ASSERT(conn->owner != NULL);
+    conn_event_del_conn(conn);
 
     peer = conn->owner;
     conn->owner = NULL;
@@ -1610,7 +1611,7 @@ dnode_rsp_gos_syn(struct context *ctx, struct conn *p_conn, struct msg *msg)
 
      //p_conn->enqueue_outq(ctx, p_conn, pmsg);
      //if (TAILQ_FIRST(&p_conn->omsg_q) != NULL && req_done(p_conn, TAILQ_FIRST(&p_conn->omsg_q))) {
-     //   status = event_add_out(ctx->evb, p_conn);
+     //   status = conn_event_add_out(p_conn);
      //   if (status != DN_OK) {
      //      p_conn->err = errno;
      //   }
@@ -1618,7 +1619,7 @@ dnode_rsp_gos_syn(struct context *ctx, struct conn *p_conn, struct msg *msg)
 
 
     if (TAILQ_FIRST(&p_conn->omsg_q) != NULL && req_done(p_conn, TAILQ_FIRST(&p_conn->omsg_q))) {
-        status = event_add_out(ctx->evb, p_conn);
+        status = conn_event_add_out(p_conn);
         if (status != DN_OK) {
             p_conn->err = errno;
         }
@@ -1654,7 +1655,7 @@ dnode_req_send_next(struct context *ctx, struct conn *conn)
         }
 
         //requeue
-        status = event_add_out(ctx->evb, conn);
+        status = conn_event_add_out(conn);
         IGNORE_RET_VAL(status);
 
         return NULL;

--- a/src/dyn_dnode_proxy.c
+++ b/src/dyn_dnode_proxy.c
@@ -40,6 +40,7 @@ dnode_unref(struct conn *conn)
     ASSERT(conn->type == CONN_DNODE_PEER_PROXY);
     ASSERT(conn->owner != NULL);
 
+    conn_event_del_conn(conn);
     pool = conn->owner;
     conn->owner = NULL;
 
@@ -204,7 +205,7 @@ dnode_accept(struct context *ctx, struct conn *p)
         }
     }
 
-    status = event_add_conn(ctx->evb, c);
+    status = conn_event_add_conn(c);
     if (status < 0) {
         log_error("dyn: event add conn from %s %d failed: %s",
                   conn_get_type_string(p), p->sd, strerror(errno));

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -33,7 +33,7 @@ dnode_req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg)
     }
 
     if (req_done(conn, TAILQ_FIRST(&conn->omsg_q))) {
-        status = event_add_out(ctx->evb, conn);
+        status = conn_event_add_out(conn);
         if (status != DN_OK) {
             conn->err = errno;
         }
@@ -71,7 +71,7 @@ dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
            (c_conn->type == CONN_DNODE_PEER_CLIENT));
 
     /* enqueue the message (request) into peer inq */
-    status = event_add_out(ctx->evb, p_conn);
+    status = conn_event_add_out(p_conn);
     if (status != DN_OK) {
         dnode_req_forward_error(ctx, p_conn, msg);
         p_conn->err = errno;
@@ -171,7 +171,7 @@ peer_gossip_forward1(struct context *ctx, struct conn *conn, bool redis, struct 
     mbuf_insert_head(&msg->mhdr, nbuf);
 
     if (TAILQ_EMPTY(&conn->imsg_q)) {
-        status = event_add_out(ctx->evb, conn);
+        status = conn_event_add_out(conn);
         if (status != DN_OK) {
             dnode_req_forward_error(ctx, conn, msg);
             conn->err = errno;
@@ -267,7 +267,7 @@ dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, struct mbuf *d
 
     /* enqueue the message (request) into peer inq */
     if (TAILQ_EMPTY(&conn->imsg_q)) {
-        status = event_add_out(ctx->evb, conn);
+        status = conn_event_add_out(conn);
         if (status != DN_OK) {
             dnode_req_forward_error(ctx, conn, msg);
             conn->err = errno;

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -1192,7 +1192,8 @@ msg_send(struct context *ctx, struct conn *conn)
     rstatus_t status;
     struct msg *msg;
 
-    ASSERT(conn->send_active);
+    ASSERT_LOG(conn->send_active, "conn %p type:%s sd %d",
+               conn, conn_get_type_string(conn), conn->sd);
 
     conn->send_ready = 1;
     do {

--- a/src/dyn_proxy.c
+++ b/src/dyn_proxy.c
@@ -55,6 +55,7 @@ proxy_unref(struct conn *conn)
     ASSERT(conn->type == CONN_PROXY);
     ASSERT(conn->owner != NULL);
 
+    conn_event_del_conn(conn);
     pool = conn->owner;
     conn->owner = NULL;
 
@@ -208,7 +209,7 @@ proxy_accept(struct context *ctx, struct conn *p)
         }
     }
 
-    status = event_add_conn(ctx->evb, c);
+    status = conn_event_add_conn(c);
     if (status < 0) {
         log_error("event add conn from %s %d failed: %s",conn_get_type_string(p),
                   p->sd, strerror(errno));

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -111,7 +111,7 @@ rsp_send_next(struct context *ctx, struct conn *conn)
             log_debug(LOG_INFO, "c %d is done", conn->sd);
         }
 
-        status = event_del_out(ctx->evb, conn);
+        status = conn_event_del_out(conn);
         if (status != DN_OK) {
             conn->err = errno;
         }

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -60,6 +60,7 @@ server_unref(struct conn *conn)
     ASSERT(conn->type == CONN_SERVER);
 	ASSERT(conn->owner != NULL);
 
+    conn_event_del_conn(conn);
 	server = conn->owner;
 	conn->owner = NULL;
 
@@ -964,7 +965,7 @@ req_send_next(struct context *ctx, struct conn *conn)
     nmsg = TAILQ_FIRST(&conn->imsg_q);
     if (nmsg == NULL) {
         /* nothing to send as the server inq is empty */
-        status = event_del_out(ctx->evb, conn);
+        status = conn_event_del_out(conn);
         if (status != DN_OK) {
             conn->err = errno;
         }

--- a/src/event/dyn_epoll.c
+++ b/src/event/dyn_epoll.c
@@ -25,6 +25,7 @@
 #ifdef DN_HAVE_EPOLL
 
 #include <sys/epoll.h>
+#include <dyn_event.h>
 
 struct event_base *
 event_base_create(int nevent, event_cb_t cb)


### PR DESCRIPTION
* Create a list of connections that have data to write and optimistically try to purge it before calling epoll
* This reduces the system calls to the epoll