### PR TITLE
Strings for message types

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -884,8 +884,9 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *req)
     uint32_t keylen = 0;
     uint8_t *key = msg_get_key(req, &pool->hash_tag, &keylen);
 
-    log_debug(LOG_DEBUG, "conn %p received message %d:%d key '%.*s' adding to dict", c_conn,
-              req->id, req->parent_id, keylen, key);
+    struct string *type = msg_type_string(req->type);
+    log_debug(LOG_DEBUG, "conn %p received message %d:%d %.*s key '%.*s' adding to dict", c_conn,
+              req->id, req->parent_id, type->len, type->data, keylen, key);
     // add the message to the dict
     dictAdd(c_conn->outstanding_msgs_dict, &req->id, req);
 

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -2170,18 +2170,18 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
     else {
     	/* Validating mbuf_size correctness */
         if (cp->mbuf_size <= 0) {
-           log_stderr(LOG_INFO,"mbuf_size: requires a positive number");
+           log_stderr("mbuf_size: requires a positive number");
     	   return DN_ERROR;
     	}
 
     	if (cp->mbuf_size < CONF_DEFAULT_MBUF_MIN_SIZE || cp->mbuf_size > CONF_DEFAULT_MBUF_MAX_SIZE) {
-    	   log_stderr(LOG_INFO,"mbuf_size: mbuf chunk size must be between %zu and"
+    	   log_stderr("mbuf_size: mbuf chunk size must be between %zu and"
     	              " %zu bytes", CONF_DEFAULT_MBUF_MIN_SIZE, CONF_DEFAULT_MBUF_MAX_SIZE);
     	   return DN_ERROR;
     	}
 
     	if ((cp->mbuf_size / 16) * 16 != cp->mbuf_size) {
-    	   log_stderr(LOG_INFO,"mbuf_size: mbuf size must be a multiple of 16");
+    	   log_stderr("mbuf_size: mbuf size must be a multiple of 16");
     	   return DN_ERROR;
     	}
     }
@@ -2196,12 +2196,12 @@ conf_validate_pool(struct conf *cf, struct conf_pool *cp)
     }
     else {
         if (cp->alloc_msgs_max <= 0) {
-            log_stderr(LOG_INFO,"dynomite: option -M requires a non-zero number");
+            log_stderr("dynomite: option -M requires a non-zero number");
             return DN_ERROR;
         }
 
         if (cp->alloc_msgs_max < CONF_DEFAULT_MIN_ALLOC_MSGS || cp->alloc_msgs_max > CONF_DEFAULT_MAX_ALLOC_MSGS) {
-            log_stderr(LOG_INFO,"max_msgs: max allocated messages buffer must be between %zu and"
+            log_stderr("max_msgs: max allocated messages buffer must be between %zu and"
                        " %zu messages", CONF_DEFAULT_MIN_ALLOC_MSGS, CONF_DEFAULT_MAX_ALLOC_MSGS);
             return DN_ERROR;
         }

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -155,6 +155,13 @@ func_msg_post_splitcopy_t g_post_splitcopy;  /* message post-split copy */
 func_msg_coalesce_t  g_pre_coalesce;    /* message pre-coalesce */
 func_msg_coalesce_t  g_post_coalesce;   /* message post-coalesce */
 
+#define DEFINE_ACTION(_name) string(#_name),
+static struct string msg_type_strings[] = {
+    MSG_TYPE_CODEC( DEFINE_ACTION )
+    null_string
+};
+#undef DEFINE_ACTION
+
 void
 set_datastore_ops(void)
 {
@@ -663,6 +670,12 @@ msg_deinit(void)
         msg_free(msg);
     }
     ASSERT(nfree_msgq == 0);
+}
+
+struct string *
+msg_type_string(msg_type_t type)
+{
+    return &msg_type_strings[type];
 }
 
 bool

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -56,157 +56,169 @@ typedef enum msg_parse_result {
     MSG_OOM_ERROR
 } msg_parse_result_t;
 
+#define MSG_TYPE_CODEC(ACTION)                                                                      \
+    ACTION( UNKNOWN )                                                                               \
+    ACTION( REQ_MC_GET )                       /* memcache retrieval requests */                    \
+    ACTION( REQ_MC_GETS )                                                                           \
+    ACTION( REQ_MC_DELETE )                    /* memcache delete request */                        \
+    ACTION( REQ_MC_CAS )                       /* memcache cas request and storage request */       \
+    ACTION( REQ_MC_SET )                       /* memcache storage request */                       \
+    ACTION( REQ_MC_ADD )                                                                            \
+    ACTION( REQ_MC_REPLACE )                                                                        \
+    ACTION( REQ_MC_APPEND )                                                                         \
+    ACTION( REQ_MC_PREPEND )                                                                        \
+    ACTION( REQ_MC_INCR )                      /* memcache arithmetic request */                    \
+    ACTION( REQ_MC_DECR )                                                                           \
+    ACTION( REQ_MC_TOUCH )                     /* memcache touch request */                         \
+    ACTION( REQ_MC_QUIT )                      /* memcache quit request */                          \
+    ACTION( RSP_MC_NUM )                       /* memcache arithmetic response */                   \
+    ACTION( RSP_MC_STORED )                    /* memcache cas and storage response */              \
+    ACTION( RSP_MC_NOT_STORED )                                                                     \
+    ACTION( RSP_MC_EXISTS )                                                                         \
+    ACTION( RSP_MC_NOT_FOUND )                                                                      \
+    ACTION( RSP_MC_END )                                                                            \
+    ACTION( RSP_MC_VALUE )                                                                          \
+    ACTION( RSP_MC_DELETED )                   /* memcache delete response */                       \
+    ACTION( RSP_MC_TOUCHED )                   /* memcache touch response */                        \
+    ACTION( RSP_MC_ERROR )                     /* memcache error responses */                       \
+    ACTION( RSP_MC_CLIENT_ERROR )                                                                   \
+    ACTION( RSP_MC_SERVER_ERROR )                                                                   \
+    ACTION( REQ_REDIS_DEL )                    /* redis commands - keys */                          \
+    ACTION( REQ_REDIS_EXISTS )                                                                      \
+    ACTION( REQ_REDIS_EXPIRE )                                                                      \
+    ACTION( REQ_REDIS_EXPIREAT )                                                                    \
+    ACTION( REQ_REDIS_PEXPIRE )                                                                     \
+    ACTION( REQ_REDIS_PEXPIREAT )                                                                   \
+    ACTION( REQ_REDIS_PERSIST )                                                                     \
+    ACTION( REQ_REDIS_PTTL )                                                                        \
+    ACTION( REQ_REDIS_SCAN )                                                                        \
+    ACTION( REQ_REDIS_SORT )                                                                        \
+    ACTION( REQ_REDIS_TTL )                                                                         \
+    ACTION( REQ_REDIS_TYPE )                                                                        \
+    ACTION( REQ_REDIS_APPEND )                 /* redis requests - string */                        \
+    ACTION( REQ_REDIS_BITCOUNT )                                                                    \
+    ACTION( REQ_REDIS_BITPOS )                                                                    \
+    ACTION( REQ_REDIS_DECR )                                                                        \
+    ACTION( REQ_REDIS_DECRBY )                                                                      \
+    ACTION( REQ_REDIS_DUMP )                                                                        \
+    ACTION( REQ_REDIS_GET )                                                                         \
+    ACTION( REQ_REDIS_GETBIT )                                                                      \
+    ACTION( REQ_REDIS_GETRANGE )                                                                    \
+    ACTION( REQ_REDIS_GETSET )                                                                      \
+    ACTION( REQ_REDIS_INCR )                                                                        \
+    ACTION( REQ_REDIS_INCRBY )                                                                      \
+    ACTION( REQ_REDIS_INCRBYFLOAT )                                                                 \
+    ACTION( REQ_REDIS_MSET )                                                                        \
+    ACTION( REQ_REDIS_MGET )                                                                        \
+    ACTION( REQ_REDIS_PSETEX )                                                                      \
+    ACTION( REQ_REDIS_RESTORE )                                                                     \
+    ACTION( REQ_REDIS_SET )                                                                         \
+    ACTION( REQ_REDIS_SETBIT )                                                                      \
+    ACTION( REQ_REDIS_SETEX )                                                                       \
+    ACTION( REQ_REDIS_SETNX )                                                                       \
+    ACTION( REQ_REDIS_SETRANGE )                                                                    \
+    ACTION( REQ_REDIS_STRLEN )                                                                      \
+    ACTION( REQ_REDIS_HDEL )                   /* redis requests - hashes */                        \
+    ACTION( REQ_REDIS_HEXISTS )                                                                     \
+    ACTION( REQ_REDIS_HGET )                                                                        \
+    ACTION( REQ_REDIS_HGETALL )                                                                     \
+    ACTION( REQ_REDIS_HINCRBY )                                                                     \
+    ACTION( REQ_REDIS_HINCRBYFLOAT )                                                                \
+    ACTION( REQ_REDIS_HKEYS )                                                                       \
+    ACTION( REQ_REDIS_HLEN )                                                                        \
+    ACTION( REQ_REDIS_HMGET )                                                                       \
+    ACTION( REQ_REDIS_HMSET )                                                                       \
+    ACTION( REQ_REDIS_HSET )                                                                        \
+    ACTION( REQ_REDIS_HSETNX )                                                                      \
+    ACTION( REQ_REDIS_HSCAN)                                                                        \
+    ACTION( REQ_REDIS_HVALS )                                                                       \
+    ACTION( REQ_REDIS_KEYS )                                                                        \
+    ACTION( REQ_REDIS_INFO )                                                                        \
+    ACTION( REQ_REDIS_LINDEX )                 /* redis requests - lists */                         \
+    ACTION( REQ_REDIS_LINSERT )                                                                     \
+    ACTION( REQ_REDIS_LLEN )                                                                        \
+    ACTION( REQ_REDIS_LPOP )                                                                        \
+    ACTION( REQ_REDIS_LPUSH )                                                                       \
+    ACTION( REQ_REDIS_LPUSHX )                                                                      \
+    ACTION( REQ_REDIS_LRANGE )                                                                      \
+    ACTION( REQ_REDIS_LREM )                                                                        \
+    ACTION( REQ_REDIS_LSET )                                                                        \
+    ACTION( REQ_REDIS_LTRIM )                                                                       \
+    ACTION( REQ_REDIS_PING )                                                                        \
+    ACTION( REQ_REDIS_QUIT )                                                                        \
+    ACTION( REQ_REDIS_RPOP )                                                                        \
+    ACTION( REQ_REDIS_RPOPLPUSH )                                                                   \
+    ACTION( REQ_REDIS_RPUSH )                                                                       \
+    ACTION( REQ_REDIS_RPUSHX )                                                                      \
+    ACTION( REQ_REDIS_SADD )                   /* redis requests - sets */                          \
+    ACTION( REQ_REDIS_SCARD )                                                                       \
+    ACTION( REQ_REDIS_SDIFF )                                                                       \
+    ACTION( REQ_REDIS_SDIFFSTORE )                                                                  \
+    ACTION( REQ_REDIS_SINTER )                                                                      \
+    ACTION( REQ_REDIS_SINTERSTORE )                                                                 \
+    ACTION( REQ_REDIS_SISMEMBER )                                                                   \
+    ACTION( REQ_REDIS_SLAVEOF )                                                                     \
+    ACTION( REQ_REDIS_SMEMBERS )                                                                    \
+    ACTION( REQ_REDIS_SMOVE )                                                                       \
+    ACTION( REQ_REDIS_SPOP )                                                                        \
+    ACTION( REQ_REDIS_SRANDMEMBER )                                                                 \
+    ACTION( REQ_REDIS_SREM )                                                                        \
+    ACTION( REQ_REDIS_SUNION )                                                                      \
+    ACTION( REQ_REDIS_SUNIONSTORE )                                                                 \
+    ACTION( REQ_REDIS_SSCAN)                                                                        \
+    ACTION( REQ_REDIS_ZADD )                   /* redis requests - sorted sets */                   \
+    ACTION( REQ_REDIS_ZCARD )                                                                       \
+    ACTION( REQ_REDIS_ZCOUNT )                                                                      \
+    ACTION( REQ_REDIS_ZINCRBY )                                                                     \
+    ACTION( REQ_REDIS_ZINTERSTORE )                                                                 \
+    /* ACTION( REQ_REDIS_ZLEXCOUNT )*/                                                              \
+    ACTION( REQ_REDIS_ZRANGE )                                                                      \
+    /* ACTION( REQ_REDIS_ZRANGEBYLEX )*/                                                            \
+    ACTION( REQ_REDIS_ZRANGEBYSCORE )                                                               \
+    ACTION( REQ_REDIS_ZRANK )                                                                       \
+    ACTION( REQ_REDIS_ZREM )                                                                        \
+    ACTION( REQ_REDIS_ZREMRANGEBYRANK )                                                             \
+    /*ACTION( REQ_REDIS_ZREMRANGEBYLEX )*/                                                          \
+    ACTION( REQ_REDIS_ZREMRANGEBYSCORE )                                                            \
+    ACTION( REQ_REDIS_ZREVRANGE )                                                                   \
+    ACTION( REQ_REDIS_ZREVRANGEBYSCORE )                                                            \
+    ACTION( REQ_REDIS_ZREVRANK )                                                                    \
+    ACTION( REQ_REDIS_ZSCORE )                                                                      \
+    ACTION( REQ_REDIS_ZUNIONSTORE )                                                                 \
+    ACTION( REQ_REDIS_ZSCAN)                                                                        \
+    ACTION( REQ_REDIS_EVAL )                   /* redis requests - eval */                          \
+    ACTION( REQ_REDIS_EVALSHA )                                                                     \
+    /* ACTION( REQ_REDIS_AUTH) */                                                                   \
+    /* ACTION( REQ_REDIS_SELECT)*/             /* only during init */                               \
+    ACTION( REQ_REDIS_PFADD )                  /* redis requests - hyperloglog */                   \
+    ACTION( REQ_REDIS_PFCOUNT )                                                                     \
+    ACTION( RSP_REDIS_STATUS )                 /* redis response */                                 \
+    ACTION( RSP_REDIS_INTEGER )                                                                     \
+    ACTION( RSP_REDIS_BULK )                                                                        \
+    ACTION( RSP_REDIS_MULTIBULK )                                                                   \
+    ACTION( REQ_REDIS_CONFIG )                                                                      \
+    ACTION( RSP_REDIS_ERROR )                                                                       \
+    ACTION( RSP_REDIS_ERROR_ERR )                                                                   \
+    ACTION( RSP_REDIS_ERROR_OOM )                                                                   \
+    ACTION( RSP_REDIS_ERROR_BUSY )                                                                  \
+    ACTION( RSP_REDIS_ERROR_NOAUTH )                                                                \
+    ACTION( RSP_REDIS_ERROR_LOADING )                                                               \
+    ACTION( RSP_REDIS_ERROR_BUSYKEY )                                                               \
+    ACTION( RSP_REDIS_ERROR_MISCONF )                                                               \
+    ACTION( RSP_REDIS_ERROR_NOSCRIPT )                                                              \
+    ACTION( RSP_REDIS_ERROR_READONLY )                                                              \
+    ACTION( RSP_REDIS_ERROR_WRONGTYPE )                                                             \
+    ACTION( RSP_REDIS_ERROR_EXECABORT )                                                             \
+    ACTION( RSP_REDIS_ERROR_MASTERDOWN )                                                            \
+    ACTION( RSP_REDIS_ERROR_NOREPLICAS )                                                            \
+    ACTION( SENTINEL )                                                                              \
+
+
+#define DEFINE_ACTION(_name) MSG_##_name,
 typedef enum msg_type {
-    MSG_UNKNOWN,
-    MSG_REQ_MC_GET,                       /* memcache retrieval requests */
-    MSG_REQ_MC_GETS,
-    MSG_REQ_MC_DELETE,                    /* memcache delete request */
-    MSG_REQ_MC_CAS,                       /* memcache cas request and storage request */
-    MSG_REQ_MC_SET,                       /* memcache storage request */
-    MSG_REQ_MC_ADD,
-    MSG_REQ_MC_REPLACE,
-    MSG_REQ_MC_APPEND,
-    MSG_REQ_MC_PREPEND,
-    MSG_REQ_MC_INCR,                      /* memcache arithmetic request */
-    MSG_REQ_MC_DECR,
-    MSG_REQ_MC_TOUCH,                     /* memcache touch request */
-    MSG_REQ_MC_QUIT,                      /* memcache quit request */
-    MSG_RSP_MC_NUM,                       /* memcache arithmetic response */
-    MSG_RSP_MC_STORED,                    /* memcache cas and storage response */
-    MSG_RSP_MC_NOT_STORED,
-    MSG_RSP_MC_EXISTS,
-    MSG_RSP_MC_NOT_FOUND,
-    MSG_RSP_MC_END,
-    MSG_RSP_MC_VALUE,
-    MSG_RSP_MC_DELETED,                   /* memcache delete response */
-    MSG_RSP_MC_TOUCHED,                   /* memcachd touch response */
-    MSG_RSP_MC_ERROR,                     /* memcache error responses */
-    MSG_RSP_MC_CLIENT_ERROR,
-    MSG_RSP_MC_SERVER_ERROR,
-    MSG_REQ_REDIS_DEL,                    /* redis commands - keys */
-    MSG_REQ_REDIS_EXISTS,
-    MSG_REQ_REDIS_EXPIRE,
-    MSG_REQ_REDIS_EXPIREAT,
-    MSG_REQ_REDIS_PEXPIRE,
-    MSG_REQ_REDIS_PEXPIREAT,
-    MSG_REQ_REDIS_PERSIST,
-    MSG_REQ_REDIS_PTTL,
-    MSG_REQ_REDIS_SCAN,
-    MSG_REQ_REDIS_SORT,
-    MSG_REQ_REDIS_TTL,
-    MSG_REQ_REDIS_TYPE,
-    MSG_REQ_REDIS_APPEND,                 /* redis requests - string */
-    MSG_REQ_REDIS_BITCOUNT,
-    MSG_REQ_REDIS_DECR,
-    MSG_REQ_REDIS_DECRBY,
-    MSG_REQ_REDIS_DUMP,
-    MSG_REQ_REDIS_GET,
-    MSG_REQ_REDIS_GETBIT,
-    MSG_REQ_REDIS_GETRANGE,
-    MSG_REQ_REDIS_GETSET,
-    MSG_REQ_REDIS_INCR,
-    MSG_REQ_REDIS_INCRBY,
-    MSG_REQ_REDIS_INCRBYFLOAT,
-    MSG_REQ_REDIS_MSET,
-    MSG_REQ_REDIS_MGET,
-    MSG_REQ_REDIS_PSETEX,
-    MSG_REQ_REDIS_RESTORE,
-    MSG_REQ_REDIS_SET,
-    MSG_REQ_REDIS_SETBIT,
-    MSG_REQ_REDIS_SETEX,
-    MSG_REQ_REDIS_SETNX,
-    MSG_REQ_REDIS_SETRANGE,
-    MSG_REQ_REDIS_STRLEN,
-    MSG_REQ_REDIS_HDEL,                   /* redis requests - hashes */
-    MSG_REQ_REDIS_HEXISTS,
-    MSG_REQ_REDIS_HGET,
-    MSG_REQ_REDIS_HGETALL,
-    MSG_REQ_REDIS_HINCRBY,
-    MSG_REQ_REDIS_HINCRBYFLOAT,
-    MSG_REQ_REDIS_HKEYS,
-    MSG_REQ_REDIS_HLEN,
-    MSG_REQ_REDIS_HMGET,
-    MSG_REQ_REDIS_HMSET,
-    MSG_REQ_REDIS_HSET,
-    MSG_REQ_REDIS_HSETNX,
-    MSG_REQ_REDIS_HSCAN,
-    MSG_REQ_REDIS_HVALS,
-    MSG_REQ_REDIS_KEYS,
-    MSG_REQ_REDIS_INFO,
-    MSG_REQ_REDIS_LINDEX,                 /* redis requests - lists */
-    MSG_REQ_REDIS_LINSERT,
-    MSG_REQ_REDIS_LLEN,
-    MSG_REQ_REDIS_LPOP,
-    MSG_REQ_REDIS_LPUSH,
-    MSG_REQ_REDIS_LPUSHX,
-    MSG_REQ_REDIS_LRANGE,
-    MSG_REQ_REDIS_LREM,
-    MSG_REQ_REDIS_LSET,
-    MSG_REQ_REDIS_LTRIM,
-    MSG_REQ_REDIS_PING,
-    MSG_REQ_REDIS_QUIT,                                                                         \
-    MSG_REQ_REDIS_RPOP,
-    MSG_REQ_REDIS_RPOPLPUSH,
-    MSG_REQ_REDIS_RPUSH,
-    MSG_REQ_REDIS_RPUSHX,
-    MSG_REQ_REDIS_SADD,                   /* redis requests - sets */
-    MSG_REQ_REDIS_SCARD,
-    MSG_REQ_REDIS_SDIFF,
-    MSG_REQ_REDIS_SDIFFSTORE,
-    MSG_REQ_REDIS_SINTER,
-    MSG_REQ_REDIS_SINTERSTORE,
-    MSG_REQ_REDIS_SISMEMBER,
-    MSG_REQ_REDIS_SLAVEOF,
-    MSG_REQ_REDIS_SMEMBERS,
-    MSG_REQ_REDIS_SMOVE,
-    MSG_REQ_REDIS_SPOP,
-    MSG_REQ_REDIS_SRANDMEMBER,
-    MSG_REQ_REDIS_SREM,
-    MSG_REQ_REDIS_SUNION,
-    MSG_REQ_REDIS_SUNIONSTORE,
-    MSG_REQ_REDIS_SSCAN,
-    MSG_REQ_REDIS_ZADD,                   /* redis requests - sorted sets */
-    MSG_REQ_REDIS_ZCARD,
-    MSG_REQ_REDIS_ZCOUNT,
-    MSG_REQ_REDIS_ZINCRBY,
-    MSG_REQ_REDIS_ZINTERSTORE,
-    MSG_REQ_REDIS_ZRANGE,
-    MSG_REQ_REDIS_ZRANGEBYSCORE,
-    MSG_REQ_REDIS_ZRANK,
-    MSG_REQ_REDIS_ZREM,
-    MSG_REQ_REDIS_ZREMRANGEBYRANK,
-    MSG_REQ_REDIS_ZREMRANGEBYSCORE,
-    MSG_REQ_REDIS_ZREVRANGE,
-    MSG_REQ_REDIS_ZREVRANGEBYSCORE,
-    MSG_REQ_REDIS_ZREVRANK,
-    MSG_REQ_REDIS_ZSCORE,
-    MSG_REQ_REDIS_ZUNIONSTORE,
-    MSG_REQ_REDIS_ZSCAN,
-    MSG_REQ_REDIS_EVAL,                   /* redis requests - Lua */
-    MSG_REQ_REDIS_EVALSHA,
-	MSG_REQ_REDIS_PFADD,                  /* redis requests - hyperloglog */
-	MSG_REQ_REDIS_PFCOUNT,
-    MSG_RSP_REDIS_STATUS,                 /* redis response */
-    MSG_RSP_REDIS_INTEGER,
-    MSG_RSP_REDIS_BULK,
-    MSG_RSP_REDIS_MULTIBULK,
-	MSG_REQ_REDIS_CONFIG,
-    MSG_RSP_REDIS_ERROR,
-    MSG_RSP_REDIS_ERROR_ERR,
-    MSG_RSP_REDIS_ERROR_OOM,
-    MSG_RSP_REDIS_ERROR_BUSY,
-    MSG_RSP_REDIS_ERROR_NOAUTH,
-    MSG_RSP_REDIS_ERROR_LOADING,
-    MSG_RSP_REDIS_ERROR_BUSYKEY,
-    MSG_RSP_REDIS_ERROR_MISCONF,
-    MSG_RSP_REDIS_ERROR_NOSCRIPT,
-    MSG_RSP_REDIS_ERROR_READONLY,
-    MSG_RSP_REDIS_ERROR_WRONGTYPE,
-    MSG_RSP_REDIS_ERROR_EXECABORT,
-    MSG_RSP_REDIS_ERROR_MASTERDOWN,
-    MSG_RSP_REDIS_ERROR_NOREPLICAS,
-    MSG_SENTINEL
+    MSG_TYPE_CODEC(DEFINE_ACTION)
 } msg_type_t;
+#undef DEFINE_ACTION
 
 
 typedef enum dyn_error {
@@ -418,6 +430,7 @@ void msg_tmo_delete(struct msg *msg);
 void msg_init(size_t alloc_msgs_max);
 rstatus_t msg_clone(struct msg *src, struct mbuf *mbuf_start, struct msg *target);
 void msg_deinit(void);
+struct string *msg_type_string(msg_type_t type);
 struct msg *msg_get(struct conn *conn, bool request, const char* const caller);
 void msg_put(struct msg *msg);
 uint32_t msg_mbuf_size(struct msg *msg);


### PR DESCRIPTION
Now we will have the type of message as strings in the logs. Much
helpful.
While at it, also remove some warnings