### PR TITLE
Single connection to datastore and peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Dynomite can be configured through a YAML file specified by the -c or --conf-fil
 + **timeout**: The timeout value in msec that we wait for to establish a connection to the server or receive a response from a server. By default, we wait indefinitely.
 + **preconnect**: A boolean value that controls if dynomite should preconnect to all the servers in this pool on process start. Defaults to false.
 + **data_store**: An integer value that controls if a server pool speaks redis (0) or memcached (1) or other protocol. Defaults to redis (0).
-+ **server_connections**: The maximum number of connections that can be opened to each server. By default, we open at most 1 server connection.
 + **auto_eject_hosts**: A boolean value that controls if server should be ejected temporarily when it fails consecutively server_failure_limit times. See [liveness recommendations](notes/recommendation.md#liveness) for information. Defaults to false.
 + **server_retry_timeout**: The timeout value in msec to wait for before retrying on a temporarily ejected server, when auto_eject_host is set to true. Defaults to 30000 msec.
 + **server_failure_limit**: The number of consecutive failures on a server that would lead to it being temporarily ejected when auto_eject_host is set to true. Defaults to 2.

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -81,14 +81,13 @@ struct conf_pool {
     struct conf_listen listen;                /* listen: */
     hash_type_t        hash;                  /* hash: */
     struct string      hash_tag;              /* hash_tag: */
-    void               *distribution;          /* Deprecated: distribution */
+    void               *deprecated;          /* Deprecated: distribution, server_connections */
     msec_t             timeout;               /* timeout: */
     int                backlog;               /* backlog: */
     int                client_connections;    /* client_connections: */
     int                data_store;            /* data_store: */
     int                preconnect;            /* preconnect: */
     int                auto_eject_hosts;      /* auto_eject_hosts: */
-    int                server_connections;    /* server_connections: */
     msec_t             server_retry_timeout_ms;  /* server_retry_timeout: in msec */
     int                server_failure_limit;  /* server_failure_limit: */
     struct conf_server *conf_datastore;       /* This is the underlying datastore */

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -132,12 +132,12 @@ typedef enum dyn_state {
 	WRITES_ONLY = 2,
 	RESUMING    = 3,
 	NORMAL      = 4,
-	SUSPENDING  = 5,
-	LEAVING     = 6,
+	//SUSPENDING  = 5,
+	//LEAVING     = 6,
 	JOINING     = 7,
 	DOWN        = 8,
-	REMOVED     = 9,
-	EXITING     = 10,
+	//REMOVED     = 9,
+	//EXITING     = 10,
 	RESET       = 11,
 	UNKNOWN     = 12
 } dyn_state_t;
@@ -151,12 +151,12 @@ get_state(dyn_state_t s) {
 		case WRITES_ONLY: return "WRITES_ONLY";
 		case RESUMING: return "RESUMING";
 		case NORMAL: return "NORMAL";
-		case SUSPENDING: return "SUSPENDING";
-		case LEAVING: return "LEAVING";
+		//case SUSPENDING: return "SUSPENDING";
+		//case LEAVING: return "LEAVING";
 		case JOINING: return "JOINING";
 		case DOWN: return "DOWN";
-		case REMOVED: return "REMOVED";
-		case EXITING: return "EXITING";
+		//case REMOVED: return "REMOVED";
+		//case EXITING: return "EXITING";
 		case RESET: return "RESET";
 		case UNKNOWN: return "Unknown";
 	}
@@ -230,8 +230,7 @@ struct datastore {
     struct endpoint     endpoint;
     struct string      name;          /* name (ref in conf_server) */
 
-    uint32_t           ns_conn_q;     /* # server connection */
-    struct conn_tqh    s_conn_q;      /* server connection q */
+    struct conn        *conn;         /* the only server connection */
 
     msec_t             next_retry_ms; /* next retry time in msec */
     sec_t              reconnect_backoff_sec; /* backoff time in seconds */
@@ -247,8 +246,7 @@ struct node {
     struct endpoint    endpoint;
     struct string      name;          /* name (ref in conf_server) */
 
-    uint32_t           ns_conn_q;     /* # server connection */
-    struct conn_tqh    s_conn_q;      /* server connection q */
+    struct conn        *conn;         /* the only peer connection */
 
     msec_t             next_retry_ms;    /* next retry time in msec */
     sec_t              reconnect_backoff_sec; /* backoff time in seconds */
@@ -294,7 +292,6 @@ struct server_pool {
     msec_t             timeout;              /* timeout in msec */
     int                backlog;              /* listen backlog */
     uint32_t           client_connections;   /* maximum # client connection */
-    uint32_t           server_connections;   /* maximum # server connection */
     msec_t             server_retry_timeout_ms; /* server retry timeout in msec */
     uint32_t           server_failure_limit; /* server failure limit */
     unsigned           auto_eject_hosts:1;   /* auto_eject_hosts? */

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -888,8 +888,8 @@ dnode_peer_replace(void *rmsg)
 
 
     if (s != NULL) {
-        log_debug(LOG_NOTICE, "Found an old node to replace '%.*s'", s->name.len, s->name.data);
-        log_debug(LOG_NOTICE, "Replace with address '%.*s'", node->name.len, node->name.data);
+        log_notice("Found an old node to replace '%.*s'", s->name.len, s->name.data);
+        log_notice("Replace with address '%.*s'", node->name.len, node->name.data);
 
         string_deinit(&s->endpoint.pname);
         string_deinit(&s->name);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -353,7 +353,7 @@ done:
 
     //dynomite
     msg->is_read = 1;
-    msg->dyn_state = 0;
+    msg->dyn_parse_state = 0;
     msg->dmsg = NULL;
     msg->msg_routing = ROUTING_NORMAL;
     msg->dyn_error_code = 0;
@@ -929,7 +929,7 @@ msg_recv_chain(struct context *ctx, struct conn *conn, struct msg *msg)
     ssize_t n;
 
     int expected_fill =
-        ((msg->dyn_state == DYN_DONE || msg->dyn_state == DYN_POST_DONE) &&
+        ((msg->dyn_parse_state == DYN_DONE || msg->dyn_parse_state == DYN_POST_DONE) &&
          msg->dmsg->bit_field == 1) ? msg->dmsg->plen : -1;  //used in encryption case only
 
     mbuf = STAILQ_LAST(&msg->mhdr, mbuf, next);

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -371,7 +371,7 @@ struct msg {
 
     //dynomite
     struct dmsg          *dmsg;          /* dyn message */
-    int                  dyn_state;
+    int                  dyn_parse_state;
     dyn_error_t          dyn_error_code; /* error code for dynomite */
     msg_routing_t        msg_routing;
     unsigned             is_read:1;       /*  0 : write

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -36,8 +36,8 @@ server_ref(struct conn *conn, void *owner)
 	struct datastore *server = owner;
 
     ASSERT(conn->type == CONN_SERVER);
-	ASSERT(conn->owner == NULL);
-	ASSERT(server->conn == NULL);
+    ASSERT(conn->owner == NULL);
+    ASSERT(server->conn == NULL);
 
 	conn->family = server->endpoint.family;
 	conn->addrlen = server->endpoint.addrlen;
@@ -119,7 +119,7 @@ server_deinit(struct datastore **pdatastore)
 {
     if (!pdatastore || !*pdatastore)
         return;
-    ASSERT(pdatastore->conn == NULL);
+    ASSERT((*pdatastore)->conn == NULL);
 }
 
 static struct conn *

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -37,14 +37,13 @@ server_ref(struct conn *conn, void *owner)
 
     ASSERT(conn->type == CONN_SERVER);
 	ASSERT(conn->owner == NULL);
+	ASSERT(server->conn == NULL);
 
 	conn->family = server->endpoint.family;
 	conn->addrlen = server->endpoint.addrlen;
 	conn->addr = server->endpoint.addr;
     string_duplicate(&conn->pname, &server->endpoint.pname);
-
-	server->ns_conn_q++;
-	TAILQ_INSERT_TAIL(&server->s_conn_q, conn, conn_tqe);
+    server->conn = conn;
 
 	conn->owner = owner;
 
@@ -64,9 +63,8 @@ server_unref(struct conn *conn)
 	server = conn->owner;
 	conn->owner = NULL;
 
-	ASSERT(server->ns_conn_q != 0);
-	server->ns_conn_q--;
-	TAILQ_REMOVE(&server->s_conn_q, conn, conn_tqe);
+    ASSERT(server->conn);
+    server->conn = NULL;
 
 	log_debug(LOG_VVERB, "unref conn %p owner %p from '%.*s'", conn, server,
 			server->endpoint.pname.len, server->endpoint.pname.data);
@@ -121,42 +119,16 @@ server_deinit(struct datastore **pdatastore)
 {
     if (!pdatastore || !*pdatastore)
         return;
-
-    struct datastore *s = *pdatastore;
-    IGNORE_RET_VAL(s);
-    ASSERT(TAILQ_EMPTY(&s->s_conn_q) && s->ns_conn_q == 0);
+    ASSERT(pdatastore->conn == NULL);
 }
 
 static struct conn *
 server_conn(struct datastore *datastore)
 {
-	struct server_pool *pool;
-	struct conn *conn;
-
-	pool = datastore->owner;
-
-	/*
-	 * FIXME: handle multiple server connections per server and do load
-	 * balancing on it. Support multiple algorithms for
-	 * 'server_connections:' > 0 key
-	 */
-
-	if (datastore->ns_conn_q < pool->server_connections) {
-		return conn_get(datastore, false);
-	}
-	ASSERT(datastore->ns_conn_q == pool->server_connections);
-
-	/*
-	 * Pick a server connection from the head of the queue and insert
-	 * it back into the tail of queue to maintain the lru order
-	 */
-	conn = TAILQ_FIRST(&datastore->s_conn_q);
-	ASSERT(conn->type == CONN_SERVER);
-
-	TAILQ_REMOVE(&datastore->s_conn_q, conn, conn_tqe);
-	TAILQ_INSERT_TAIL(&datastore->s_conn_q, conn, conn_tqe);
-
-	return conn;
+    if (!datastore->conn) {
+        return conn_get(datastore, false);
+    }
+    return datastore->conn;
 }
 
 static rstatus_t
@@ -188,12 +160,8 @@ datastore_disconnect(struct datastore *datastore)
 {
 	struct server_pool *pool = datastore->owner;
 
-	while (!TAILQ_EMPTY(&datastore->s_conn_q)) {
-		struct conn *conn;
-
-		ASSERT(datastore->ns_conn_q > 0);
-
-		conn = TAILQ_FIRST(&datastore->s_conn_q);
+    struct conn *conn = datastore->conn;
+    if (conn) {
 		conn_close(pool->ctx, conn);
 	}
 
@@ -237,17 +205,12 @@ server_failure(struct context *ctx, struct datastore *server)
 
 	server->failure_count = 0;
 	server->next_retry_ms = next_ms;
-    // Schedule a reconnect task to call datastore_preconnect
 }
 
 static void
 server_close_stats(struct context *ctx, struct datastore *server, err_t err,
 		unsigned eof, unsigned connected)
 {
-	if (connected) {
-		stats_server_decr(ctx, server_connections);
-	}
-
 	if (eof) {
 		stats_server_incr(ctx, server_eof);
 		return;
@@ -404,15 +367,11 @@ server_connected(struct context *ctx, struct conn *conn)
     ASSERT(conn->type == CONN_SERVER);
 	ASSERT(conn->connecting && !conn->connected);
 
-	stats_server_incr(ctx, server_connections);
-
 	conn->connecting = 0;
 	conn->connected = 1;
 
-        if (log_loggable(LOG_INFO)) {
-	   log_debug(LOG_INFO, "connected on s %d to server '%.*s'", conn->sd,
-		   	server->endpoint.pname.len, server->endpoint.pname.data);
-        }
+    log_notice("connected to %s '%.*s' from sd %u", conn_get_type_string(conn),
+               server->endpoint.pname.len, server->endpoint.pname.data, conn->sd);
 }
 
 static void

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1419,6 +1419,7 @@ stats_create(uint16_t stats_port, struct string pname, int stats_interval,
 
     st->port = stats_port;
     st->interval = stats_interval;
+    string_init(&st->addr);
     if (string_duplicate(&st->addr,&stats_ip) != DN_OK) {
     	goto error;
     }

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -84,7 +84,6 @@
     ACTION( server_eof,                   STATS_COUNTER,           "# eof on server connections")                              \
     ACTION( server_err,                   STATS_COUNTER,           "# errors on server connections")                           \
     ACTION( server_timedout,              STATS_COUNTER,           "# timeouts on server connections")                         \
-    ACTION( server_connections,           STATS_GAUGE,             "# active server connections")                              \
     ACTION( server_ejected_at,            STATS_TIMESTAMP,         "timestamp when server was ejected in usec since epoch")    \
     ACTION( server_dropped_requests,      STATS_COUNTER,           "# server dropped requests")                                \
     ACTION( server_timedout_requests,     STATS_COUNTER,           "# server timedout requests")                               \

--- a/src/dyn_test.c
+++ b/src/dyn_test.c
@@ -229,9 +229,7 @@ init_peer(struct node *s)
     s->endpoint.addrlen = info->addrlen;
     s->endpoint.addr = (struct sockaddr *)&info->addr;
 
-
-    s->ns_conn_q = 0;
-    TAILQ_INIT(&s->s_conn_q);
+    s->conn = NULL;
 
     s->next_retry_ms = 0ULL;
     s->reconnect_backoff_sec = MIN_WAIT_BEFORE_RECONNECT_IN_SECS;


### PR DESCRIPTION
* Having multiple connections to server and spraying messages will corrupt data, unless there is a good mapping of client connections to datastore connections etc
* Get ride of server_connections option in YAML (deprecated)
* rename dyn_state to dyn_parse_state where appropriate