### PR TITLE
Rename some confusing variables

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -399,7 +399,7 @@ core_timeout(struct context *ctx)
 
 		/* skip over req that are in-error or done */
 
-		if (msg->error || msg->done) {
+		if (msg->is_error || msg->done) {
 			msg_tmo_delete(msg);
 			continue;
 		}

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -24,8 +24,8 @@ dnode_req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg)
             strerror(errno));
 
     msg->done = 1;
-    msg->error = 1;
-    msg->err = errno;
+    msg->is_error = 1;
+    msg->error_code = errno;
 
     if (!msg->expect_datastore_reply || msg->swallow) {
         req_put(msg);
@@ -44,7 +44,7 @@ dnode_req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg)
 static void
 dnode_peer_req_forward_stats(struct context *ctx, struct node *server, struct msg *msg)
 {
-    ASSERT(msg->request);
+    ASSERT(msg->is_request);
     stats_pool_incr(ctx, peer_requests);
     stats_pool_incr_by(ctx, peer_request_bytes, msg->mlen);
 }

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -325,10 +325,10 @@ struct msg {
     uint32_t             nfrag;           /* # fragment */
     uint64_t             frag_id;         /* id of fragmented message */
 
-    err_t                err;             /* errno on error? */
-    unsigned             error:1;         /* error? */
-    unsigned             ferror:1;        /* one or more fragments are in error? */
-    unsigned             request:1;       /* request? or response? */
+    err_t                error_code;      /* errno on error? */
+    unsigned             is_error:1;      /* error? */
+    unsigned             is_ferror:1;     /* one or more fragments are in error? */
+    unsigned             is_request:1;    /* request? or response? */
     unsigned             quit:1;          /* quit request? */
     unsigned             expect_datastore_reply:1;       /* expect datastore reply */
     unsigned             done:1;          /* done? */
@@ -347,7 +347,7 @@ struct msg {
     //dynomite
     struct dmsg          *dmsg;          /* dyn message */
     int                  dyn_state;
-    dyn_error_t          dyn_error;      /* error code for dynomite */
+    dyn_error_t          dyn_error_code; /* error code for dynomite */
     uint8_t              msg_type;       /* for special message types
                                               0 : normal,
                                               1 : local cmd only no matter what

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -177,7 +177,7 @@ req_error(struct conn *conn, struct msg *msg)
 
     ASSERT(msg->request && req_done(conn, msg));
 
-    if (msg->error) {
+    if (msg->is_error) {
         return true;
     }
 
@@ -186,7 +186,7 @@ req_error(struct conn *conn, struct msg *msg)
         return false;
     }
 
-    if (msg->ferror) {
+    if (msg->is_ferror) {
         /* request has already been marked to be in error */
         return true;
     }
@@ -197,7 +197,7 @@ req_error(struct conn *conn, struct msg *msg)
          cmsg != NULL && cmsg->frag_id == id;
          cmsg = TAILQ_PREV(cmsg, msg_tqh, c_tqe)) {
 
-        if (cmsg->error) {
+        if (cmsg->is_error) {
             goto ferror;
         }
     }
@@ -206,7 +206,7 @@ req_error(struct conn *conn, struct msg *msg)
          cmsg != NULL && cmsg->frag_id == id;
          cmsg = TAILQ_NEXT(cmsg, c_tqe)) {
 
-        if (cmsg->error) {
+        if (cmsg->is_error) {
             goto ferror;
         }
     }
@@ -220,20 +220,20 @@ ferror:
      * future req_error calls for any of fragments of this request
      */
 
-    msg->ferror = 1;
+    msg->is_ferror = 1;
     nfragment = 1;
 
     for (cmsg = TAILQ_PREV(msg, msg_tqh, c_tqe);
          cmsg != NULL && cmsg->frag_id == id;
          cmsg = TAILQ_PREV(cmsg, msg_tqh, c_tqe)) {
-        cmsg->ferror = 1;
+        cmsg->is_ferror = 1;
         nfragment++;
     }
 
     for (cmsg = TAILQ_NEXT(msg, c_tqe);
          cmsg != NULL && cmsg->frag_id == id;
          cmsg = TAILQ_NEXT(cmsg, c_tqe)) {
-        cmsg->ferror = 1;
+        cmsg->is_ferror = 1;
         nfragment++;
     }
 

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -140,9 +140,9 @@ rspmgr_get_response(struct response_mgr *rspmgr)
     } else {
         log_info("none of the responses match, returning error");
         struct msg *rsp = msg_get(rspmgr->conn, false, __FUNCTION__);
-        rsp->error = 1;
-        rsp->err = NO_QUORUM_ACHIEVED;
-        rsp->dyn_error = NO_QUORUM_ACHIEVED;
+        rsp->is_error = 1;
+        rsp->error_code = NO_QUORUM_ACHIEVED;
+        rsp->dyn_error_code = NO_QUORUM_ACHIEVED;
         ASSERT(rspmgr->err_rsp == NULL);
         rspmgr->err_rsp = rsp;
         rspmgr->error_responses++;
@@ -171,7 +171,7 @@ rspmgr_submit_response(struct response_mgr *rspmgr, struct msg*rsp)
 {
     log_info("req %d submitting response %d awaiting_rsps %d",
               rspmgr->msg->id, rsp->id, rspmgr->msg->awaiting_rsps);
-    if (rsp->error) {
+    if (rsp->is_error) {
         log_debug(LOG_VERB, "Received error response %d:%d for req %d:%d",
                   rsp->id, rsp->parent_id, rspmgr->msg->id, rspmgr->msg->parent_id);
         rspmgr->error_responses++;

--- a/src/dyn_test.c
+++ b/src/dyn_test.c
@@ -335,7 +335,7 @@ test_msg_recv_chain(struct conn *conn, struct msg *msg)
                 log_debug(LOG_VVERB, "Parsing MSG_PARSE_OK - more data but can't split!");
             }
 
-            nmsg = msg_get(msg->owner, msg->request, __FUNCTION__);
+            nmsg = msg_get(msg->owner, msg->is_request, __FUNCTION__);
             mbuf_insert(&nmsg->mhdr, nbuf);
             nmsg->pos = nbuf->pos;
 

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1330,8 +1330,8 @@ memcache_pre_coalesce(struct msg *r)
         mbuf = STAILQ_FIRST(&r->mhdr);
         log_hexdump(LOG_ERR, mbuf->pos, mbuf_length(mbuf), "rsp fragment "
                     "with unknown type %d", r->type);
-        pr->error = 1;
-        pr->err = EINVAL;
+        pr->is_error = 1;
+        pr->error_code = EINVAL;
         break;
     }
 }


### PR DESCRIPTION
No functionality changes
Rename 
request to is_request
error to is_error
ferror to is_ferror
err to error_code
dyn_error to dyn_error_code