### PR TITLE
Better Error handling during request forwarding

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -782,8 +782,10 @@ req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
                      rack_msg->parent_id, rack->name->len, rack->name->data);
 
             s = remote_req_forward(ctx, c_conn, rack_msg, rack, key, keylen, &dyn_error_code);
-            if ((s != DN_OK) && (req->consistency != DC_ONE)) {
-                req_forward_error(ctx, c_conn, req, s, dyn_error_code);
+            if (s != DN_OK) {
+                if (req->consistency != DC_ONE) {
+                    req_forward_error(ctx, c_conn, rack_msg, s, dyn_error_code);
+                }
                 req_put(rack_msg);
                 continue;
             }

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -57,7 +57,7 @@ core_print_peer_status(void *arg1)
                 if (!peer)
                     log_panic("peer is null. Topology not inited proerly");
 
-                log_notice("%u)%p %.*s\t%.*s\t%.*s\t%s", peer_index, peer,dc->name->len, dc->name->data,
+                log_notice("%u)%p %.*s %.*s %.*s %s", peer_index, peer,dc->name->len, dc->name->data,
                            rack->name->len, rack->name->data, peer->endpoint.pname.len,
                            peer->endpoint.pname.data, get_state(peer->state));
             }
@@ -511,7 +511,7 @@ core_core(void *arg, uint32_t events)
 	struct conn *conn = arg;
 	struct context *ctx = conn_to_ctx(conn);
 
-    log_debug(LOG_VVVERB, "event %04"PRIX32" on %s %d", events,
+    log_debug(LOG_VVERB, "event %04"PRIX32" on %s %d", events,
               conn_get_type_string(conn), conn->sd);
 
 	conn->events = events;
@@ -664,6 +664,7 @@ core_loop(struct context *ctx)
     TAILQ_FOREACH_SAFE(conn, &sp->ready_conn_q, ready_tqe, nconn) {
 		rstatus_t status = core_send(ctx, conn);
         if (status == DN_OK) {
+            log_debug(LOG_VVERB, "Flushing writes on %s %d", conn_get_type_string(conn), conn->sd);
             conn_event_del_out(conn);
         } else {
             TAILQ_REMOVE(&sp->ready_conn_q, conn, ready_tqe);

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -195,7 +195,6 @@ dnode_client_handle_response(struct conn *conn, msgid_t reqid, struct msg *rsp)
 {
     // Forward the response to the caller which is client connection.
     rstatus_t status = DN_OK;
-    struct context *ctx = conn_to_ctx(conn);
 
     ASSERT(conn->type == CONN_DNODE_PEER_CLIENT);
     // Fetch the original request
@@ -327,8 +326,9 @@ dnode_req_forward(struct context *ctx, struct conn *conn, struct msg *req)
                log_debug(LOG_DEBUG, "forwarding request from conn '%s' to rack '%.*s' dc '%.*s' ",
                            dn_unresolve_peer_desc(conn->sd), rack->name->len, rack->name->data, rack->dc->len, rack->dc->data);
             }
-
-            remote_req_forward(ctx, conn, rack_msg, rack, key, keylen);
+            dyn_error_t dyn_error_code = 0;
+            rstatus_t s = remote_req_forward(ctx, conn, rack_msg, rack, key, keylen, &dyn_error_code);
+            IGNORE_RET_VAL(s);
         }
     }
 }

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -25,7 +25,6 @@ static unsigned char aes_decrypted_buf[34];
 
 static rstatus_t dmsg_to_gossip(struct ring_msg *rmsg);
 
-
 static bool 
 dyn_parse_core(struct msg *r)
 {
@@ -481,6 +480,9 @@ dyn_parse_req(struct msg *r)
 				//Decrypt AES key
 				dyn_rsa_decrypt(dmsg->data, aes_decrypted_buf);
 				strncpy((char*)r->owner->aes_key, (char*)aes_decrypted_buf, strlen((char*)aes_decrypted_buf));
+				SCOPED_CHARPTR(encoded_aes_key) = base64_encode(r->owner->aes_key, AES_KEYLEN);
+				if (encoded_aes_key)
+				    loga("AES decryption key: %s\n", (char*)encoded_aes_key);
 			}
 
 			if (dmsg->plen + b->pos <= b->last) {

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -1150,9 +1150,8 @@ dnode_peer_pool_server(struct context *ctx, struct server_pool *pool,
 struct conn *
 dnode_peer_pool_server_conn(struct context *ctx, struct node *peer)
 {
-    // This peer is marked as down. lets check if it is time to connect
     if (peer->state == DOWN) {
-        msec_t now_ms = dn_msec_now();
+        /*msec_t now_ms = dn_msec_now();
         static msec_t next_log_ms = 0; // Log every 1 sec
         if (peer->next_retry_ms && (now_ms > peer->next_retry_ms)) {
             peer->state = NORMAL;
@@ -1165,7 +1164,8 @@ dnode_peer_pool_server_conn(struct context *ctx, struct node *peer)
                 next_log_ms = now_ms + 1000;
             }
             return NULL;
-        }
+        }*/
+        return NULL;
     }
 
     /* pick a connection to a given peer */

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -1151,20 +1151,6 @@ struct conn *
 dnode_peer_pool_server_conn(struct context *ctx, struct node *peer)
 {
     if (peer->state == DOWN) {
-        /*msec_t now_ms = dn_msec_now();
-        static msec_t next_log_ms = 0; // Log every 1 sec
-        if (peer->next_retry_ms && (now_ms > peer->next_retry_ms)) {
-            peer->state = NORMAL;
-            peer->next_retry_ms = 0;
-            peer->failure_count = 0;
-        } else {
-            if (now_ms > next_log_ms) {
-                log_warn("Detecting peer '%.*s' is set with state Down",
-                         peer->endpoint.pname.len, peer->endpoint.pname.data);
-                next_log_ms = now_ms + 1000;
-            }
-            return NULL;
-        }*/
         return NULL;
     }
 

--- a/src/dyn_dnode_proxy.c
+++ b/src/dyn_dnode_proxy.c
@@ -106,8 +106,8 @@ dnode_init(struct context *ctx)
     	log_datastore = "memcache";
     }
 
-    log_debug(LOG_NOTICE, "dyn: p %d listening on '%.*s' in %s pool '%.*s'"
-              " with %"PRIu32" servers", p->sd, pool->dnode_proxy_endpoint.pname.len,
+    log_debug(LOG_NOTICE, "dyn: p %d listening on '%.*s' in %s pool '%.*s'",
+              p->sd, pool->dnode_proxy_endpoint.pname.len,
               pool->dnode_proxy_endpoint.pname.data,
 			  log_datastore,
               pool->name.len, pool->name.data );

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -213,6 +213,7 @@ typedef enum dyn_error {
     DYNOMITE_OK,
     DYNOMITE_UNKNOWN_ERROR,
     DYNOMITE_INVALID_STATE,
+    DYNOMITE_INVALID_ADMIN_REQ,
     PEER_CONNECTION_REFUSE,
     PEER_HOST_DOWN,
     PEER_HOST_NOT_CONNECTED,
@@ -228,6 +229,8 @@ dn_strerror(dyn_error_t err)
     {
         case DYNOMITE_INVALID_STATE:
             return "Dynomite's current state does not allow this request";
+        case DYNOMITE_INVALID_ADMIN_REQ:
+            return "Invalid request in Dynomite's admin mode";
         case DYNOMITE_NO_QUORUM_ACHIEVED:
             return "Failed to achieve Quorum";
         case PEER_HOST_DOWN:
@@ -244,6 +247,7 @@ dyn_error_source(dyn_error_t err)
 {
     switch(err)
     {
+        case DYNOMITE_INVALID_ADMIN_REQ:
         case DYNOMITE_INVALID_STATE:
         case DYNOMITE_NO_QUORUM_ACHIEVED:
             return "Dynomite:";

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -452,8 +452,9 @@ void rsp_send_done(struct context *ctx, struct conn *conn, struct msg *msg);
 void dnode_rsp_gos_syn(struct context *ctx, struct conn *p_conn, struct msg *msg);
 
 
-void remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
-		                struct rack *rack, uint8_t *key, uint32_t keylen);
+rstatus_t remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
+		                     struct rack *rack, uint8_t *key, uint32_t keylen,
+                             dyn_error_t *dyn_error_code);
 void local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg, uint8_t *key, uint32_t keylen);
 void dnode_peer_req_forward(struct context *ctx, struct conn *c_conn, struct conn *p_conn,
 		                struct msg *msg, struct rack *rack, uint8_t *key, uint32_t keylen);

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -210,6 +210,7 @@ typedef enum msg_type {
 
 
 typedef enum dyn_error {
+    DYNOMITE_OK,
     DYNOMITE_UNKNOWN_ERROR,
     DYNOMITE_INVALID_STATE,
     PEER_CONNECTION_REFUSE,
@@ -452,12 +453,23 @@ void rsp_send_done(struct context *ctx, struct conn *conn, struct msg *msg);
 void dnode_rsp_gos_syn(struct context *ctx, struct conn *p_conn, struct msg *msg);
 
 
+void
+req_forward_error(struct context *ctx, struct conn *conn, struct msg *req,
+                  err_t error_code, err_t dyn_error_code);
 rstatus_t remote_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg,
 		                     struct rack *rack, uint8_t *key, uint32_t keylen,
                              dyn_error_t *dyn_error_code);
-void local_req_forward(struct context *ctx, struct conn *c_conn, struct msg *msg, uint8_t *key, uint32_t keylen);
-void dnode_peer_req_forward(struct context *ctx, struct conn *c_conn, struct conn *p_conn,
-		                struct msg *msg, struct rack *rack, uint8_t *key, uint32_t keylen);
+void req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
+                                 struct msg *req, struct mbuf *orig_mbuf,
+                                 uint8_t *key, uint32_t keylen,
+                                 struct datacenter *dc);
+rstatus_t local_req_forward(struct context *ctx, struct conn *c_conn,
+                            struct msg *msg, uint8_t *key, uint32_t keylen,
+                            dyn_error_t *dyn_error_code);
+rstatus_t dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
+                                 struct conn *p_conn, struct msg *msg,
+                                 struct rack *rack, uint8_t *key,
+                                 uint32_t keylen, dyn_error_t *dyn_error_code);
 
 //void peer_gossip_forward(struct context *ctx, struct conn *conn, struct string *data);
 void dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, struct mbuf *data);

--- a/src/dyn_response_mgr.h
+++ b/src/dyn_response_mgr.h
@@ -26,6 +26,7 @@ bool rspmgr_check_is_done(struct response_mgr *rspmgr);
 struct msg* rspmgr_get_response(struct response_mgr *rspmgr);
 void rspmgr_free_response(struct response_mgr *rspmgr, struct msg *dont_free);
 void rspmgr_free_other_responses(struct response_mgr *rspmgr, struct msg *dont_free);
+rstatus_t msg_local_one_rsp_handler(struct msg *req, struct msg *rsp);
 
 
 #endif

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -178,9 +178,9 @@ server_failure(struct context *ctx, struct datastore *server)
 
 	server->failure_count++;
 
-	log_debug(LOG_VERB, "server '%.*s' failure count %"PRIu32" limit %"PRIu32,
-			server->endpoint.pname.len, server->endpoint.pname.data, server->failure_count,
-			pool->server_failure_limit);
+	log_warn("server '%.*s' failure count %"PRIu32" limit %"PRIu32,
+			 server->endpoint.pname.len, server->endpoint.pname.data, server->failure_count,
+			 pool->server_failure_limit);
 
 	if (server->failure_count < pool->server_failure_limit) {
 		return;
@@ -740,8 +740,7 @@ server_rsp_filter(struct context *ctx, struct conn *conn, struct msg *rsp)
          return true;
     }
 
-    ASSERT(req->selected_rsp == NULL);
-    ASSERT(req->is_request && !req->done);
+    ASSERT(req->is_request);
 
     if (req->swallow) {
         conn_dequeue_outq(ctx, conn, req);
@@ -786,8 +785,7 @@ server_rsp_forward(struct context *ctx, struct conn *s_conn, struct msg *rsp)
 
     /* dequeue peer message (request) from server */
     req = TAILQ_FIRST(&s_conn->omsg_q);
-    ASSERT(req != NULL && req->selected_rsp == NULL);
-    ASSERT(req->is_request && !req->done);
+    ASSERT(req->is_request);
     if (req->request_send_time) {
         struct stats *st = ctx->stats;
         uint64_t delay = dn_usec_now() - req->request_send_time;

--- a/src/dyn_task.c
+++ b/src/dyn_task.c
@@ -11,6 +11,9 @@
  * task_mgr_init()
  * schedule_task()
  * execute_expired_tasks()
+ *
+ * Add some comments about time complexity here 
+ *
  */
 
 

--- a/src/dyn_task.c
+++ b/src/dyn_task.c
@@ -12,7 +12,8 @@
  * schedule_task()
  * execute_expired_tasks()
  *
- * Add some comments about time complexity here 
+ * The time complexity for insert/delete in the red black tree is O(log N), where
+ * N is the number of elements in the tree.
  *
  */
 

--- a/src/dyn_test.c
+++ b/src/dyn_test.c
@@ -36,9 +36,6 @@ static char *data = "$2014$ 1 3 0 1 1 *1 d *0\r\n*3\r\n$3\r\nset\r\n$4\r\nfoo1\r
 
 static size_t position = 0;
 
-static unsigned char aes_key[AES_KEYLEN];
-
-
 static struct option long_options[] = {
     { "help",           no_argument,        NULL,   'h' },
     { "version",        no_argument,        NULL,   'V' },
@@ -363,14 +360,16 @@ rsa_test(void)
         msg = generate_aes_key();
 
         log_debug(LOG_VERB, "i = %d", i);
-        log_debug(LOG_VERB, "AES key           : %s \n", base64_encode(msg, AES_KEYLEN));
+        SCOPED_CHARPTR(encoded_aes_key) = base64_encode(msg, AES_KEYLEN);
+        log_debug(LOG_VERB, "AES key           : %s \n", encoded_aes_key);
 
 
         dyn_rsa_encrypt(msg, encrypted_buf);
 
         dyn_rsa_decrypt(encrypted_buf, decrypted_buf);
 
-        log_debug(LOG_VERB, "Decrypted message : %s \n", base64_encode(decrypted_buf, AES_KEYLEN));
+        SCOPED_CHARPTR(encoded_decrypted_buf) = base64_encode(decrypted_buf, AES_KEYLEN);
+        log_debug(LOG_VERB, "Decrypted message : %s \n", encoded_decrypted_buf);
     }
 
     return DN_OK;
@@ -378,13 +377,13 @@ rsa_test(void)
 
 static void gen_random(unsigned char *s, const int len)
 {
-    static const char data[] =
+    static const unsigned char possible_data[] =
         "0123456789"
         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         "abcdefghijklmnopqrstuvwxyz\r\n";
     int i;
     for (i = 0; i < len; ++i) {
-        s[i] = data[rand() % (sizeof(data) - 1)];
+        s[i] = possible_data[rand() % (sizeof(possible_data) - 1)];
     }
 
     s[len] = 0;
@@ -397,7 +396,7 @@ aes_test(void)
     unsigned char msg[MAX_MSG_LEN+1];
     loga("=======================AES======================");
     unsigned char* aes_key = generate_aes_key();
-    char *aes_key_print = base64_encode(aes_key, strlen((char*)aes_key));
+    SCOPED_CHARPTR(aes_key_print) = base64_encode(aes_key, strlen((char*)aes_key));
     loga("aesKey is '%s'", aes_key_print);
 
     size_t i=0;

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include <stdlib.h>
 typedef uint64_t msgid_t;
 typedef uint64_t msec_t;
 typedef uint64_t usec_t;
@@ -28,5 +29,15 @@ struct stats;
 struct entropy_conn;
 struct instance;
 struct event_base;
+struct datacenter;
 struct rack;
 struct dyn_ring;
+
+static void
+cleanup_charptr(char **ptr) {
+    if (*ptr)
+        free(*ptr);
+}
+
+#define SCOPED_CHARPTR(var) \
+    char * var __attribute__ ((__cleanup__(cleanup_charptr))) 


### PR DESCRIPTION
This is an important patch that sort of redesigns some of the APIs used by the coordinator.
The general idea is to propagate errors back so that the higher layers can act accordingly.
The errors are of two types: rstatus which talks about overall operation failure and dyn_error_code which is a more precise error code. Eventually these should be combined.
The Dnode client coordinator (the coordinator) which receives request from peer nodes reuses the client co-ordinator functionality.
