### PR TITLE
Rename msg to req and rsp to make code readable

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -182,7 +182,7 @@ static void
 client_close(struct context *ctx, struct conn *conn)
 {
     rstatus_t status;
-    struct msg *msg, *nmsg; /* current and next message */
+    struct msg *req, *nreq; /* current and next message */
 
     ASSERT(conn->type == CONN_CLIENT);
 
@@ -193,44 +193,44 @@ client_close(struct context *ctx, struct conn *conn)
         return;
     }
 
-    msg = conn->rmsg;
-    if (msg != NULL) {
+    req = conn->rmsg;
+    if (req != NULL) {
         conn->rmsg = NULL;
 
-        ASSERT(msg->peer == NULL);
-        ASSERT(msg->is_request && !msg->done);
+        ASSERT(req->peer == NULL);
+        ASSERT(req->is_request && !req->done);
 
         log_debug(LOG_INFO, "close c %d discarding pending req %"PRIu64" len "
-                  "%"PRIu32" type %d", conn->sd, msg->id, msg->mlen,
-                  msg->type);
+                  "%"PRIu32" type %d", conn->sd, req->id, req->mlen,
+                  req->type);
 
-        req_put(msg);
+        req_put(req);
     }
 
     ASSERT(conn->smsg == NULL);
     ASSERT(TAILQ_EMPTY(&conn->imsg_q));
 
-    for (msg = TAILQ_FIRST(&conn->omsg_q); msg != NULL; msg = nmsg) {
-        nmsg = TAILQ_NEXT(msg, c_tqe);
+    for (req = TAILQ_FIRST(&conn->omsg_q); req != NULL; req = nreq) {
+        nreq = TAILQ_NEXT(req, c_tqe);
 
         /* dequeue the message (request) from client outq */
-        conn_dequeue_outq(ctx, conn, msg);
+        conn_dequeue_outq(ctx, conn, req);
 
-        if (msg->done) {
+        if (req->done) {
             log_debug(LOG_INFO, "close c %d discarding %s req %"PRIu64" len "
                       "%"PRIu32" type %d", conn->sd,
-                      msg->is_error ? "error": "completed", msg->id, msg->mlen,
-                      msg->type);
-            req_put(msg);
+                      req->is_error ? "error": "completed", req->id, req->mlen,
+                      req->type);
+            req_put(req);
         } else {
-            msg->swallow = 1;
+            req->swallow = 1;
 
-            ASSERT(msg->is_request);
-            ASSERT(msg->peer == NULL);
+            ASSERT(req->is_request);
+            ASSERT(req->peer == NULL);
 
             log_debug(LOG_INFO, "close c %d schedule swallow of req %"PRIu64" "
-                      "len %"PRIu32" type %d", conn->sd, msg->id, msg->mlen,
-                      msg->type);
+                      "len %"PRIu32" type %d", conn->sd, req->id, req->mlen,
+                      req->type);
         }
 
         stats_pool_incr(ctx, client_dropped_requests);
@@ -301,13 +301,13 @@ client_handle_response(struct conn *conn, msgid_t reqid, struct msg *rsp)
 struct msg *
 req_recv_next(struct context *ctx, struct conn *conn, bool alloc)
 {
-    struct msg *msg;
+    struct msg *req;
 
     ASSERT((conn->type == CONN_DNODE_PEER_CLIENT) ||
            (conn->type = CONN_CLIENT));
 
     if (conn->eof) {
-        msg = conn->rmsg;
+        req = conn->rmsg;
 
         //if (conn->dyn_mode) {
         //    if (conn->non_bytes_recv > MAX_CONN_ALLOWABLE_NON_RECV) {
@@ -315,20 +315,20 @@ req_recv_next(struct context *ctx, struct conn *conn, bool alloc)
         //        return NULL;
         //    }
         //    conn->eof = 0;
-        //    return msg;
+        //    return req;
         //}
 
         /* client sent eof before sending the entire request */
-        if (msg != NULL) {
+        if (req != NULL) {
             conn->rmsg = NULL;
 
-            ASSERT(msg->peer == NULL);
-            ASSERT(msg->is_request && !msg->done);
+            ASSERT(req->peer == NULL);
+            ASSERT(req->is_request && !req->done);
 
             log_error("eof c %d discarding incomplete req %"PRIu64" len "
-                      "%"PRIu32"", conn->sd, msg->id, msg->mlen);
+                      "%"PRIu32"", conn->sd, req->id, req->mlen);
 
-            req_put(msg);
+            req_put(req);
         }
 
         /*
@@ -346,34 +346,34 @@ req_recv_next(struct context *ctx, struct conn *conn, bool alloc)
         return NULL;
     }
 
-    msg = conn->rmsg;
-    if (msg != NULL) {
-        ASSERT(msg->is_request);
-        return msg;
+    req = conn->rmsg;
+    if (req != NULL) {
+        ASSERT(req->is_request);
+        return req;
     }
 
     if (!alloc) {
         return NULL;
     }
 
-    msg = req_get(conn);
-    if (msg != NULL) {
-        conn->rmsg = msg;
+    req = req_get(conn);
+    if (req != NULL) {
+        conn->rmsg = req;
     }
 
-    return msg;
+    return req;
 }
 
 static bool
-req_filter(struct context *ctx, struct conn *conn, struct msg *msg)
+req_filter(struct context *ctx, struct conn *conn, struct msg *req)
 {
     ASSERT(conn->type == CONN_CLIENT);
 
-    if (msg_empty(msg)) {
+    if (msg_empty(req)) {
         ASSERT(conn->rmsg == NULL);
-        log_debug(LOG_VERB, "filter empty req %"PRIu64" from c %d", msg->id,
+        log_debug(LOG_VERB, "filter empty req %"PRIu64" from c %d", req->id,
                   conn->sd);
-        req_put(msg);
+        req_put(req);
         return true;
     }
 
@@ -381,13 +381,13 @@ req_filter(struct context *ctx, struct conn *conn, struct msg *msg)
      * Handle "quit\r\n", which is the protocol way of doing a
      * passive close
      */
-    if (msg->quit) {
+    if (req->quit) {
         ASSERT(conn->rmsg == NULL);
-        log_debug(LOG_INFO, "filter quit req %"PRIu64" from c %d", msg->id,
+        log_debug(LOG_INFO, "filter quit req %"PRIu64" from c %d", req->id,
                   conn->sd);
         conn->eof = 1;
         conn->recv_ready = 0;
-        req_put(msg);
+        req_put(req);
         return true;
     }
 
@@ -412,17 +412,17 @@ send_rsp_integer(struct context *ctx, struct conn *c_conn, struct msg *req)
 }
 
 static void
-req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg,
+req_forward_error(struct context *ctx, struct conn *conn, struct msg *req,
                   err_t err)
 {
     if (log_loggable(LOG_INFO)) {
        log_debug(LOG_INFO, "forward req %"PRIu64" len %"PRIu32" type %d from "
-                 "c %d failed: %s", msg->id, msg->mlen, msg->type, conn->sd,
+                 "c %d failed: %s", req->id, req->mlen, req->type, conn->sd,
                  strerror(err));
     }
 
-    if (!msg->expect_datastore_reply) {
-        req_put(msg);
+    if (!req->expect_datastore_reply) {
+        req_put(req);
         return;
     }
 
@@ -430,19 +430,19 @@ req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg,
     // This response gets dropped in rsp_make_error anyways. But since this is
     // an error path its ok with the overhead.
     struct msg *rsp = msg_get(conn, false, __FUNCTION__);
-    rsp->peer = msg;
+    rsp->peer = req;
     rsp->is_error = 1;
     rsp->error_code = err;
 
-    rstatus_t status = conn_handle_response(conn, msg->id, rsp);
+    rstatus_t status = conn_handle_response(conn, req->id, rsp);
     IGNORE_RET_VAL(status);
 }
 
 static void
-req_redis_stats(struct context *ctx, struct msg *msg)
+req_redis_stats(struct context *ctx, struct msg *req)
 {
 
-    switch (msg->type) {
+    switch (req->type) {
 
     case MSG_REQ_REDIS_GET:
          stats_server_incr(ctx, redis_req_get);
@@ -530,21 +530,21 @@ req_redis_stats(struct context *ctx, struct msg *msg)
 }
 
 static void
-req_forward_stats(struct context *ctx, struct msg *msg)
+req_forward_stats(struct context *ctx, struct msg *req)
 {
-    ASSERT(msg->is_request);
+    ASSERT(req->is_request);
 
-    if (msg->is_read) {
+    if (req->is_read) {
        stats_server_incr(ctx, read_requests);
-       stats_server_incr_by(ctx, read_request_bytes, msg->mlen);
+       stats_server_incr_by(ctx, read_request_bytes, req->mlen);
     } else {
        stats_server_incr(ctx, write_requests);
-       stats_server_incr_by(ctx, write_request_bytes, msg->mlen);
+       stats_server_incr_by(ctx, write_request_bytes, req->mlen);
     }
 }
 
 void
-local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
+local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *req,
                   uint8_t *key, uint32_t keylen)
 {
     rstatus_t status;
@@ -558,14 +558,14 @@ local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
            (c_conn->type == CONN_DNODE_PEER_CLIENT));
 
     /* enqueue message (request) into client outq, if response is expected */
-    if (msg->expect_datastore_reply) {
-        conn_enqueue_outq(ctx, c_conn, msg);
+    if (req->expect_datastore_reply) {
+        conn_enqueue_outq(ctx, c_conn, req);
     }
 
     s_conn = get_datastore_conn(ctx, c_conn->owner);
     log_debug(LOG_VERB, "c_conn %p got server conn %p", c_conn, s_conn);
     if (s_conn == NULL) {
-        req_forward_error(ctx, c_conn, msg, errno);
+        req_forward_error(ctx, c_conn, req, errno);
         return;
     }
     ASSERT(s_conn->type == CONN_SERVER);
@@ -581,94 +581,94 @@ local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
             status = conn_event_add_out(s_conn);
 
             if (status != DN_OK) {
-                req_forward_error(ctx, c_conn, msg, errno);
+                req_forward_error(ctx, c_conn, req, errno);
                 s_conn->err = errno;
                 return;
             }
         }
     } else if (ctx->dyn_state == STANDBY) {  //no reads/writes from peers/clients
         log_debug(LOG_INFO, "Node is in STANDBY state. Drop write/read requests");
-        req_forward_error(ctx, c_conn, msg, errno);
+        req_forward_error(ctx, c_conn, req, errno);
         return;
-    } else if (ctx->dyn_state == WRITES_ONLY && msg->is_read) {
+    } else if (ctx->dyn_state == WRITES_ONLY && req->is_read) {
         //no reads from peers/clients but allow writes from peers/clients
         log_debug(LOG_INFO, "Node is in WRITES_ONLY state. Drop read requests");
-        req_forward_error(ctx, c_conn, msg, errno);
+        req_forward_error(ctx, c_conn, req, errno);
         return;
     } else if (ctx->dyn_state == RESUMING) {
         log_debug(LOG_INFO, "Node is in RESUMING state. Still drop read requests and flush out all the queued writes");
-        if (msg->is_read) {
-            req_forward_error(ctx, c_conn, msg, errno);
+        if (req->is_read) {
+            req_forward_error(ctx, c_conn, req, errno);
             return;
         }
 
         status = conn_event_add_out(s_conn);
 
         if (status != DN_OK) {
-            req_forward_error(ctx, c_conn, msg, errno);
+            req_forward_error(ctx, c_conn, req, errno);
             s_conn->err = errno;
             return;
         }
     }
 
-    conn_enqueue_inq(ctx, s_conn, msg);
-    req_forward_stats(ctx, msg);
+    conn_enqueue_inq(ctx, s_conn, req);
+    req_forward_stats(ctx, req);
     if(g_data_store == DATA_REDIS){
-        req_redis_stats(ctx, msg);
+        req_redis_stats(ctx, req);
     }
 
 
     if (log_loggable(LOG_VERB)) {
        log_debug(LOG_VERB, "local forward from c %d to s %d req %"PRIu64" len %"PRIu32
-                " type %d with key '%.*s'", c_conn->sd, s_conn->sd, msg->id,
-                msg->mlen, msg->type, keylen, key);
+                " type %d with key '%.*s'", c_conn->sd, s_conn->sd, req->id,
+                req->mlen, req->type, keylen, key);
     }
 }
 
 
 static void
-admin_local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
+admin_local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *req,
                         struct rack *rack, uint8_t *key, uint32_t keylen)
 {
     ASSERT((c_conn->type == CONN_CLIENT) ||
            (c_conn->type == CONN_DNODE_PEER_CLIENT));
 
-    struct node *peer = dnode_peer_pool_server(ctx, c_conn->owner, rack, key, keylen, msg->msg_type);
+    struct node *peer = dnode_peer_pool_server(ctx, c_conn->owner, rack, key, keylen, req->msg_type);
     if (!peer->is_local) {
-        send_rsp_integer(ctx, c_conn, msg);
+        send_rsp_integer(ctx, c_conn, req);
         return;
     }
 
     struct conn *p_conn = dnode_peer_pool_server_conn(ctx, peer);
     if (p_conn == NULL) {
         c_conn->err = EHOSTDOWN;
-        req_forward_error(ctx, c_conn, msg, c_conn->err);
+        req_forward_error(ctx, c_conn, req, c_conn->err);
         return;
     }
 
     log_debug(LOG_NOTICE, "Need to delete [%.*s] ", keylen, key);
-    local_req_forward(ctx, c_conn, msg, key, keylen);
+    local_req_forward(ctx, c_conn, req, key, keylen);
 }
 
 void
-remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg, 
+remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *req, 
                    struct rack *rack, uint8_t *key, uint32_t keylen)
 {
     ASSERT((c_conn->type == CONN_CLIENT) ||
            (c_conn->type == CONN_DNODE_PEER_CLIENT));
 
     struct node * peer = dnode_peer_pool_server(ctx, c_conn->owner, rack, key,
-                                                keylen, msg->msg_type);
+                                                keylen, req->msg_type);
     if (peer->is_local) {
         log_debug(LOG_VERB, "c_conn: %p forwarding %d:%d is local", c_conn,
-                  msg->id, msg->parent_id);
-        local_req_forward(ctx, c_conn, msg, key, keylen);
+                  req->id, req->parent_id);
+        local_req_forward(ctx, c_conn, req, key, keylen);
         return;
     }
 
     /* enqueue message (request) into client outq, if response is expected */
-    if (msg->expect_datastore_reply  && !msg->swallow) {
-        conn_enqueue_outq(ctx, c_conn, msg);
+    if (req->expect_datastore_reply  && !req->swallow) {
+        conn_enqueue_outq(ctx, c_conn, req);
     }
     // now get a peer connection
     struct conn *p_conn = dnode_peer_pool_server_conn(ctx, peer);
@@ -683,54 +683,54 @@ remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
             }
         }
         // No response for DC_ONE & swallow
-        if ((msg->consistency == DC_ONE) && (msg->swallow)) {
-            msg_put(msg);
+        if ((req->consistency == DC_ONE) && (req->swallow)) {
+            msg_put(req);
             return;
         }
         // No response for remote dc
         struct server_pool *pool = c_conn->owner;
         bool same_dc = is_same_dc(pool, peer)? 1 : 0;
         if (!same_dc) {
-            msg_put(msg);
+            msg_put(req);
             return;
         }
         // All other cases return a response
         struct msg *rsp = msg_get(c_conn, false, __FUNCTION__);
-        msg->done = 1;
+        req->done = 1;
         rsp->type = MSG_RSP_REDIS_ERROR;
-        rsp->is_error = msg->is_error = 1;
-        rsp->error_code = msg->error_code = (p_conn ? PEER_HOST_NOT_CONNECTED : PEER_HOST_DOWN);
-        rsp->dyn_error_code = msg->dyn_error_code = (p_conn ? PEER_HOST_NOT_CONNECTED:
+        rsp->is_error = req->is_error = 1;
+        rsp->error_code = req->error_code = (p_conn ? PEER_HOST_NOT_CONNECTED : PEER_HOST_DOWN);
+        rsp->dyn_error_code = req->dyn_error_code = (p_conn ? PEER_HOST_NOT_CONNECTED:
                                                               PEER_HOST_DOWN);
         rsp->dmsg = dmsg_get();
-        rsp->peer = msg;
-        rsp->dmsg->id =  msg->id;
-        log_info("%lu:%lu <-> %lu:%lu Short circuit....", msg->id, msg->parent_id, rsp->id, rsp->parent_id);
-        conn_handle_response(c_conn, msg->parent_id ? msg->parent_id : msg->id,
+        rsp->peer = req;
+        rsp->dmsg->id =  req->id;
+        log_info("%lu:%lu <-> %lu:%lu Short circuit....", req->id, req->parent_id, rsp->id, rsp->parent_id);
+        conn_handle_response(c_conn, req->parent_id ? req->parent_id : req->id,
                              rsp);
-        if (msg->swallow)
-            msg_put(msg);
+        if (req->swallow)
+            msg_put(req);
         return;
     }
 
     log_debug(LOG_VERB, "c_conn: %p forwarding %d:%d to p_conn %p", c_conn,
-            msg->id, msg->parent_id, p_conn);
-    dnode_peer_req_forward(ctx, c_conn, p_conn, msg, rack, key, keylen);
+            req->id, req->parent_id, p_conn);
+    dnode_peer_req_forward(ctx, c_conn, p_conn, req, rack, key, keylen);
 }
 
 static void
 req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
-                            struct msg *msg, struct mbuf *orig_mbuf,
+                            struct msg *req, struct mbuf *orig_mbuf,
                             uint8_t *key, uint32_t keylen, struct datacenter *dc)
 {
     //log_debug(LOG_DEBUG, "dc name  '%.*s'",
     //            dc->name->len, dc->name->data);
     uint8_t rack_cnt = (uint8_t)array_n(&dc->racks);
     uint8_t rack_index;
-    msg->rsp_handler = msg_get_rsp_handler(msg);
-    init_response_mgr(&msg->rspmgr, msg, msg->is_read, rack_cnt, c_conn);
-    log_info("msg %d:%d same DC racks:%d expect replies %d",
-             msg->id, msg->parent_id, rack_cnt, msg->rspmgr.max_responses);
+    req->rsp_handler = msg_get_rsp_handler(req);
+    init_response_mgr(&req->rspmgr, req, req->is_read, rack_cnt, c_conn);
+    log_info("req %d:%d same DC racks:%d expect replies %d",
+             req->id, req->parent_id, rack_cnt, req->rspmgr.max_responses);
     for(rack_index = 0; rack_index < rack_cnt; rack_index++) {
         struct rack *rack = array_get(&dc->racks, rack_index);
         //log_debug(LOG_DEBUG, "rack name '%.*s'",
@@ -739,9 +739,9 @@ req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
         // clone message even for local node
         struct server_pool *pool = c_conn->owner;
         if (string_compare(rack->name, &pool->rack) == 0 ) {
-            rack_msg = msg;
+            rack_msg = req;
         } else {
-            rack_msg = msg_get(c_conn, msg->is_request, __FUNCTION__);
+            rack_msg = msg_get(c_conn, req->is_request, __FUNCTION__);
             if (rack_msg == NULL) {
                 log_debug(LOG_VERB, "whelp, looks like yer screwed "
                         "now, buddy. no inter-rack messages for "
@@ -749,9 +749,9 @@ req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
                 continue;
             }
 
-            msg_clone(msg, orig_mbuf, rack_msg);
-            log_info("msg (%d:%d) clone to rack msg (%d:%d)",
-                     msg->id, msg->parent_id, rack_msg->id, rack_msg->parent_id);
+            msg_clone(req, orig_mbuf, rack_msg);
+            log_info("req (%d:%d) clone to rack req (%d:%d)",
+                     req->id, req->parent_id, rack_msg->id, rack_msg->parent_id);
             rack_msg->swallow = true;
         }
 
@@ -766,9 +766,9 @@ req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
 }
 
 static bool
-request_send_to_all_dcs(struct msg *msg)
+request_send_to_all_dcs(struct msg *req)
 {
-    if (!msg->is_read)
+    if (!req->is_read)
         return true;
     return false;
 }
@@ -776,25 +776,25 @@ request_send_to_all_dcs(struct msg *msg)
 /**
  * Determine if a request should be forwarded to all replicas within the local
  * DC.
- * @param[in] msg Message.
+ * @param[in] req Message.
  * @return bool True if message should be forwarded to all local replicas, else false
  */
 static bool
-request_send_to_all_local_racks(struct msg *msg)
+request_send_to_all_local_racks(struct msg *req)
 {
-    if (!msg->is_read)
+    if (!req->is_read)
         return true;
-    if ((msg->type == MSG_REQ_REDIS_PING) ||
-        (msg->type == MSG_REQ_REDIS_INFO))
+    if ((req->type == MSG_REQ_REDIS_PING) ||
+        (req->type == MSG_REQ_REDIS_INFO))
         return false;
-    if ((msg->consistency == DC_QUORUM) ||
-        (msg->consistency == DC_SAFE_QUORUM))
+    if ((req->consistency == DC_QUORUM) ||
+        (req->consistency == DC_SAFE_QUORUM))
         return true;
     return false;
 }
 
 static void
-req_forward_remote_dc(struct context *ctx, struct conn *c_conn, struct msg *msg,
+req_forward_remote_dc(struct context *ctx, struct conn *c_conn, struct msg *req,
                       struct mbuf *orig_mbuf, uint8_t *key, uint32_t keylen,
                       struct datacenter *dc)
 {
@@ -806,16 +806,16 @@ req_forward_remote_dc(struct context *ctx, struct conn *c_conn, struct msg *msg,
     if (rack == NULL)
         rack = array_get(&dc->racks, 0);
 
-    struct msg *rack_msg = msg_get(c_conn, msg->is_request, __FUNCTION__);
+    struct msg *rack_msg = msg_get(c_conn, req->is_request, __FUNCTION__);
     if (rack_msg == NULL) {
         log_debug(LOG_VERB, "whelp, looks like yer screwed now, buddy. no inter-rack messages for you!");
         msg_put(rack_msg);
         return;
     }
 
-    msg_clone(msg, orig_mbuf, rack_msg);
-    log_info("msg (%d:%d) clone to remote rack msg (%d:%d)",
-            msg->id, msg->parent_id, rack_msg->id, rack_msg->parent_id);
+    msg_clone(req, orig_mbuf, rack_msg);
+    log_info("req (%d:%d) clone to remote rack req (%d:%d)",
+            req->id, req->parent_id, rack_msg->id, rack_msg->parent_id);
     rack_msg->swallow = true;
 
     if (log_loggable(LOG_DEBUG)) {
@@ -826,27 +826,27 @@ req_forward_remote_dc(struct context *ctx, struct conn *c_conn, struct msg *msg,
 }
 
 static void
-req_forward_local_dc(struct context *ctx, struct conn *c_conn, struct msg *msg,
+req_forward_local_dc(struct context *ctx, struct conn *c_conn, struct msg *req,
                      struct mbuf *orig_mbuf, uint8_t *key, uint32_t keylen,
                      struct datacenter *dc)
 {
     struct server_pool *pool = c_conn->owner;
-    if (request_send_to_all_local_racks(msg)) {
+    if (request_send_to_all_local_racks(req)) {
         // send request to all local racks
-        req_forward_all_local_racks(ctx, c_conn, msg, orig_mbuf, key, keylen, dc);
+        req_forward_all_local_racks(ctx, c_conn, req, orig_mbuf, key, keylen, dc);
     } else {
         // send request to only local token owner
-        ASSERT(msg->is_read);
-        msg->rsp_handler = msg_get_rsp_handler(msg);
+        ASSERT(req->is_read);
+        req->rsp_handler = msg_get_rsp_handler(req);
         struct rack * rack = server_get_rack_by_dc_rack(pool, &pool->rack,
                                                         &pool->dc);
-        remote_req_forward(ctx, c_conn, msg, rack, key, keylen);
+        remote_req_forward(ctx, c_conn, req, rack, key, keylen);
     }
 
 }
 
 static void
-req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
+req_forward(struct context *ctx, struct conn *c_conn, struct msg *req)
 {
     struct server_pool *pool = c_conn->owner;
     uint8_t *key;
@@ -854,8 +854,8 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
 
     ASSERT(c_conn->type == CONN_CLIENT);
 
-    if (msg->is_read) {
-        if (msg->type != MSG_REQ_REDIS_PING)
+    if (req->is_read) {
+        if (req->type != MSG_REQ_REDIS_PING)
             stats_pool_incr(ctx, client_read_requests);
     } else
         stats_pool_incr(ctx, client_write_requests);
@@ -864,16 +864,16 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
     keylen = 0;
 
     // add the message to the dict
-    log_debug(LOG_DEBUG, "conn %p adding message %d:%d", c_conn, msg->id, msg->parent_id);
-    dictAdd(c_conn->outstanding_msgs_dict, &msg->id, msg);
+    log_debug(LOG_DEBUG, "conn %p adding message %d:%d", c_conn, req->id, req->parent_id);
+    dictAdd(c_conn->outstanding_msgs_dict, &req->id, req);
 
     if (!string_empty(&pool->hash_tag)) {
         struct string *tag = &pool->hash_tag;
         uint8_t *tag_start, *tag_end;
 
-        tag_start = dn_strchr(msg->key_start, msg->key_end, tag->data[0]);
+        tag_start = dn_strchr(req->key_start, req->key_end, tag->data[0]);
         if (tag_start != NULL) {
-            tag_end = dn_strchr(tag_start + 1, msg->key_end, tag->data[1]);
+            tag_end = dn_strchr(tag_start + 1, req->key_end, tag->data[1]);
             if (tag_end != NULL) {
                 key = tag_start + 1;
                 keylen = (uint32_t)(tag_end - key);
@@ -882,35 +882,35 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
     }
 
     if (keylen == 0) {
-        key = msg->key_start;
-        keylen = (uint32_t)(msg->key_end - msg->key_start);
+        key = req->key_start;
+        keylen = (uint32_t)(req->key_end - req->key_start);
     }
 
     // need to capture the initial mbuf location as once we add in the dynomite
-    // headers (as mbufs to the src msg), that will bork the request sent to
+    // headers (as mbufs to the src req), that will bork the request sent to
     // secondary racks
-    struct mbuf *orig_mbuf = STAILQ_FIRST(&msg->mhdr);
+    struct mbuf *orig_mbuf = STAILQ_FIRST(&req->mhdr);
 
     if (ctx->admin_opt == 1) {
-        if (msg->type == MSG_REQ_REDIS_DEL || msg->type == MSG_REQ_MC_DELETE) {
+        if (req->type == MSG_REQ_REDIS_DEL || req->type == MSG_REQ_MC_DELETE) {
           struct rack * rack = server_get_rack_by_dc_rack(pool, &pool->rack, &pool->dc);
-          admin_local_req_forward(ctx, c_conn, msg, rack, key, keylen);
+          admin_local_req_forward(ctx, c_conn, req, rack, key, keylen);
           return;
         }
     }
 
-    if (msg->msg_type == 1) {
+    if (req->msg_type == 1) {
         // Strictly local host only
-        msg->consistency = DC_ONE;
-        msg->rsp_handler = msg_local_one_rsp_handler;
-        local_req_forward(ctx, c_conn, msg, key, keylen);
+        req->consistency = DC_ONE;
+        req->rsp_handler = msg_local_one_rsp_handler;
+        local_req_forward(ctx, c_conn, req, key, keylen);
         return;
     }
 
-    if (msg->is_read) {
-        msg->consistency = conn_get_read_consistency(c_conn);
+    if (req->is_read) {
+        req->consistency = conn_get_read_consistency(c_conn);
     } else {
-        msg->consistency = conn_get_write_consistency(c_conn);
+        req->consistency = conn_get_write_consistency(c_conn);
     }
 
     /* forward the request */
@@ -926,9 +926,9 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
         }
 
         if (string_compare(dc->name, &pool->dc) == 0)
-            req_forward_local_dc(ctx, c_conn, msg, orig_mbuf, key, keylen, dc);
-        else if (request_send_to_all_dcs(msg)) {
-            req_forward_remote_dc(ctx, c_conn, msg, orig_mbuf, key, keylen, dc);
+            req_forward_local_dc(ctx, c_conn, req, orig_mbuf, key, keylen, dc);
+        else if (request_send_to_all_dcs(req)) {
+            req_forward_remote_dc(ctx, c_conn, req, orig_mbuf, key, keylen, dc);
         }
     }
 }
@@ -936,26 +936,26 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg)
 
 void
 req_recv_done(struct context *ctx, struct conn *conn,
-              struct msg *msg, struct msg *nmsg)
+              struct msg *req, struct msg *nreq)
 {
     ASSERT(conn->type == CONN_CLIENT);
-    ASSERT(msg->is_request);
-    ASSERT(msg->owner == conn);
-    ASSERT(conn->rmsg == msg);
-    ASSERT(nmsg == NULL || nmsg->is_request);
+    ASSERT(req->is_request);
+    ASSERT(req->owner == conn);
+    ASSERT(conn->rmsg == req);
+    ASSERT(nreq == NULL || nreq->is_request);
 
-    if (!msg->is_read)
-        stats_histo_add_payloadsize(ctx, msg->mlen);
+    if (!req->is_read)
+        stats_histo_add_payloadsize(ctx, req->mlen);
 
     /* enqueue next message (request), if any */
-    conn->rmsg = nmsg;
+    conn->rmsg = nreq;
 
-    if (req_filter(ctx, conn, msg)) {
+    if (req_filter(ctx, conn, req)) {
         return;
     }
 
-    msg->stime_in_microsec = dn_usec_now();
-    req_forward(ctx, conn, msg);
+    req->stime_in_microsec = dn_usec_now();
+    req_forward(ctx, conn, req);
 }
 
 static msg_response_handler_t 
@@ -1015,31 +1015,31 @@ msg_quorum_rsp_handler(struct msg *req, struct msg *rsp)
 }
 
 static void
-req_client_enqueue_omsgq(struct context *ctx, struct conn *conn, struct msg *msg)
+req_client_enqueue_omsgq(struct context *ctx, struct conn *conn, struct msg *req)
 {
-    ASSERT(msg->is_request);
+    ASSERT(req->is_request);
     ASSERT(conn->type == CONN_CLIENT);
 
     conn->omsg_count++;
     histo_add(&ctx->stats->client_out_queue, conn->omsg_count);
-    TAILQ_INSERT_TAIL(&conn->omsg_q, msg, c_tqe);
-    log_debug(LOG_VERB, "conn %p enqueue outq %lu:%lu", conn, msg->id, msg->parent_id);
+    TAILQ_INSERT_TAIL(&conn->omsg_q, req, c_tqe);
+    log_debug(LOG_VERB, "conn %p enqueue outq %lu:%lu", conn, req->id, req->parent_id);
 }
 
 static void
-req_client_dequeue_omsgq(struct context *ctx, struct conn *conn, struct msg *msg)
+req_client_dequeue_omsgq(struct context *ctx, struct conn *conn, struct msg *req)
 {
-    ASSERT(msg->is_request);
+    ASSERT(req->is_request);
     ASSERT(conn->type == CONN_CLIENT);
 
-    if (msg->stime_in_microsec) {
-        usec_t latency = dn_usec_now() - msg->stime_in_microsec;
+    if (req->stime_in_microsec) {
+        usec_t latency = dn_usec_now() - req->stime_in_microsec;
         stats_histo_add_latency(ctx, latency);
     }
     conn->omsg_count--;
     histo_add(&ctx->stats->client_out_queue, conn->omsg_count);
-    TAILQ_REMOVE(&conn->omsg_q, msg, c_tqe);
-    log_debug(LOG_VERB, "conn %p dequeue outq %lu:%lu", conn, msg->id, msg->parent_id);
+    TAILQ_REMOVE(&conn->omsg_q, req, c_tqe);
+    log_debug(LOG_VERB, "conn %p dequeue outq %lu:%lu", conn, req->id, req->parent_id);
 }
 
 struct conn_ops client_ops = {

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -13,22 +13,22 @@
 static uint64_t peer_msg_id = 0;
 
 static void
-dnode_req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg)
+dnode_req_forward_error(struct context *ctx, struct conn *conn, struct msg *req)
 {
     rstatus_t status;
 
     ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
 
     log_debug(LOG_INFO, "dyn: forward req %"PRIu64" len %"PRIu32" type %d from "
-            "c %d failed: %s", msg->id, msg->mlen, msg->type, conn->sd,
+            "c %d failed: %s", req->id, req->mlen, req->type, conn->sd,
             strerror(errno));
 
-    msg->done = 1;
-    msg->is_error = 1;
-    msg->error_code = errno;
+    req->done = 1;
+    req->is_error = 1;
+    req->error_code = errno;
 
-    if (!msg->expect_datastore_reply || msg->swallow) {
-        req_put(msg);
+    if (!req->expect_datastore_reply || req->swallow) {
+        req_put(req);
         return;
     }
 
@@ -42,18 +42,18 @@ dnode_req_forward_error(struct context *ctx, struct conn *conn, struct msg *msg)
 }
 
 static void
-dnode_peer_req_forward_stats(struct context *ctx, struct node *server, struct msg *msg)
+dnode_peer_req_forward_stats(struct context *ctx, struct node *server, struct msg *req)
 {
-    ASSERT(msg->is_request);
+    ASSERT(req->is_request);
     stats_pool_incr(ctx, peer_requests);
-    stats_pool_incr_by(ctx, peer_request_bytes, msg->mlen);
+    stats_pool_incr_by(ctx, peer_request_bytes, req->mlen);
 }
 
 
 /* Forward a client request over to a peer */
 void
 dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
-                       struct conn *p_conn, struct msg *msg,
+                       struct conn *p_conn, struct msg *req,
                        struct rack *rack, uint8_t *key, uint32_t keylen)
 {
 
@@ -73,7 +73,7 @@ dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
     /* enqueue the message (request) into peer inq */
     status = conn_event_add_out(p_conn);
     if (status != DN_OK) {
-        dnode_req_forward_error(ctx, p_conn, msg);
+        dnode_req_forward_error(ctx, p_conn, req);
         p_conn->err = errno;
         return;
     }
@@ -81,7 +81,7 @@ dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
     struct mbuf *header_buf = mbuf_get();
     if (header_buf == NULL) {
         loga("Unable to obtain an mbuf for dnode msg's header!");
-        req_put(msg);
+        req_put(req);
         return;
     }
 
@@ -100,11 +100,11 @@ dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
 
         //write dnode header
         if (ENCRYPTION) {
-            status = dyn_aes_encrypt_msg(msg, p_conn->aes_key);
+            status = dyn_aes_encrypt_msg(req, p_conn->aes_key);
             if (status == DN_ERROR) {
                 loga("OOM to obtain an mbuf for encryption!");
                 mbuf_put(header_buf);
-                req_put(msg);
+                req_put(req);
                 return;
             }
 
@@ -112,34 +112,34 @@ dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
                log_debug(LOG_VERB, "#encrypted bytes : %d", status);
             }
 
-            dmsg_write(header_buf, msg->id, msg_type, p_conn, msg_length(msg));
+            dmsg_write(header_buf, req->id, msg_type, p_conn, msg_length(req));
         } else {
             if (log_loggable(LOG_VVERB)) {
                log_debug(LOG_VERB, "no encryption on the msg payload");
             }
-            dmsg_write(header_buf, msg->id, msg_type, p_conn, msg_length(msg));
+            dmsg_write(header_buf, req->id, msg_type, p_conn, msg_length(req));
         }
 
     } else {
         //write dnode header
-        dmsg_write(header_buf, msg->id, msg_type, p_conn, msg_length(msg));
+        dmsg_write(header_buf, req->id, msg_type, p_conn, msg_length(req));
     }
 
-    mbuf_insert_head(&msg->mhdr, header_buf);
+    mbuf_insert_head(&req->mhdr, header_buf);
 
     if (log_loggable(LOG_VVERB)) {
         log_hexdump(LOG_VVERB, header_buf->pos, mbuf_length(header_buf), "dyn message header: ");
-        msg_dump(msg);
+        msg_dump(req);
     }
 
-    conn_enqueue_inq(ctx, p_conn, msg);
+    conn_enqueue_inq(ctx, p_conn, req);
 
-    dnode_peer_req_forward_stats(ctx, p_conn->owner, msg);
+    dnode_peer_req_forward_stats(ctx, p_conn->owner, req);
 
     if (log_loggable(LOG_VVERB)) {
        log_debug(LOG_VVERB, "remote forward from c %d to s %d req %"PRIu64" len %"PRIu32
-                   " type %d with key '%.*s'", c_conn->sd, p_conn->sd, msg->id,
-                   msg->mlen, msg->type, keylen, key);
+                   " type %d with key '%.*s'", c_conn->sd, p_conn->sd, req->id,
+                   req->mlen, req->type, keylen, key);
     }
 
 }
@@ -224,7 +224,7 @@ dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, struct mbuf *d
                 return; //TODOs: need to clean up
             }
 
-            status = dyn_aes_encrypt(data_buf->pos, (int)mbuf_length(data_buf), encrypted_buf, conn->aes_key);
+            status = dyn_aes_encrypt(data_buf->pos, mbuf_length(data_buf), encrypted_buf, conn->aes_key);
             if (log_loggable(LOG_VERB)) {
                log_debug(LOG_VERB, "#encrypted bytes : %d", status);
             }

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -27,8 +27,9 @@
 #include "dyn_proto.h"
 
 #define RSP_STRING(ACTION)                                   \
-    ACTION( ok,               "+OK\r\n"                     ) \
-    ACTION( pong,             "+PONG\r\n"                   ) \
+    ACTION( ok,               "+OK\r\n"                     )
+
+    /*ACTION( pong,             "+PONG\r\n"                   ) \ */
 
 #define DEFINE_ACTION(_var, _str) static struct string rsp_##_var = string(_str);
     RSP_STRING( DEFINE_ACTION )
@@ -319,7 +320,7 @@ redis_argeval(struct msg *r)
  * Return true, if the redis response is an error response i.e. a simple
  * string whose first character is '-', otherwise return false.
  */
-static bool
+/*static bool
 redis_error(struct msg *r)
 {
     switch (r->type) {
@@ -344,7 +345,7 @@ redis_error(struct msg *r)
     }
 
     return false;
-}
+}*/
 
 /*
  * Reference: http://redis.io/topics/protocol
@@ -375,7 +376,7 @@ void
 redis_parse_req(struct msg *r)
 {
     struct mbuf *b;
-    uint8_t *p, *m;
+    uint8_t *p, *m = 0;
     uint8_t ch;
     enum {
         SW_START,
@@ -2399,27 +2400,27 @@ error:
 void
 redis_pre_splitcopy(struct mbuf *mbuf, void *arg)
 {
-    struct msg *r = arg;
+    struct msg *req = arg;
     int n;
 
-    ASSERT(r->is_request);
-    ASSERT(r->narg > 1);
+    ASSERT(req->is_request);
+    ASSERT(req->narg > 1);
     ASSERT(mbuf_empty(mbuf));
 
-    switch (r->type) {
+    switch (req->type) {
     case MSG_REQ_REDIS_MGET:
         n = dn_snprintf(mbuf->last, mbuf_size(mbuf), "*%d\r\n$4\r\nmget\r\n",
-                        r->narg - 1);
+                        req->narg - 1);
         break;
 
      case MSG_REQ_REDIS_MSET:
         n = dn_snprintf(mbuf->last, mbuf_size(mbuf), "*%d\r\n$4\r\nmset\r\n",
-                        r->narg - 2);
+                        req->narg - 2);
         break;
 
     case MSG_REQ_REDIS_DEL:
         n = dn_snprintf(mbuf->last, mbuf_size(mbuf), "*%d\r\n$3\r\ndel\r\n",
-                        r->narg - 1);
+                        req->narg - 1);
         break;
 
     default:
@@ -2435,18 +2436,18 @@ redis_pre_splitcopy(struct mbuf *mbuf, void *arg)
  * 'mget' or 'del' request and has already been split into two requests
  */
 rstatus_t
-redis_post_splitcopy(struct msg *r)
+redis_post_splitcopy(struct msg *req)
 {
     struct mbuf *hbuf, *nhbuf;         /* head mbuf and new head mbuf */
     struct string hstr = string("*2"); /* header string */
-    if (r->type == MSG_REQ_REDIS_MSET) {
+    if (req->type == MSG_REQ_REDIS_MSET) {
         string_set_text(&hstr, "*3");
     }
 
-    ASSERT(r->is_request);
-    ASSERT(r->type == MSG_REQ_REDIS_MGET || r->type == MSG_REQ_REDIS_DEL ||
-           r->type == MSG_REQ_REDIS_MSET);
-    ASSERT(!STAILQ_EMPTY(&r->mhdr));
+    ASSERT(req->is_request);
+    ASSERT(req->type == MSG_REQ_REDIS_MGET || req->type == MSG_REQ_REDIS_DEL ||
+           req->type == MSG_REQ_REDIS_MSET);
+    ASSERT(!STAILQ_EMPTY(&req->mhdr));
 
     nhbuf = mbuf_get();
     if (nhbuf == NULL) {
@@ -2457,21 +2458,21 @@ redis_post_splitcopy(struct msg *r)
      * Fix the head mbuf in the head (A) msg. The fix is straightforward
      * as we just need to skip over the narg token
      */
-    hbuf = STAILQ_FIRST(&r->mhdr);
-    ASSERT(hbuf->pos == r->narg_start);
-    ASSERT(hbuf->pos < r->narg_end && r->narg_end <= hbuf->last);
-    hbuf->pos = r->narg_end;
+    hbuf = STAILQ_FIRST(&req->mhdr);
+    ASSERT(hbuf->pos == req->narg_start);
+    ASSERT(hbuf->pos < req->narg_end && req->narg_end <= hbuf->last);
+    hbuf->pos = req->narg_end;
 
     /*
      * Add a new head mbuf in the head (A) msg that just contains '*2'
      * token
      */
-    STAILQ_INSERT_HEAD(&r->mhdr, nhbuf, next);
+    STAILQ_INSERT_HEAD(&req->mhdr, nhbuf, next);
     mbuf_copy(nhbuf, hstr.data, hstr.len);
 
     /* fix up the narg_start and narg_end */
-    r->narg_start = nhbuf->pos;
-    r->narg_end = nhbuf->last;
+    req->narg_start = nhbuf->pos;
+    req->narg_end = nhbuf->last;
 
     return DN_OK;
 }
@@ -2482,82 +2483,82 @@ redis_post_splitcopy(struct msg *r)
  * responses to the fragmented request vector hasn't been received
  */
 void
-redis_pre_coalesce(struct msg *r)
+redis_pre_coalesce(struct msg *rsp)
 {
-    struct msg *pr = r->peer; /* peer request */
+    struct msg *req = rsp->peer; /* peer request */
     struct mbuf *mbuf;
 
-    ASSERT(!r->is_request);
-    ASSERT(pr->is_request);
+    ASSERT(!rsp->is_request);
+    ASSERT(req->is_request);
 
-    if (pr->frag_id == 0) {
+    if (req->frag_id == 0) {
         /* do nothing, if not a response to a fragmented request */
         return;
     }
 
-    switch (r->type) {
+    switch (rsp->type) {
     case MSG_RSP_REDIS_INTEGER:
         /* only redis 'del' fragmented request sends back integer reply */
-        ASSERT(pr->type == MSG_REQ_REDIS_DEL);
+        ASSERT(req->type == MSG_REQ_REDIS_DEL);
 
-        mbuf = STAILQ_FIRST(&r->mhdr);
+        mbuf = STAILQ_FIRST(&rsp->mhdr);
         /*
          * Our response parser guarantees that the integer reply will be
          * completely encapsulated in a single mbuf and we should skip over
          * all the mbuf contents and discard it as the parser has already
          * parsed the integer reply and stored it in msg->integer
          */
-        ASSERT(mbuf == STAILQ_LAST(&r->mhdr, mbuf, next));
-        ASSERT(r->mlen == mbuf_length(mbuf));
+        ASSERT(mbuf == STAILQ_LAST(&rsp->mhdr, mbuf, next));
+        ASSERT(rsp->mlen == mbuf_length(mbuf));
 
-        r->mlen -= mbuf_length(mbuf);
+        rsp->mlen -= mbuf_length(mbuf);
         mbuf_rewind(mbuf);
 
         /* accumulate the integer value in frag_owner of peer request */
-        pr->frag_owner->integer += r->integer;
+        req->frag_owner->integer += rsp->integer;
         break;
 
     case MSG_RSP_REDIS_MULTIBULK:
         /* only redis 'mget' fragmented request sends back multi-bulk reply */
-        ASSERT(pr->type == MSG_REQ_REDIS_MGET);
+        ASSERT(req->type == MSG_REQ_REDIS_MGET);
 
-        mbuf = STAILQ_FIRST(&r->mhdr);
+        mbuf = STAILQ_FIRST(&rsp->mhdr);
         /*
          * Muti-bulk reply can span over multiple mbufs and in each reply
          * we should skip over the narg token. Our response parser
          * guarantees thaat the narg token and the immediately following
          * '\r\n' will exist in a contiguous region in the first mbuf
          */
-        ASSERT(r->narg_start == mbuf->pos);
-        ASSERT(r->narg_start < r->narg_end);
+        ASSERT(rsp->narg_start == mbuf->pos);
+        ASSERT(rsp->narg_start < rsp->narg_end);
 
-        r->narg_end += CRLF_LEN;
-        r->mlen -= (uint32_t)(r->narg_end - r->narg_start);
-        mbuf->pos = r->narg_end;
+        rsp->narg_end += CRLF_LEN;
+        rsp->mlen -= (uint32_t)(rsp->narg_end - rsp->narg_start);
+        mbuf->pos = rsp->narg_end;
 
-        if (pr->first_fragment) {
+        if (req->first_fragment) {
             mbuf = mbuf_get();
             if (mbuf == NULL) {
-                pr->is_error = 1;
-                pr->error_code = EINVAL;
+                req->is_error = 1;
+                req->error_code = EINVAL;
                 return;
             }
-            STAILQ_INSERT_HEAD(&r->mhdr, mbuf, next);
+            STAILQ_INSERT_HEAD(&rsp->mhdr, mbuf, next);
         }
         break;
 
     case MSG_RSP_REDIS_STATUS:
-        if (pr->type == MSG_REQ_REDIS_MSET) {       /* MSET segments */
-            mbuf = STAILQ_FIRST(&r->mhdr);
-            r->mlen -= mbuf_length(mbuf);
+        if (req->type == MSG_REQ_REDIS_MSET) {       /* MSET segments */
+            mbuf = STAILQ_FIRST(&rsp->mhdr);
+            rsp->mlen -= mbuf_length(mbuf);
             mbuf_rewind(mbuf);
         }
         break;
 
     case MSG_RSP_REDIS_ERROR:
-        pr->is_error = r->is_error;
-        pr->error_code = r->error_code;
-        pr->dyn_error_code = r->dyn_error_code;
+        req->is_error = rsp->is_error;
+        req->error_code = rsp->error_code;
+        req->dyn_error_code = rsp->dyn_error_code;
         break;
 
     default:
@@ -2566,12 +2567,12 @@ redis_pre_coalesce(struct msg *r)
          * MSG_RSP_REDIS_MULTIBULK. For an invalid response, we send out -ERR
          * with EINVAL errno
          */
-        mbuf = STAILQ_FIRST(&r->mhdr);
+        mbuf = STAILQ_FIRST(&rsp->mhdr);
         if (mbuf)
             log_hexdump(LOG_ERR, mbuf->pos, mbuf_length(mbuf), "rsp fragment "
-                        "with unknown type %d", r->type);
-        pr->is_error = 1;
-        pr->error_code = EINVAL;
+                        "with unknown type %d", rsp->type);
+        req->is_error = 1;
+        req->error_code = EINVAL;
         break;
     }
 }
@@ -2583,60 +2584,60 @@ redis_pre_coalesce(struct msg *r)
  * the fragmented request is consider to be done
  */
 void
-redis_post_coalesce(struct msg *r)
+redis_post_coalesce(struct msg *req)
 {
-    struct msg *pr = r->selected_rsp; /* peer response */
+    struct msg *rsp = req->selected_rsp; /* peer response */
     struct mbuf *mbuf;
     int n;
     rstatus_t status = DN_OK;
 
-    ASSERT(r->is_request && r->first_fragment);
-    if (r->is_error || r->is_ferror) {
+    ASSERT(req->is_request && req->first_fragment);
+    if (req->is_error || req->is_ferror) {
         /* do nothing, if msg is in error */
         return;
     }
 
-    ASSERT(!pr->is_request);
+    ASSERT(!rsp->is_request);
 
-    switch (pr->type) {
+    switch (rsp->type) {
     case MSG_RSP_REDIS_INTEGER:
         /* only redis 'del' fragmented request sends back integer reply */
-        ASSERT(r->type == MSG_REQ_REDIS_DEL);
+        ASSERT(req->type == MSG_REQ_REDIS_DEL);
 
-        mbuf = STAILQ_FIRST(&pr->mhdr);
+        mbuf = STAILQ_FIRST(&rsp->mhdr);
 
-        ASSERT(pr->mlen == 0);
+        ASSERT(rsp->mlen == 0);
         ASSERT(mbuf_empty(mbuf));
 
-        n = dn_scnprintf(mbuf->last, mbuf_size(mbuf), ":%d\r\n", r->integer);
+        n = dn_scnprintf(mbuf->last, mbuf_size(mbuf), ":%d\r\n", req->integer);
         mbuf->last += n;
-        pr->mlen += (uint32_t)n;
+        rsp->mlen += (uint32_t)n;
         break;
 
     case MSG_RSP_REDIS_MULTIBULK:
         /* only redis 'mget' fragmented request sends back multi-bulk reply */
-        ASSERT(r->type == MSG_REQ_REDIS_MGET);
+        ASSERT(req->type == MSG_REQ_REDIS_MGET);
 
-        mbuf = STAILQ_FIRST(&pr->mhdr);
+        mbuf = STAILQ_FIRST(&rsp->mhdr);
         ASSERT(mbuf_empty(mbuf));
 
-        n = dn_scnprintf(mbuf->last, mbuf_size(mbuf), "*%d\r\n", r->nfrag);
+        n = dn_scnprintf(mbuf->last, mbuf_size(mbuf), "*%d\r\n", req->nfrag);
         mbuf->last += n;
-        pr->mlen += (uint32_t)n;
+        rsp->mlen += (uint32_t)n;
         break;
 
     case MSG_RSP_REDIS_STATUS:
-        status = msg_append(pr, rsp_ok.data, rsp_ok.len);
+        status = msg_append(rsp, rsp_ok.data, rsp_ok.len);
         if (status != DN_OK) {
-            pr->is_error = 1;        /* mark this msg as err */
-            pr->error_code = errno;
+            rsp->is_error = 1;        /* mark this msg as err */
+            rsp->error_code = errno;
         }
         break;
     default:
         log_error("req %lu:%lu type %u has rsp %lu:%lu with invalid type %u",
-                  r->id, r->parent_id, r->type, pr->id, pr->parent_id, pr->type);
+                  req->id, req->parent_id, req->type, rsp->id, rsp->parent_id, rsp->type);
         if (log_loggable(LOG_INFO)) {
-            msg_dump(pr);
+            msg_dump(rsp);
         }
         NOT_REACHED();
     }


### PR DESCRIPTION
This helps to understand the context of the function more easily as compared to naming variables as r, pr, msg etc