### PR TITLE
Custom printf specifier

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -884,9 +884,8 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *req)
     uint32_t keylen = 0;
     uint8_t *key = msg_get_key(req, &pool->hash_tag, &keylen);
 
-    struct string *type = msg_type_string(req->type);
-    log_debug(LOG_DEBUG, "conn %p received message %d:%d %.*s key '%.*s' adding to dict", c_conn,
-              req->id, req->parent_id, type->len, type->data, keylen, key);
+    log_debug(LOG_DEBUG, "%M received %M key '%.*s' adding to dict", c_conn,
+              req, keylen, key);
     // add the message to the dict
     dictAdd(c_conn->outstanding_msgs_dict, &req->id, req);
 

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -91,6 +91,7 @@ typedef enum connection_type {
 } connection_type_t;
 
 struct conn {
+    object_type_t      object_type;
     TAILQ_ENTRY(conn)  conn_tqe;      /* link in server_pool / server / free q */
     TAILQ_ENTRY(conn)  ready_tqe;     /* link in ready connection q */
     void               *owner;        /* connection owner - server_pool / server */
@@ -188,6 +189,7 @@ conn_handle_response(struct conn *conn, msgid_t msgid, struct msg *rsp)
         (conn)->ops->dequeue_outq(ctx, conn, msg)
 TAILQ_HEAD(conn_tqh, conn);
 
+int print_conn(FILE *stream, struct conn *conn);
 void conn_set_write_consistency(struct conn *conn, consistency_t cons);
 consistency_t conn_get_write_consistency(struct conn *conn);
 void conn_set_read_consistency(struct conn *conn, consistency_t cons);

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -87,6 +87,7 @@ typedef int err_t;     /* error type */
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdbool.h>
 #include <inttypes.h>
 #include <string.h>
@@ -350,6 +351,7 @@ struct context {
 
 
 
+int core_register_printf_function(void);
 rstatus_t core_start(struct instance *nci);
 void core_stop(struct context *ctx);
 rstatus_t core_core(void *arg, uint32_t events);

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -322,6 +322,7 @@ get_msg_routing_string(msg_routing_t route)
 
 
 struct msg {
+    object_type_t        object_type;
     TAILQ_ENTRY(msg)     c_tqe;           /* link in client q */
     TAILQ_ENTRY(msg)     s_tqe;           /* link in server q */
     TAILQ_ENTRY(msg)     m_tqe;           /* link in send q / free q */
@@ -421,6 +422,8 @@ msg_handle_response(struct msg *req, struct msg *rsp)
     return req->rsp_handler(req, rsp);
 }
 
+int print_req(FILE *stream, struct msg *req);
+int print_rsp(FILE *stream, struct msg *rsp);
 size_t msg_free_queue_size(void);
 
 struct msg *msg_tmo_min(void);

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -41,3 +41,9 @@ cleanup_charptr(char **ptr) {
 
 #define SCOPED_CHARPTR(var) \
     char * var __attribute__ ((__cleanup__(cleanup_charptr))) 
+
+typedef enum {
+    OBJ_REQ,
+    OBJ_RSP,
+    OBJ_CONN
+}object_type_t;

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -615,6 +615,7 @@ main(int argc, char **argv)
 
     dn_coredump_init();
     dn_set_default_options(&nci);
+    core_register_printf_function();
 
     status = dn_get_options(argc, argv, &nci);
     if (status != DN_OK) {


### PR DESCRIPTION
Implemented a printf handler of M to print out objects.
Created a new object type enum for each type of object. Right now it is
only for request, response and connection.
Printing information about this objects now is very simple is
customizable at one place.

This, I believe will ease printing information in the logs and hence help debugging issues