### PR TITLE
Detect peer node disconnects

### DIFF
--- a/conf/redis_node2.yml
+++ b/conf/redis_node2.yml
@@ -11,4 +11,4 @@ dyn_o_mite:
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem
   data_store: 0
-  stats_listen: 0.0.0.0:22222
+  stats_listen: 0.0.0.0:22223

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -220,7 +220,6 @@ _conn_get(void)
     conn->avail_tokens = msgs_per_sec();
     conn->last_sent = 0;
     conn->attempted_reconnect = 0;
-    conn->non_bytes_recv = 0;
     //conn->non_bytes_send = 0;
     conn_set_read_consistency(conn, g_read_consistency);
     conn_set_write_consistency(conn, g_write_consistency);
@@ -677,14 +676,12 @@ conn_recv_data(struct conn *conn, void *buf, size_t size)
                 conn->recv_ready = 0;
             }
             conn->recv_bytes += (size_t)n;
-            conn->non_bytes_recv = 0;
             return n;
         }
 
         if (n == 0) {
             conn->recv_ready = 0;
             conn->eof = 1;
-            conn->non_bytes_recv++;
             log_debug(LOG_NOTICE, "recv on sd %d eof rb %zu sb %zu", conn->sd,
                       conn->recv_bytes, conn->send_bytes);
             return n;

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -134,7 +134,6 @@ struct conn {
     uint32_t           avail_tokens;          /* used to throttle the traffics */
     uint32_t           last_sent;             /* ts in sec used to determine the last sent time */
     uint32_t           attempted_reconnect;   /* #attempted reconnect before calling close */
-    uint32_t           non_bytes_recv;        /* #times or epoll triggers we receive no bytes */
     //uint32_t           non_bytes_send;        /* #times or epoll triggers that we are not able to send any bytes */
     consistency_t      read_consistency;
     consistency_t      write_consistency;

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -494,6 +494,7 @@ core_core(void *arg, uint32_t events)
 					core_close(ctx, conn);
 					return DN_ERROR;
 				}
+				core_close(ctx, conn);
 				return DN_OK;
 			}
 

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -665,15 +665,6 @@ rsp_recv_next(struct context *ctx, struct conn *conn, bool alloc)
     if (conn->eof) {
         rsp = conn->rmsg;
 
-        if (conn->dyn_mode) {
-            if (conn->non_bytes_recv > MAX_CONN_ALLOWABLE_NON_RECV) {
-                conn->err = EPIPE;
-                return NULL;
-            }
-            conn->eof = 0;
-            return rsp;
-        }
-
         /* server sent eof before sending the entire request */
         if (rsp != NULL) {
             conn->rmsg = NULL;


### PR DESCRIPTION
The code to detect that a remote node has disconnected and hence do our
cleanup, was broken. This worked well for client and redis connections
but not for peer connections.
I fixed this for outgoing peer connections.

While at it, also fix stats port in the example conf files