### PR TITLE
Fix autoeject for datastore

### DIFF
--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -441,7 +441,6 @@ conf_pool_transform(struct server_pool *sp, struct conf_pool *cp)
     /* sp->ncontinuum = 0; */
     /* sp->nserver_continuum = 0; */
     /* sp->continuum = NULL; */
-    sp->nlive_server = 0;
     sp->next_rebuild = 0ULL;
 
     sp->name = cp->name;

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -284,7 +284,6 @@ struct server_pool {
 
     struct datastore   *datastore;           /* underlying datastore */
     struct array       datacenters;          /* racks info  */
-    uint32_t           nlive_server;         /* # live server */
     uint64_t           next_rebuild;         /* next distribution rebuild time in usec */
 
     struct string      name;                 /* pool name (ref in conf_pool) */

--- a/src/dyn_gossip.h
+++ b/src/dyn_gossip.h
@@ -67,7 +67,6 @@ struct gossip_node_pool {
     struct context     *ctx;                 /* owner context */
     seeds_provider_t   seeds_provider;       /* seeds provider */
     struct array       datacenters;          /* gossip datacenters */
-    uint32_t           nlive_server;         /* # live server */
     int64_t            last_run;             /* last time run in usec */
     int                g_interval;           /* gossip interval */
     dict               *dict_dc;

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -210,7 +210,8 @@ typedef enum msg_type {
 
 
 typedef enum dyn_error {
-    UNKNOWN_ERROR,
+    DYNOMITE_UNKNOWN_ERROR,
+    DYNOMITE_INVALID_STATE,
     PEER_CONNECTION_REFUSE,
     PEER_HOST_DOWN,
     PEER_HOST_NOT_CONNECTED,
@@ -224,6 +225,8 @@ dn_strerror(dyn_error_t err)
 {
     switch(err)
     {
+        case DYNOMITE_INVALID_STATE:
+            return "Dynomite's current state does not allow this request";
         case NO_QUORUM_ACHIEVED:
             return "Failed to achieve Quorum";
         case PEER_HOST_DOWN:
@@ -240,6 +243,7 @@ dyn_error_source(dyn_error_t err)
 {
     switch(err)
     {
+        case DYNOMITE_INVALID_STATE:
         case NO_QUORUM_ACHIEVED:
             return "Dynomite:";
         case PEER_CONNECTION_REFUSE:

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -217,7 +217,7 @@ typedef enum dyn_error {
     PEER_HOST_NOT_CONNECTED,
     STORAGE_CONNECTION_REFUSE,
     BAD_FORMAT,
-    NO_QUORUM_ACHIEVED,
+    DYNOMITE_NO_QUORUM_ACHIEVED,
 } dyn_error_t;
 
 static inline char *
@@ -227,7 +227,7 @@ dn_strerror(dyn_error_t err)
     {
         case DYNOMITE_INVALID_STATE:
             return "Dynomite's current state does not allow this request";
-        case NO_QUORUM_ACHIEVED:
+        case DYNOMITE_NO_QUORUM_ACHIEVED:
             return "Failed to achieve Quorum";
         case PEER_HOST_DOWN:
             return "Peer Node is down";
@@ -244,7 +244,7 @@ dyn_error_source(dyn_error_t err)
     switch(err)
     {
         case DYNOMITE_INVALID_STATE:
-        case NO_QUORUM_ACHIEVED:
+        case DYNOMITE_NO_QUORUM_ACHIEVED:
             return "Dynomite:";
         case PEER_CONNECTION_REFUSE:
         case PEER_HOST_DOWN:

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -141,8 +141,8 @@ rspmgr_get_response(struct response_mgr *rspmgr)
         log_info("none of the responses match, returning error");
         struct msg *rsp = msg_get(rspmgr->conn, false, __FUNCTION__);
         rsp->is_error = 1;
-        rsp->error_code = NO_QUORUM_ACHIEVED;
-        rsp->dyn_error_code = NO_QUORUM_ACHIEVED;
+        rsp->error_code = DYNOMITE_NO_QUORUM_ACHIEVED;
+        rsp->dyn_error_code = DYNOMITE_NO_QUORUM_ACHIEVED;
         ASSERT(rspmgr->err_rsp == NULL);
         rspmgr->err_rsp = rsp;
         rspmgr->error_responses++;


### PR DESCRIPTION
* when a datastore is autoejected, we never got it back. Fix it
* Add new dyn_error_code to indicate a dynomite error to the higher layer