### PR TITLE
enable_gossip property in the .yml

### DIFF
--- a/conf/a_dc2_rack2_node1.yml
+++ b/conf/a_dc2_rack2_node1.yml
@@ -15,4 +15,5 @@ dyn_o_mite:
   pem_key_file: conf/dynomite.pem
   data_store: 0
   stats_listen: 0.0.0.0:22224
+  enable_gossip: true
   

--- a/conf/a_dc2_rack2_node1.yml
+++ b/conf/a_dc2_rack2_node1.yml
@@ -15,5 +15,5 @@ dyn_o_mite:
   pem_key_file: conf/dynomite.pem
   data_store: 0
   stats_listen: 0.0.0.0:22224
-  enable_gossip: true
+  enable_gossip: false
   

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -62,8 +62,9 @@ static struct string dist_strings[] = {
 #define CONF_ROOT_DEPTH     1
 #define CONF_MAX_DEPTH      CONF_ROOT_DEPTH + 1
 #define CONF_DEFAULT_ARGS       3
-#define CONF_UNSET_NUM  0
-#define CONF_UNSET_PTR  NULL
+#define CONF_UNSET_BOOL  false
+#define CONF_UNSET_NUM   0
+#define CONF_UNSET_PTR   NULL
 #define CONF_DEFAULT_SERVERS    8
 #define CONF_UNSET_HASH (hash_type_t) -1
 #define CONF_UNSET_DIST (dist_type_t) -1
@@ -329,6 +330,7 @@ conf_pool_init(struct conf_pool *cp, struct string *name)
     array_null(&cp->dyn_seeds);
 
     cp->valid = 0;
+    cp->enable_gossip = CONF_UNSET_BOOL;
 
     status = string_duplicate(&cp->name, name);
     if (status != DN_OK) {
@@ -493,6 +495,7 @@ conf_pool_transform(struct server_pool *sp, struct conf_pool *cp)
     sp->dc = cp->dc;
     sp->tokens = cp->tokens;
     sp->env = cp->env;
+    sp->enable_gossip = cp->enable_gossip;
 
     /* dynomite stats init */
     sp->stats_endpoint.pname = cp->stats_listen.pname;
@@ -1410,16 +1413,16 @@ static struct command conf_commands[] = {
       offsetof(struct conf_pool, secure_server_option) },
 
     { string("pem_key_file"),
-        conf_set_string,
-        offsetof(struct conf_pool, pem_key_file) },
+      conf_set_string,
+      offsetof(struct conf_pool, pem_key_file) },
 
 	{ string("recon_key_file"),
-	    conf_set_string,
-	    offsetof(struct conf_pool, recon_key_file) },
+      conf_set_string,
+	  offsetof(struct conf_pool, recon_key_file) },
 
 	{ string("recon_iv_file"),
-		conf_set_string,
-		offsetof(struct conf_pool, recon_iv_file) },
+      conf_set_string,
+      offsetof(struct conf_pool, recon_iv_file) },
 
     { string("datacenter"),
       conf_set_string,
@@ -1448,6 +1451,10 @@ static struct command conf_commands[] = {
 	{ string("stats_interval"),
 	  conf_set_string,
 	  offsetof(struct conf_pool, stats_interval) },
+
+	{ string("enable_gossip"),
+	  conf_set_bool,
+	  offsetof(struct conf_pool, enable_gossip) },
 
     null_command
 };
@@ -2215,7 +2222,7 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
     }
 
     if (cp->stats_interval == CONF_UNSET_NUM) {
-            cp->stats_interval = CONF_DEFAULT_STATS_INTERVAL_MS;
+        cp->stats_interval = CONF_DEFAULT_STATS_INTERVAL_MS;
     }
 
     if (!cp->stats_listen.valid) {

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -112,6 +112,7 @@ struct conf_pool {
     struct string      dc;                    /* this node's dc */
     struct string      env;                   /* AWS, Google, network, ... */
     uint32_t           conn_msg_rate;         /* conn msg per sec */
+    bool               enable_gossip;         /* enable/disable gossip */
 
     /* stats info */
     int                stats_interval;        /* stats aggregation interval */

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -227,7 +227,6 @@ core_ctx_create(struct instance *nci)
     ctx->cf = NULL;
     ctx->stats = NULL;
     ctx->evb = NULL;
-    ctx->dyn_state = INIT;
 
     /* parse and create configuration */
     ctx->cf = conf_create(nci->conf_filename);
@@ -242,10 +241,18 @@ core_ctx_create(struct instance *nci)
     ctx->max_timeout = cp->stats_interval;
     ctx->timeout = ctx->max_timeout;
 
+    /* Gossip status */
+    struct server_pool *sp = &ctx->pool;
+    ctx->dyn_state = INIT;
+    if (!sp->enable_gossip) {
+    	ctx->dyn_state = NORMAL;
+    } else {
+    	loga("Gossip state: Initialization");
+    }
 
     rstatus_t status = core_server_pool_init(ctx);
     if (status != DN_OK) {
-        server_pool_deinit(&ctx->pool);
+        server_pool_deinit(sp);
         conf_destroy(ctx->cf);
         dn_free(ctx);
         return DN_ERROR;

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -242,18 +242,12 @@ core_ctx_create(struct instance *nci)
     ctx->max_timeout = cp->stats_interval;
     ctx->timeout = ctx->max_timeout;
 
-    /* Gossip status */
-    struct server_pool *sp = &ctx->pool;
+    /* Gossip initialization */
     ctx->dyn_state = INIT;
-    if (!sp->enable_gossip) {
-    	ctx->dyn_state = NORMAL;
-    } else {
-    	loga("Gossip state: Initialization");
-    }
 
     rstatus_t status = core_server_pool_init(ctx);
     if (status != DN_OK) {
-        server_pool_deinit(sp);
+        server_pool_deinit(&ctx->pool);
         conf_destroy(ctx->cf);
         dn_free(ctx);
         return DN_ERROR;

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -324,6 +324,7 @@ struct server_pool {
     struct string      recon_iv_file;        /* file with Initialization Vector encryption in reconciliation */
     struct endpoint    stats_endpoint;       /* stats_listen: socket info for stats */
     int                stats_interval;       /* stats aggregation interval */
+    bool               enable_gossip;        /* enable/disable gossip */
 
 };
 
@@ -346,7 +347,6 @@ struct context {
     int                timeout;     /* timeout in msec */
     dyn_state_t        dyn_state;   /* state of the node.  Don't need volatile as
                                        it is ok to eventually get its new value */
-    unsigned           enable_gossip:1;   /* enable/disable gossip */
     unsigned           admin_opt;   /* admin mode */
 };
 

--- a/src/dyn_gossip.c
+++ b/src/dyn_gossip.c
@@ -803,7 +803,7 @@ gossip_loop(void *arg)
             gn_pool.ctx->dyn_state = NORMAL;
         }
 
-        if (!sp->ctx->enable_gossip) {
+        if (!sp->enable_gossip) {
             //gossip_debug();
             continue;  //no gossiping
         }

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -581,6 +581,10 @@ dn_run(struct instance *nci)
     struct context *ctx = nci->ctx;
     ctx->admin_opt = (unsigned)admin_opt;
 
+    struct server_pool *sp = &ctx->pool;
+    if (!sp->enable_gossip)
+    	ctx->dyn_state = NORMAL;
+
     /* run rabbit run */
     for (;;) {
         status = core_loop(ctx);

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -60,7 +60,6 @@ static int show_version;
 static int test_conf;
 static int admin_opt = 0;
 static int daemonize;
-static bool enable_gossip = false;
 static int describe_stats;
 
 static struct option long_options[] = {
@@ -69,7 +68,6 @@ static struct option long_options[] = {
     { "test-conf",            no_argument,        NULL,   't' },
     { "daemonize",            no_argument,        NULL,   'd' },
     { "describe-stats",       no_argument,        NULL,   'D' },
-    { "gossip",               no_argument,        NULL,   'g' },
     { "verbosity",            required_argument,  NULL,   'v' },
     { "output",               required_argument,  NULL,   'o' },
     { "conf-file",            required_argument,  NULL,   'c' },
@@ -234,7 +232,6 @@ dn_show_usage(void)
         "  -h, --help             : this help" CRLF
         "  -V, --version          : show version and exit" CRLF
         "  -t, --test-conf        : test configuration for syntax errors and exit" CRLF
-        "  -g, --gossip           : enable gossip (default: disable)" CRLF
         "  -d, --daemonize        : run as a daemon" CRLF
         "  -D, --describe-stats   : print stats description and exit");
     log_stderr(
@@ -374,10 +371,6 @@ dn_get_options(int argc, char **argv, struct instance *nci)
         case 'D':
             describe_stats = 1;
             show_version = 1;
-            break;
-
-        case 'g':
-            enable_gossip = true;
             break;
 
         case 'v':
@@ -586,11 +579,7 @@ dn_run(struct instance *nci)
     THROW_STATUS(core_start(nci));
 
     struct context *ctx = nci->ctx;
-    ctx->enable_gossip = enable_gossip;
     ctx->admin_opt = (unsigned)admin_opt;
-
-    if (!ctx->enable_gossip)
-    	ctx->dyn_state = NORMAL;
 
     /* run rabbit run */
     for (;;) {

--- a/src/entropy/dyn_entropy_util.c
+++ b/src/entropy/dyn_entropy_util.c
@@ -136,7 +136,7 @@ entropy_crypto_deinit()
  * Function: entropy_decrypt
  * --------------------
  *  Decrypt the input data using the key and the Initialization Vector (IV).
- *  Uses AES_256_CBC
+ *  Uses AES_128_CBC
  *
  *  returns: the length of the ciphertext if it has ended successfully,
  *  or the DN_ERROR status.
@@ -156,7 +156,7 @@ entropy_decrypt(unsigned char *ciphertext, int ciphertext_len, unsigned char *pl
   if(!(ctx = EVP_CIPHER_CTX_new()))
 	  goto error;
 
-  /* Initialize the decryption operation with 256 bit AES */
+  /* Initialize the decryption operation with 128 bit AES */
   if(1 != EVP_DecryptInit_ex(ctx, EVP_aes_128_cbc(), NULL, theKey, theIv))
      goto error;
 


### PR DESCRIPTION
Simplifying configuration commands by moving gossip enable/disable to YAML.