### PR TITLE
Epoll File descriptors can be 0

### DIFF
--- a/src/event/dyn_epoll.c
+++ b/src/event/dyn_epoll.c
@@ -80,7 +80,7 @@ event_base_destroy(struct event_base *evb)
         return;
     }
 
-    ASSERT(evb->ep > 0);
+    ASSERT(evb->ep >= 0);
 
     dn_free(evb->event);
 
@@ -100,7 +100,7 @@ event_add_in(struct event_base *evb, struct conn *c)
     struct epoll_event event;
     int ep = evb->ep;
 
-    ASSERT(ep > 0);
+    ASSERT(ep >= 0);
     ASSERT(c != NULL);
     ASSERT(c->sd > 0);
 
@@ -135,7 +135,7 @@ event_add_out(struct event_base *evb, struct conn *c)
     struct epoll_event event;
     int ep = evb->ep;
 
-    ASSERT(ep > 0);
+    ASSERT(ep >= 0);
     ASSERT(c != NULL);
     ASSERT(c->sd > 0);
     ASSERT(c->recv_active);
@@ -166,7 +166,7 @@ event_del_out(struct event_base *evb, struct conn *c)
     struct epoll_event event;
     int ep = evb->ep;
 
-    ASSERT(ep > 0);
+    ASSERT(ep >= 0);
     ASSERT(c != NULL);
     ASSERT(c->sd > 0);
     ASSERT(c->recv_active);
@@ -197,7 +197,7 @@ event_add_conn(struct event_base *evb, struct conn *c)
     struct epoll_event event;
     int ep = evb->ep;
 
-    ASSERT(ep > 0);
+    ASSERT(ep >= 0);
     ASSERT(c != NULL);
     ASSERT(c->sd > 0);
 
@@ -223,7 +223,7 @@ event_del_conn(struct event_base *evb, struct conn *c)
     int status;
     int ep = evb->ep;
 
-    ASSERT(ep > 0);
+    ASSERT(ep >= 0);
     ASSERT(c != NULL);
     ASSERT(c->sd > 0);
 
@@ -247,7 +247,7 @@ event_wait(struct event_base *evb, int timeout)
     struct epoll_event *event = evb->event;
     int nevent = evb->nevent;
 
-    ASSERT(ep > 0);
+    ASSERT(ep >= 0);
     ASSERT(event != NULL);
     ASSERT(nevent > 0);
 


### PR DESCRIPTION
It happened that dynomite did not start on my node because it was
getting 0 as the epoll FD. Changing the asserts to reflect the same