### PR TITLE
Remove the concept of distribution

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -32,11 +32,14 @@ SUBDIRS = hashkit proto event seedsprovider tools entropy
 sbin_PROGRAMS = dynomite dynomite-test
 
 dynomite_SOURCES =			                          \
+        dyn_array.c dyn_array.h		                          \
+        dyn_asciilogo.h                                           \
         dyn_cbuf.h                                                \
-        dyn_crypto.c dyn_crypto.h                                 \
-        dyn_core.c dyn_core.h                                     \
-        dyn_connection.c dyn_connection.h                         \
         dyn_client.c dyn_client.h                                 \
+        dyn_conf.c dyn_conf.h		                          \
+        dyn_connection.c dyn_connection.h                         \
+        dyn_core.c dyn_core.h                                     \
+        dyn_crypto.c dyn_crypto.h                                 \
         dyn_dict_msg_id.h dyn_dict_msg_id.c                       \
         dyn_dnode_client.h dyn_dnode_client.c                     \
         dyn_dnode_msg.c dyn_dnode_msg.h                           \
@@ -44,28 +47,26 @@ dynomite_SOURCES =			                          \
         dyn_dnode_request.c                                       \
         dyn_dnode_proxy.c dyn_dnode_proxy.h                       \
         dyn_histogram.c dyn_histogram.h                           \
-        dyn_server.c dyn_server.h		                  \
         dyn_proxy.c dyn_proxy.h		                          \
         dyn_message.c dyn_message.h	                          \
         dyn_request.c dyn_response_mgr.c	                  \
         dyn_response.c			                          \
         dyn_ring_queue.h dyn_ring_queue.c                         \
         dyn_mbuf.c dyn_mbuf.h		                          \
-        dyn_conf.c dyn_conf.h		                          \
         dyn_node_snitch.c dyn_node_snitch.h                       \
-        dyn_setting.c dyn_setting.h                               \
-        dyn_stats.c dyn_stats.h		                          \
-        dyn_signal.c dyn_signal.h		                  \
-        dyn_token.c dyn_token.h                                   \
         dyn_rbtree.c dyn_rbtree.h		                  \
-        dyn_log.c dyn_log.h		                          \
+        dyn_server.c dyn_server.h		                  \
+        dyn_setting.c dyn_setting.h                               \
+        dyn_signal.c dyn_signal.h		                  \
+        dyn_stats.c dyn_stats.h		                          \
         dyn_string.c dyn_string.h		                  \
-        dyn_array.c dyn_array.h		                          \
+        dyn_token.c dyn_token.h                                   \
+        dyn_log.c dyn_log.h		                          \
         dyn_util.c dyn_util.h		                          \
+        dyn_vnode.c dyn_vnode.h                                   \
         dyn_queue.h			                          \
         dyn_gossip.c dyn_gossip.h                                 \
         dyn_dict.c dyn_dict.h                                     \
-        dyn_asciilogo.h                                           \
         dynomite.c 
 
 dynomite_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
@@ -93,7 +94,7 @@ dynomite_test_SOURCES =                                           \
         dyn_server.c dyn_server.h                                 \
         dyn_proxy.c dyn_proxy.h                                   \
         dyn_message.c dyn_message.h                               \
-        dyn_request.c dyn_response_mgr.c	                  \
+        dyn_request.c dyn_response_mgr.c                          \
         dyn_response.c                                            \
         dyn_ring_queue.h dyn_ring_queue.c                         \
         dyn_mbuf.c dyn_mbuf.h                                     \
@@ -109,6 +110,7 @@ dynomite_test_SOURCES =                                           \
         dyn_array.c dyn_array.h                                   \
         dyn_util.c dyn_util.h                                     \
         dyn_queue.h                                               \
+        dyn_vnode.c dyn_vnode.h                                   \
         dyn_gossip.c dyn_gossip.h                                 \
         dyn_dict.c dyn_dict.h                                     \
         dyn_asciilogo.h                                           \

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -79,7 +79,7 @@ struct conf_pool {
     struct conf_listen listen;                /* listen: */
     hash_type_t        hash;                  /* hash: */
     struct string      hash_tag;              /* hash_tag: */
-    dist_type_t        distribution;          /* distribution: */
+    void               *distribution;          /* Deprecated: distribution */
     msec_t             timeout;               /* timeout: */
     int                backlog;               /* backlog: */
     int                client_connections;    /* client_connections: */

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -85,25 +85,6 @@ typedef int err_t;     /* error type */
 
 #define IGNORE_RET_VAL(x) x;
 
-struct array;
-struct string;
-struct context;
-struct conn;
-struct conn_tqh;
-struct msg;
-struct msg_tqh;
-struct server;
-struct server_pool;
-struct mbuf;
-struct mhdr;
-struct conf;
-struct stats;
-struct entropy_conn;
-struct instance;
-struct event_base;
-struct rack;
-struct dyn_ring;
-
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -308,7 +289,6 @@ struct server_pool {
 
     struct string      name;                 /* pool name (ref in conf_pool) */
     struct endpoint    proxy_endpoint;
-    int                dist_type;            /* distribution type (dist_type_t) */
     int                key_hash_type;        /* key hash type (hash_type_t) */
     hash_t             key_hash;             /* key hasher */
     struct string      hash_tag;             /* key hash tag (ref in conf_pool) */

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -13,6 +13,7 @@
 #include "dyn_dnode_peer.h"
 #include "dyn_node_snitch.h"
 #include "dyn_token.h"
+#include "dyn_vnode.h"
 
 static rstatus_t dnode_peer_pool_update(struct server_pool *pool);
 
@@ -1131,8 +1132,8 @@ dnode_peer_for_key_on_rack(struct server_pool *pool, struct rack *rack,
     }*/
 
     if (log_loggable(LOG_VERB)) {
-        log_debug(LOG_VERB, "dyn: key '%.*s' on dist %d maps to server '%.*s'", keylen,
-                key, pool->dist_type, server->endpoint.pname.len, server->endpoint.pname.data);
+        log_debug(LOG_VERB, "dyn: key '%.*s' maps to server '%.*s'", keylen,
+                key, server->endpoint.pname.len, server->endpoint.pname.data);
     }
 
     return server;

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -288,8 +288,8 @@ struct msg {
     struct msg           *peer;           /* message peer */
     struct conn          *owner;          /* message owner - client | server */
     usec_t               stime_in_microsec;  /* start time in microsec */
-    int64_t              request_inqueue_enqueue_time_us; /* when message was enqueued in inqueue, either to the data store or remote region or cross rack */
-    int64_t              request_send_time; /* when message was sent: either to the data store or remote region or cross rack */
+    usec_t               request_inqueue_enqueue_time_us; /* when message was enqueued in inqueue, either to the data store or remote region or cross rack */
+    usec_t               request_send_time; /* when message was sent: either to the data store or remote region or cross rack */
     uint8_t              awaiting_rsps;
     struct msg           *selected_rsp;
 

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -11,3 +11,22 @@ typedef enum {
     SECURE_OPTION_DC,
     SECURE_OPTION_ALL,
 }secure_server_option_t;
+
+struct array;
+struct string;
+struct context;
+struct conn;
+struct conn_tqh;
+struct msg;
+struct msg_tqh;
+struct server;
+struct server_pool;
+struct mbuf;
+struct mhdr;
+struct conf;
+struct stats;
+struct entropy_conn;
+struct instance;
+struct event_base;
+struct rack;
+struct dyn_ring;

--- a/src/dyn_vnode.c
+++ b/src/dyn_vnode.c
@@ -27,7 +27,7 @@
 #include <dyn_dnode_peer.h>
 #include <dyn_core.h>
 #include <dyn_server.h>
-#include <dyn_hashkit.h>
+#include <dyn_vnode.h>
 
 static int
 vnode_item_cmp(const void *t1, const void *t2)

--- a/src/dyn_vnode.h
+++ b/src/dyn_vnode.h
@@ -1,0 +1,6 @@
+#pragma once
+#include <dyn_types.h>
+
+rstatus_t vnode_update(struct server_pool *pool);
+uint32_t vnode_dispatch(struct continuum *continuum, uint32_t ncontinuum, struct dyn_token *token);
+

--- a/src/hashkit/Makefile.am
+++ b/src/hashkit/Makefile.am
@@ -20,11 +20,7 @@ libhashkit_a_SOURCES =		\
 	dyn_fnv.c		\
 	dyn_hsieh.c		\
 	dyn_jenkins.c		\
-	dyn_ketama.c		\
 	dyn_md5.c		\
-	dyn_modula.c		\
 	dyn_murmur.c		\
 	dyn_one_at_a_time.c	\
-	dyn_random.c		\
-	dyn_vnode.c             \
 	dyn_murmur3.c

--- a/src/hashkit/dyn_hashkit.h
+++ b/src/hashkit/dyn_hashkit.h
@@ -43,25 +43,11 @@
     ACTION( HASH_JENKINS,       jenkins       ) \
     ACTION( HASH_MURMUR3,       murmur3       ) \
 
-#define DIST_CODEC(ACTION)                      \
-    ACTION( DIST_KETAMA,        ketama        ) \
-    ACTION( DIST_MODULA,        modula        ) \
-    ACTION( DIST_RANDOM,        random        ) \
-    ACTION( DIST_VNODE,         vnode         ) \
-    ACTION( DIST_SINGLE,        single        ) \
-
 #define DEFINE_ACTION(_hash, _name) _hash,
 typedef enum hash_type {
     HASH_CODEC( DEFINE_ACTION )
     HASH_SENTINEL
 } hash_type_t;
-#undef DEFINE_ACTION
-
-#define DEFINE_ACTION(_dist, _name) _dist,
-typedef enum dist_type {
-    DIST_CODEC( DEFINE_ACTION )
-    DIST_SENTINEL
-} dist_type_t;
 #undef DEFINE_ACTION
 
 rstatus_t hash_one_at_a_time(const char *key, size_t key_length, struct dyn_token *token);
@@ -81,16 +67,5 @@ uint32_t crc32_sz(const char *buf, size_t length, uint32_t in_crc32);
 
 rstatus_t hash_murmur(const char *key, size_t length, struct dyn_token *token);
 rstatus_t hash_murmur3(const char *key, size_t length, struct dyn_token *token);
-
-rstatus_t vnode_update(struct server_pool *pool);
-uint32_t vnode_dispatch(struct continuum *continuum, uint32_t ncontinuum, struct dyn_token *token);
-
-
-rstatus_t ketama_update(struct server_pool *pool);
-uint32_t ketama_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
-rstatus_t modula_update(struct server_pool *pool);
-uint32_t modula_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
-rstatus_t random_update(struct server_pool *pool);
-uint32_t random_dispatch(struct continuum *continuum, uint32_t ncontinuum, uint32_t hash);
 
 #endif


### PR DESCRIPTION
* We use only one type of distribution thats provided by the dynomite
  manager to keep things simple. Cleanup code related to that
* Reduce some warnings