### PR TITLE
Remote DC replication Failover

### DIFF
--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -525,7 +525,10 @@ dnode_peer_close(struct context *ctx, struct conn *conn)
         dnode_peer_ack_err(ctx, conn, req);
         in_counter++;
 
-        stats_pool_incr(ctx, peer_dropped_requests);
+        if (conn->same_dc)
+            stats_pool_incr(ctx, peer_dropped_requests);
+        else
+            stats_pool_incr(ctx, remote_peer_dropped_requests);
     }
 
     ASSERT(TAILQ_EMPTY(&conn->imsg_q));

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -50,9 +50,11 @@
     ACTION( dnode_client_out_queue,       STATS_GAUGE,        "# dnode client requests in outgoing queue")                \
     ACTION( dnode_client_out_queue_bytes, STATS_GAUGE,        "current dnode client request bytes in outgoing queue")     \
     /* peer behavior */                                                                                                   \
-    ACTION( peer_dropped_requests,        STATS_COUNTER,      "# local dc peer dropped requests")                                  \
-    ACTION( peer_timedout_requests,       STATS_COUNTER,      "# local dc peer timedout requests")                                 \
-    ACTION( remote_peer_timedout_requests,STATS_COUNTER,      "# remote dc peer timedout requests")                                 \
+    ACTION( peer_dropped_requests,        STATS_COUNTER,      "# local dc peer dropped requests")                         \
+    ACTION( peer_timedout_requests,       STATS_COUNTER,      "# local dc peer timedout requests")                        \
+    ACTION( remote_peer_dropped_requests, STATS_COUNTER,      "# remote dc peer dropped requests")                        \
+    ACTION( remote_peer_timedout_requests,STATS_COUNTER,      "# remote dc peer timedout requests")                       \
+    ACTION( remote_peer_failover_requests,STATS_COUNTER,      "# remote dc peer failover requests")                       \
     ACTION( peer_eof,                     STATS_COUNTER,      "# eof on peer connections")                                \
     ACTION( peer_err,                     STATS_COUNTER,      "# errors on peer connections")                             \
     ACTION( peer_timedout,                STATS_COUNTER,      "# timeouts on local dc peer connections")                           \


### PR DESCRIPTION
This is the final patch in the series to enable remote DC replication
failover. If a node figures a remote node is marked as DOWN, it tries to
failover to another node. This does not failover those requests which
were already queued on the connection and could not be forwarded due to
network issues, but only those that arrived after the remote peer was
marked as DOWN.