### PR TITLE
Start peer with state DOWN initially

### DIFF
--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -213,7 +213,7 @@ conf_seed_each_transform(void *elem, void *data)
     s->owner = NULL;
     s->endpoint.pname = cseed->pname;
 
-    s->state = NORMAL;//assume peers are normal initially
+    s->state = DOWN;//assume peers are down initially
 
     uint8_t *p = cseed->name.data + cseed->name.len - 1;
     uint8_t *start = cseed->name.data;

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -355,5 +355,6 @@ void core_stop(struct context *ctx);
 rstatus_t core_core(void *arg, uint32_t events);
 rstatus_t core_loop(struct context *ctx);
 void core_debug(struct context *ctx);
+void core_set_local_state(struct context *ctx, dyn_state_t state);
 
 #endif

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -60,6 +60,8 @@ dnode_peer_unref(struct conn *conn)
 
     peer = conn->owner;
     conn->owner = NULL;
+    // Mark the peer as down
+    peer->state = DOWN;
 
     /* FIXME: This is a wrong place to schedule a reconnection since this unref has no
      * context around why the disconnection happened. Ideally this task should be
@@ -439,8 +441,6 @@ dnode_peer_failure(struct context *ctx, struct node *server)
         (2 * server->reconnect_backoff_sec) > MAX_WAIT_BEFORE_RECONNECT_IN_SECS ?
                                                 MAX_WAIT_BEFORE_RECONNECT_IN_SECS :
                                                 2 * server->reconnect_backoff_sec;
-    // Mark the peer as down
-    server->state = DOWN;
     status = dnode_peer_pool_update(pool);
     if (status != DN_OK) {
         log_error("dyn: updating peer pool '%.*s' failed: %s",

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1210,7 +1210,7 @@ stats_send_rsp(struct stats *st)
                         "/state/<get_state|writes_only|normal|%s>\n\n", "resuming");
         return stats_http_rsp(sd, rsp, dn_strlen(rsp));
     } else if (cmd == CMD_NORMAL) {
-        st->ctx->dyn_state = NORMAL;
+        core_set_local_state(st->ctx, NORMAL);
         return stats_http_rsp(sd, ok.data, ok.len);
     } else if (cmd == CMD_CL_DESCRIBE) {
         if (stats_make_cl_desc_rsp(st) != DN_OK)
@@ -1218,13 +1218,13 @@ stats_send_rsp(struct stats *st)
         else
             return stats_http_rsp(sd, st->clus_desc_buf.data, st->clus_desc_buf.len);
     } else if (cmd == CMD_STANDBY) {
-        st->ctx->dyn_state = STANDBY;
+        core_set_local_state(st->ctx, STANDBY);
         return stats_http_rsp(sd, ok.data, ok.len);
     } else if (cmd == CMD_WRITES_ONLY) {
-        st->ctx->dyn_state = WRITES_ONLY;
+        core_set_local_state(st->ctx, WRITES_ONLY);
         return stats_http_rsp(sd, ok.data, ok.len);
     } else if (cmd == CMD_RESUMING) {
-        st->ctx->dyn_state = RESUMING;
+        core_set_local_state(st->ctx, RESUMING);
         return stats_http_rsp(sd, ok.data, ok.len);
     } else if (cmd == CMD_GET_STATE) {
         char rsp[1024];

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -582,7 +582,7 @@ dn_run(struct instance *nci)
 
     struct server_pool *sp = &ctx->pool;
     if (!sp->enable_gossip)
-    	ctx->dyn_state = NORMAL;
+        core_set_local_state(ctx, NORMAL);
 
     /* run rabbit run */
     for (;;) {


### PR DESCRIPTION
* Start with peer as DOWN initially and then make them NORMAL after connection is established.
* A NORMAL state means a node is up and connected.
* Self node is NORMAL by default.
* Peer node becomes normal after a connection is successful.
* Also make sure the peer is marked DOWN as soon as the connection breaks so that the higher layers can react accordingly.
* This will help in rerouting traffic to a different rack as soon as the node in the remote region goes down