### PR TITLE
Hotfix/v0.5.8-4_HscanLocalRack

### DIFF
--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -1140,7 +1140,7 @@ dnode_peer_for_key_on_rack(struct server_pool *pool, struct rack *rack,
 struct node *
 dnode_peer_pool_server(struct context *ctx, struct server_pool *pool,
                        struct rack *rack, uint8_t *key, uint32_t keylen,
-                       uint8_t msg_type)
+                       msg_routing_t msg_routing)
 {
     rstatus_t status;
     struct node *peer;
@@ -1153,7 +1153,7 @@ dnode_peer_pool_server(struct context *ctx, struct server_pool *pool,
         return NULL;
     }
 
-    if (msg_type == 1) {  //always local
+    if (msg_routing == ROUTING_LOCAL_NODE_ONLY) {  //always local
         peer = array_get(&pool->peers, 0);
     } else {
         /* from a given {key, keylen} pick a peer from pool */

--- a/src/dyn_dnode_peer.h
+++ b/src/dyn_dnode_peer.h
@@ -17,7 +17,9 @@ rstatus_t dnode_peer_init(struct context *ctx);
 void dnode_peer_deinit(struct array *nodes);
 void dnode_peer_connected(struct context *ctx, struct conn *conn);
 
-struct node *dnode_peer_pool_server(struct context *ctx, struct server_pool *pool, struct rack *rack, uint8_t *key, uint32_t keylen, uint8_t msg_type);
+struct node *dnode_peer_pool_server(struct context *ctx, struct server_pool *pool,
+                                    struct rack *rack, uint8_t *key, uint32_t keylen,
+                                    msg_routing_t msg_routing);
 struct conn *dnode_peer_pool_server_conn(struct context *ctx, struct node *server);
 rstatus_t dnode_peer_pool_preconnect(struct context *ctx);
 void dnode_peer_pool_disconnect(struct context *ctx);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -355,7 +355,7 @@ done:
     msg->is_read = 1;
     msg->dyn_state = 0;
     msg->dmsg = NULL;
-    msg->msg_type = 0;
+    msg->msg_routing = ROUTING_NORMAL;
     msg->dyn_error = 0;
     msg->rsp_handler = msg_cant_handle_response;
     msg->consistency = DC_ONE;

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -279,6 +279,27 @@ extern consistency_t g_write_consistency;
 extern consistency_t g_read_consistency;
 extern uint8_t g_timeout_factor;
 
+typedef enum msg_routing {
+    ROUTING_NORMAL = 0,
+    ROUTING_LOCAL_NODE_ONLY = 1, /* Ignore the key hashing */
+    ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY = 2, /* apply key hashing, but local rack only */
+    ROUTING_ALL_NODES_LOCAL_RACK_ONLY = 3, /* Ignore key hashing, local rack only */
+} msg_routing_t;
+
+static inline char*
+get_msg_routing_string(msg_routing_t route)
+{
+    switch(route)
+    {
+        case ROUTING_NORMAL: return "ROUTING_NORMAL";
+        case ROUTING_LOCAL_NODE_ONLY: return "ROUTING_LOCAL_NODE_ONLY";
+        case ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY: return "ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY";
+        case ROUTING_ALL_NODES_LOCAL_RACK_ONLY: return "ROUTING_ALL_NODES_LOCAL_RACK_ONLY";
+    }
+    return "INVALID MSG ROUTING TYPE";
+}
+
+
 struct msg {
     TAILQ_ENTRY(msg)     c_tqe;           /* link in client q */
     TAILQ_ENTRY(msg)     s_tqe;           /* link in server q */
@@ -348,12 +369,7 @@ struct msg {
     struct dmsg          *dmsg;          /* dyn message */
     int                  dyn_state;
     dyn_error_t          dyn_error;      /* error code for dynomite */
-    uint8_t              msg_type;       /* for special message types
-                                              0 : normal,
-                                              1 : local cmd only no matter what
-                                              2 : cmd to all nodes in same RACK no matter whats
-                                              3 : cmd to all RACKs (one node from each RACK)
-                                          */
+    msg_routing_t        msg_routing;
     unsigned             is_read:1;       /*  0 : write
                                               1 : read */
     msg_response_handler_t rsp_handler;

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -624,14 +624,14 @@ redis_parse_req(struct msg *r)
 
                 if (str4icmp(m, 'k', 'e', 'y', 's')) { /* Yannis: Need to identify how this is defined in Redis protocol */
                     r->type = MSG_REQ_REDIS_KEYS;
-                    r->msg_type = 1; //local only
+                    r->msg_routing = ROUTING_LOCAL_NODE_ONLY;
                     r->is_read = 1;
                     break;
                 }
 
                 if (str4icmp(m, 'i', 'n', 'f', 'o')) {
                     r->type = MSG_REQ_REDIS_INFO;
-                    r->msg_type = 1; //local only
+                    r->msg_routing = ROUTING_LOCAL_NODE_ONLY;
                     p = p + 1;
                     r->is_read = 1;
                     goto done;
@@ -675,6 +675,7 @@ redis_parse_req(struct msg *r)
 
                 if (str4icmp(m, 'p', 'i', 'n', 'g')) {
                     r->type = MSG_REQ_REDIS_PING;
+                    r->msg_routing = ROUTING_LOCAL_NODE_ONLY;
                     p = p + 1;
                     r->is_read = 1;
                     goto done;
@@ -694,7 +695,7 @@ redis_parse_req(struct msg *r)
 
                 if (str4icmp(m, 's', 'c', 'a', 'n')) {
                     r->type = MSG_REQ_REDIS_SCAN;
-                    r->msg_type = 1; //local only
+                    r->msg_routing = ROUTING_LOCAL_NODE_ONLY;
                     r->is_read = 1;
                     break;
                 }
@@ -770,12 +771,14 @@ redis_parse_req(struct msg *r)
 
                 if (str5icmp(m, 'h', 'v', 'a', 'l', 's')) {
                     r->type = MSG_REQ_REDIS_HVALS;
+                    r->msg_routing = ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY;
                     r->is_read = 1;
                     break;
                 }
 
                 if (str5icmp(m, 'h', 's', 'c', 'a', 'n')) {
                     r->type = MSG_REQ_REDIS_HSCAN;
+                    r->msg_routing = ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY;
                     r->is_read = 1;
                     break;
                 }
@@ -830,6 +833,7 @@ redis_parse_req(struct msg *r)
 
                 if (str5icmp(m, 's', 's', 'c', 'a', 'n')) {
                     r->type = MSG_REQ_REDIS_SSCAN;
+                    r->msg_routing = ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY;
                     r->is_read = 1;
                     break;
                 }
@@ -848,6 +852,7 @@ redis_parse_req(struct msg *r)
 
                 if (str5icmp(m, 'z', 's', 'c', 'a', 'n')) {
                      r->type = MSG_REQ_REDIS_ZSCAN;
+                    r->msg_routing = ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY;
                      r->is_read = 1;
                      break;
                 }
@@ -982,7 +987,7 @@ redis_parse_req(struct msg *r)
 
                 if (str6icmp(m, 'c', 'o', 'n', 'f', 'i', 'g')) {
                 	r->type = MSG_REQ_REDIS_CONFIG;
-                    r->msg_type = 1; //local only
+                    r->msg_routing = ROUTING_LOCAL_NODE_ONLY;
                 	r->is_read = 1;
                 	break;
                 }
@@ -1046,7 +1051,7 @@ redis_parse_req(struct msg *r)
 
                 if (str7icmp(m, 's', 'l', 'a', 'v', 'e', 'o', 'f')) {
                     r->type = MSG_REQ_REDIS_SLAVEOF;
-                    r->msg_type = 1;
+                    r->msg_routing = ROUTING_LOCAL_NODE_ONLY;
                     r->is_read = 0;
                     break;
                 }


### PR DESCRIPTION
* Replace earlier msg_type with an enum of Message Routing
* This will enable individual datastore parser to override the default
  behaviour of routing a message in the system.