### PR TITLE
Do not close listening sockets

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -425,8 +425,7 @@ core_recv(struct context *ctx, struct conn *conn)
 
 	status = conn_recv(ctx, conn);
 	if (status != DN_OK) {
-		log_info("recv on %s %d failed: %s", conn_get_type_string(conn),
-				 conn->sd, strerror(errno));
+		log_info("%M recv failed: %s", conn, strerror(errno));
 	}
 
 	return status;
@@ -439,8 +438,7 @@ core_send(struct context *ctx, struct conn *conn)
 
 	status = conn_send(ctx, conn);
 	if (status != DN_OK) {
-		log_info("send on %s %d failed: %s", conn_get_type_string(conn),
-				 conn->sd, strerror(errno));
+		log_info("%M send failed: %s", conn, strerror(errno));
 	}
 
 	return status;


### PR DESCRIPTION
If there are failures during accepting a connections, like unable to set
non blocking on the socket, we were closing the listening sockets,
silently taking the node down. Fix it and log appropriately.

Fixes #424