### PR TITLE
Connection cleanup

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ dynomite_SOURCES =			                          \
         dyn_cbuf.h                                                \
         dyn_client.c dyn_client.h                                 \
         dyn_conf.c dyn_conf.h		                          \
-        dyn_connection.c dyn_connection.h                         \
+        dyn_connection_internal.c dyn_connection.c dyn_connection.h                         \
         dyn_core.c dyn_core.h                                     \
         dyn_crypto.c dyn_crypto.h                                 \
         dyn_dict_msg_id.h dyn_dict_msg_id.c                       \
@@ -83,7 +83,7 @@ dynomite_test_SOURCES =                                           \
         dyn_cbuf.h                                                \
         dyn_crypto.c dyn_crypto.h                                 \
         dyn_core.c dyn_core.h                                     \
-        dyn_connection.c dyn_connection.h                         \
+        dyn_connection_internal.c dyn_connection.c dyn_connection.h                         \
         dyn_client.c dyn_client.h                                 \
         dyn_dict_msg_id.h dyn_dict_msg_id.c                       \
         dyn_dnode_client.h dyn_dnode_client.c                     \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,8 @@ dynomite_SOURCES =			                          \
         dyn_cbuf.h                                                \
         dyn_client.c dyn_client.h                                 \
         dyn_conf.c dyn_conf.h		                          \
-        dyn_connection_internal.c dyn_connection.c dyn_connection.h                         \
+        dyn_connection.c dyn_connection.h                         \
+        dyn_connection_internal.c dyn_connection_internal.h       \
         dyn_core.c dyn_core.h                                     \
         dyn_crypto.c dyn_crypto.h                                 \
         dyn_dict_msg_id.h dyn_dict_msg_id.c                       \
@@ -61,6 +62,7 @@ dynomite_SOURCES =			                          \
         dyn_stats.c dyn_stats.h		                          \
         dyn_string.c dyn_string.h		                  \
         dyn_token.c dyn_token.h                                   \
+        dyn_types.c dyn_types.h                                   \
         dyn_log.c dyn_log.h		                          \
         dyn_util.c dyn_util.h		                          \
         dyn_vnode.c dyn_vnode.h                                   \
@@ -83,7 +85,8 @@ dynomite_test_SOURCES =                                           \
         dyn_cbuf.h                                                \
         dyn_crypto.c dyn_crypto.h                                 \
         dyn_core.c dyn_core.h                                     \
-        dyn_connection_internal.c dyn_connection.c dyn_connection.h                         \
+        dyn_connection.c dyn_connection.h                         \
+        dyn_connection_internal.c dyn_connection_internal.h		  \
         dyn_client.c dyn_client.h                                 \
         dyn_dict_msg_id.h dyn_dict_msg_id.c                       \
         dyn_dnode_client.h dyn_dnode_client.c                     \
@@ -105,6 +108,7 @@ dynomite_test_SOURCES =                                           \
         dyn_stats.c dyn_stats.h                                   \
         dyn_signal.c dyn_signal.h                                 \
         dyn_token.c dyn_token.h                                   \
+        dyn_types.c dyn_types.h                                   \
         dyn_rbtree.c dyn_rbtree.h                                 \
         dyn_log.c dyn_log.h                                       \
         dyn_string.c dyn_string.h                                 \

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -1055,6 +1055,7 @@ struct conn_ops client_ops = {
 void
 init_client_conn(struct conn *conn)
 {
+    conn->dyn_mode = 0;
     conn->type = CONN_CLIENT;
     conn->ops = &client_ops;
 }

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -422,7 +422,10 @@ conf_pool_transform(struct server_pool *sp, struct conf_pool *cp)
     ASSERT(cp->valid);
 
     memset(sp, 0, sizeof(struct server_pool));
-    sp->object_type = OBJ_POOL;
+    sp->object = (object_t){
+        .type = OBJ_POOL,
+        .func_print = print_server_pool
+    };
     sp->ctx = NULL;
     sp->p_conn = NULL;
     sp->dn_conn_q = 0;

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -26,6 +26,7 @@
 #include "dyn_server.h"
 #include "dyn_client.h"
 #include "dyn_proxy.h"
+#include "dyn_connection_internal.h"
 #include "dyn_dnode_proxy.h"
 #include "dyn_dnode_peer.h"
 #include "dyn_dnode_client.h"
@@ -94,14 +95,6 @@
  */
 
 #define DYN_KEEPALIVE_INTERVAL_S 15 /* seconds */
-extern void _conn_deinit(void);
-extern void _conn_init(void);
-extern void _conn_put(struct conn *conn);
-extern inline char *_conn_get_type_string(struct conn *conn);
-extern void _add_to_ready_q(struct context *ctx, struct conn *conn);
-extern void _remove_from_ready_q(struct context *ctx, struct conn *conn);
-extern rstatus_t _conn_reuse(struct conn *p);
-
 consistency_t g_read_consistency = DEFAULT_READ_CONSISTENCY;
 consistency_t g_write_consistency = DEFAULT_WRITE_CONSISTENCY;
 
@@ -141,32 +134,6 @@ conn_to_ctx(struct conn *conn)
     }
 
     return pool ? pool->ctx : NULL;
-}
-
-int
-print_conn(FILE *stream, struct conn *conn)
-{
-    if ((conn->type == CONN_DNODE_PEER_PROXY) ||
-        (conn->type == CONN_PROXY)) {
-        return fprintf(stream, "<%s %p %d listening on '%.*s'>",
-                   _conn_get_type_string(conn), conn, conn->sd,
-                   conn->pname.len, conn->pname.data);
-    }
-    if ((conn->type == CONN_DNODE_PEER_CLIENT) ||
-        (conn->type == CONN_CLIENT)) {
-        return fprintf(stream, "<%s %p %d from '%.*s'>",
-                   _conn_get_type_string(conn), conn, conn->sd,
-                   conn->pname.len, conn->pname.data);
-    }
-    if ((conn->type == CONN_DNODE_PEER_SERVER) ||
-        (conn->type == CONN_SERVER)) {
-        return fprintf(stream, "<%s %p %d to '%.*s'>",
-                   _conn_get_type_string(conn), conn, conn->sd,
-                   conn->pname.len, conn->pname.data);
-    }
-
-    return fprintf(stream, "<%s %p %d>",
-                   _conn_get_type_string(conn), conn, conn->sd);
 }
 
 inline void

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -142,8 +142,6 @@ struct conn {
     connection_type_t  type;
 };
 
-char * conn_get_type_string(struct conn *conn);
-
 static inline rstatus_t
 conn_cant_handle_response(struct conn *conn, msgid_t reqid, struct msg *resp)
 {
@@ -196,10 +194,9 @@ void conn_set_read_consistency(struct conn *conn, consistency_t cons);
 consistency_t conn_get_read_consistency(struct conn *conn);
 struct context *conn_to_ctx(struct conn *conn);
 struct conn *test_conn_get(void);
-struct conn *conn_get(void *owner, bool client);
-struct conn *conn_get_proxy(void *owner);
-struct conn *conn_get_peer(void *owner, bool client);
-struct conn *conn_get_dnode(void *owner);
+
+typedef void (*func_conn_init_t)(struct conn *conn);
+struct conn *conn_get(void *owner, func_conn_init_t func_conn_init);
 void conn_put(struct conn *conn);
 rstatus_t conn_listen(struct context *ctx, struct conn *p);
 
@@ -216,7 +213,6 @@ ssize_t conn_recv_data(struct conn *conn, void *buf, size_t size);
 ssize_t conn_sendv_data(struct conn *conn, struct array *sendv, size_t nsend);
 void conn_init(void);
 void conn_deinit(void);
-void conn_print(struct conn *conn);
 
 bool conn_is_req_first_in_outqueue(struct conn *conn, struct msg *req);
 rstatus_t conn_event_add_conn(struct conn * conn);

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -91,7 +91,7 @@ typedef enum connection_type {
 } connection_type_t;
 
 struct conn {
-    object_type_t      object_type;
+    object_t           object;
     TAILQ_ENTRY(conn)  conn_tqe;      /* link in server_pool / server / free q */
     TAILQ_ENTRY(conn)  ready_tqe;     /* link in ready connection q */
     void               *owner;        /* connection owner - server_pool / server */
@@ -187,7 +187,6 @@ conn_handle_response(struct conn *conn, msgid_t msgid, struct msg *rsp)
         (conn)->ops->dequeue_outq(ctx, conn, msg)
 TAILQ_HEAD(conn_tqh, conn);
 
-int print_conn(FILE *stream, struct conn *conn);
 void conn_set_write_consistency(struct conn *conn, consistency_t cons);
 consistency_t conn_get_write_consistency(struct conn *conn);
 void conn_set_read_consistency(struct conn *conn, consistency_t cons);

--- a/src/dyn_connection_internal.c
+++ b/src/dyn_connection_internal.c
@@ -4,9 +4,6 @@
  */ 
 
 /*
- * twemproxy - A fast and lightweight proxy for memcached protocol.
- * Copyright (C) 2011 Twitter, Inc.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/src/dyn_connection_internal.c
+++ b/src/dyn_connection_internal.c
@@ -1,0 +1,223 @@
+/*
+ * Dynomite - A thin, distributed replication layer for multi non-distributed storages.
+ * Copyright (C) 2014 Netflix, Inc.
+ */ 
+
+/*
+ * twemproxy - A fast and lightweight proxy for memcached protocol.
+ * Copyright (C) 2011 Twitter, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/uio.h>
+
+#include "dyn_core.h"
+#include "dyn_server.h"
+#include "dyn_client.h"
+#include "dyn_proxy.h"
+#include "dyn_dnode_proxy.h"
+#include "dyn_dnode_peer.h"
+#include "dyn_dnode_client.h"
+#include "event/dyn_event.h"
+
+#include "proto/dyn_proto.h"
+
+static uint32_t nfree_connq;       /* # free conn q */
+static struct conn_tqh free_connq; /* free conn q */
+
+inline char *
+_conn_get_type_string(struct conn *conn)
+{
+    switch(conn->type) {
+        case CONN_UNSPECIFIED: return "UNSPEC";
+        case CONN_PROXY : return "PROXY";
+        case CONN_CLIENT: return "CLIENT";
+        case CONN_SERVER: return "SERVER";
+        case CONN_DNODE_PEER_PROXY: return "PEER_PROXY";
+        case CONN_DNODE_PEER_CLIENT: return conn->same_dc ?
+                                            "LOCAL_PEER_CLIENT" : "REMOTE_PEER_CLIENT";
+        case CONN_DNODE_PEER_SERVER: return conn->same_dc ?
+                                            "LOCAL_PEER_SERVER" : "REMOTE_PEER_SERVER";
+    }
+    return "INVALID";
+}
+
+struct conn *
+_conn_get(void)
+{
+    struct conn *conn;
+
+    if (!TAILQ_EMPTY(&free_connq)) {
+        ASSERT(nfree_connq > 0);
+
+        conn = TAILQ_FIRST(&free_connq);
+        nfree_connq--;
+        TAILQ_REMOVE(&free_connq, conn, conn_tqe);
+    } else {
+        conn = dn_alloc(sizeof(*conn));
+        if (conn == NULL) {
+            return NULL;
+        }
+        memset(conn, 0, sizeof(*conn));
+    }
+
+    conn->object_type = OBJ_CONN;
+    conn->owner = NULL;
+
+    conn->sd = -1;
+    string_init(&conn->pname);
+    /* {family, addrlen, addr} are initialized in enqueue handler */
+
+    TAILQ_INIT(&conn->imsg_q);
+    conn->imsg_count = 0;
+
+    TAILQ_INIT(&conn->omsg_q);
+    conn->omsg_count = 0;
+
+    conn->rmsg = NULL;
+    conn->smsg = NULL;
+
+    /*
+     * Callbacks {recv, recv_next, recv_done}, {send, send_next, send_done},
+     * {close, active}, parse, {ref, unref}, {enqueue_inq, dequeue_inq} and
+     * {enqueue_outq, dequeue_outq} are initialized by the wrapper.
+     */
+
+    conn->send_bytes = 0;
+    conn->recv_bytes = 0;
+
+    conn->events = 0;
+    conn->err = 0;
+    conn->recv_active = 0;
+    conn->recv_ready = 0;
+    conn->send_active = 0;
+    conn->send_ready = 0;
+
+    conn->connecting = 0;
+    conn->connected = 0;
+    conn->eof = 0;
+    conn->done = 0;
+    conn->waiting_to_unref = 0;
+
+    /* for dynomite */
+    conn->dyn_mode = 0;
+    conn->dnode_secured = 0;
+    conn->dnode_crypto_state = 0;
+
+    conn->same_dc = 1;
+    conn->avail_tokens = msgs_per_sec();
+    conn->last_sent = 0;
+    conn->attempted_reconnect = 0;
+    //conn->non_bytes_send = 0;
+    conn_set_read_consistency(conn, g_read_consistency);
+    conn_set_write_consistency(conn, g_write_consistency);
+    conn->type = CONN_UNSPECIFIED;
+
+    unsigned char *aes_key = generate_aes_key();
+    strncpy((char *)conn->aes_key, (char *)aes_key, strlen((char *)aes_key)); //generate a new key for each connection
+
+    return conn;
+}
+
+void
+_add_to_ready_q(struct context *ctx, struct conn *conn)
+{
+    // This check is required to check if the connection is already
+    // on the ready queue
+    if (conn->ready_tqe.tqe_prev == NULL) {
+        struct server_pool *pool = &ctx->pool;
+        TAILQ_INSERT_TAIL(&pool->ready_conn_q, conn, ready_tqe);
+    }
+}
+
+void
+_remove_from_ready_q(struct context *ctx, struct conn *conn)
+{
+    // This check is required to check if the connection is already
+    // on the ready queue
+    if (conn->ready_tqe.tqe_prev != NULL) {
+        struct server_pool *pool = &ctx->pool;
+        TAILQ_REMOVE(&pool->ready_conn_q, conn, ready_tqe);
+    }
+}
+
+static void
+_conn_free(struct conn *conn)
+{
+    log_debug(LOG_VVERB, "free conn %p", conn);
+    dn_free(conn);
+}
+
+void
+_conn_put(struct conn *conn)
+{
+    nfree_connq++;
+    TAILQ_INSERT_HEAD(&free_connq, conn, conn_tqe);
+}
+
+/**
+ * Initialize connections.
+ */
+void
+_conn_init(void)
+{
+    log_debug(LOG_DEBUG, "conn size %d", sizeof(struct conn));
+    nfree_connq = 0;
+    TAILQ_INIT(&free_connq);
+}
+
+void
+_conn_deinit(void)
+{
+    struct conn *conn, *nconn; /* current and next connection */
+
+    for (conn = TAILQ_FIRST(&free_connq); conn != NULL;
+         conn = nconn, nfree_connq--) {
+        ASSERT(nfree_connq > 0);
+        nconn = TAILQ_NEXT(conn, conn_tqe);
+        _conn_free(conn);
+    }
+    ASSERT(nfree_connq == 0);
+}
+
+rstatus_t
+_conn_reuse(struct conn *p)
+{
+    rstatus_t status;
+    struct sockaddr_un *un;
+
+    switch (p->family) {
+    case AF_INET:
+    case AF_INET6:
+        status = dn_set_reuseaddr(p->sd);
+        break;
+
+    case AF_UNIX:
+        /*
+         * bind() will fail if the pathname already exist. So, we call unlink()
+         * to delete the pathname, in case it already exists. If it does not
+         * exist, unlink() returns error, which we ignore
+         */
+        un = (struct sockaddr_un *) p->addr;
+        unlink(un->sun_path);
+        status = DN_OK;
+        break;
+
+    default:
+        NOT_REACHED();
+        status = DN_ERROR;
+    }
+
+    return status;
+}

--- a/src/dyn_connection_internal.h
+++ b/src/dyn_connection_internal.h
@@ -1,0 +1,9 @@
+#pragma once
+extern void _conn_deinit(void);
+extern void _conn_init(void);
+extern struct conn *_conn_get(void);
+extern void _conn_put(struct conn *conn);
+extern inline char *_conn_get_type_string(struct conn *conn);
+extern void _add_to_ready_q(struct context *ctx, struct conn *conn);
+extern void _remove_from_ready_q(struct context *ctx, struct conn *conn);
+extern rstatus_t _conn_reuse(struct conn *p);

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -351,9 +351,11 @@ core_start(struct instance *nci)
     return status;
 }
 
-static int
-print_server_pool(FILE *stream, struct server_pool *sp)
+int
+print_server_pool(FILE *stream, const struct object *obj)
 {
+    ASSERT(obj->type == OBJ_POOL);
+    struct server_pool *sp = (struct server_pool *)obj;
     return fprintf(stream, "<POOL %p '%.*s'>", sp, sp->name.len, sp->name.data);
 }
 
@@ -371,31 +373,24 @@ print_obj_arginfo(const struct printf_info *info, size_t n,
 static int
 print_obj(FILE *stream, const struct printf_info *info, const void *const *args)
 {
-    const object_type_t *obj_type;
+    const object_t *obj;
     const struct msg *msg;
     const struct conn *conn;
     const struct server_pool *sp;
 
-    obj_type = *((const object_type_t **) (args[0]));
-    if (obj_type == NULL) {
+    obj = *((const object_t **) (args[0]));
+    if (obj == NULL) {
         return fprintf(stream, "<NULL>");
     }
 
-    switch (*obj_type) {
+    switch (obj->type) {
         case OBJ_REQ:
-            msg = *((const struct msg **) (args[0]));
-            return print_req(stream, msg);
         case OBJ_RSP:
-            msg = *((const struct msg **) (args[0]));
-            return print_rsp(stream, msg);
         case OBJ_CONN:
-            conn = *((const struct conn **) (args[0]));
-            return print_conn(stream, conn);
         case OBJ_POOL:
-            sp = *((const struct server_pool **) (args[0]));
-            return print_server_pool(stream, sp);
+            return obj->func_print(stream, obj);
         default:
-            return fprintf(stream, "<unknown %p>", obj_type);
+            return fprintf(stream, "<unknown %p>", obj);
     }
 }
 

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -274,7 +274,7 @@ struct node {
  * information such as dc, rack, node token and runtime environment.
  */
 struct server_pool {
-    object_type_t        object_type;
+    object_t           object;
     struct context     *ctx;                 /* owner context */
     struct conf_pool   *conf_pool;           /* back reference to conf_pool */
 
@@ -360,5 +360,6 @@ rstatus_t core_core(void *arg, uint32_t events);
 rstatus_t core_loop(struct context *ctx);
 void core_debug(struct context *ctx);
 void core_set_local_state(struct context *ctx, dyn_state_t state);
+int print_server_pool(FILE *stream, const struct object *obj);
 
 #endif

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -544,6 +544,7 @@ struct conn_ops dnode_client_ops = {
 void
 init_dnode_client_conn(struct conn *conn)
 {
+    conn->dyn_mode = 1;
     conn->type = CONN_DNODE_PEER_CLIENT;
     conn->ops = &dnode_client_ops;
 }

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -342,7 +342,7 @@ dnode_peer_conn(struct node *peer)
     pool = peer->owner;
 
     if (peer->conn == NULL) {
-        conn = conn_get_peer(peer, false);
+        conn = conn_get(peer, init_dnode_peer_conn);
         if (is_conn_secured(pool, peer)) {
             conn->dnode_secured = 1;
             conn->dnode_crypto_state = 0; //need to do a encryption handshake
@@ -1751,6 +1751,7 @@ struct conn_ops dnode_peer_ops = {
 void
 init_dnode_peer_conn(struct conn *conn)
 {
+    conn->dyn_mode = 1;
     conn->type = CONN_DNODE_PEER_SERVER;
     conn->ops = &dnode_peer_ops;
 }

--- a/src/dyn_dnode_proxy.c
+++ b/src/dyn_dnode_proxy.c
@@ -9,6 +9,7 @@
 #include "dyn_core.h"
 #include "dyn_server.h"
 #include "dyn_dnode_peer.h"
+#include "dyn_dnode_client.h"
 #include "dyn_dnode_proxy.h"
 
 static void
@@ -87,7 +88,7 @@ dnode_init(struct context *ctx)
 {
     rstatus_t status;
     struct server_pool *pool = &ctx->pool;
-    struct conn *p = conn_get_dnode(pool);
+    struct conn *p = conn_get(pool, init_dnode_proxy_conn);
     if (p == NULL) {
         return DN_ENOMEM;
     }
@@ -170,7 +171,7 @@ dnode_accept(struct context *ctx, struct conn *p)
        loga("Unable to get client's address for accept on sd %d\n", sd);
     }
 
-    c = conn_get_peer(p->owner, true);
+    c = conn_get(p->owner, init_dnode_client_conn);
     if (c == NULL) {
         log_error("get conn for PEER_CLIENT %d from %M failed: %s", sd, p,
                   strerror(errno));
@@ -252,6 +253,7 @@ struct conn_ops dnode_server_ops = {
 void
 init_dnode_proxy_conn(struct conn *conn)
 {
+    conn->dyn_mode = 1;
     conn->type = CONN_DNODE_PEER_PROXY;
     conn->ops = &dnode_server_ops;
 }

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -322,7 +322,7 @@ get_msg_routing_string(msg_routing_t route)
 
 
 struct msg {
-    object_type_t        object_type;
+    object_t             object;
     TAILQ_ENTRY(msg)     c_tqe;           /* link in client q */
     TAILQ_ENTRY(msg)     s_tqe;           /* link in server q */
     TAILQ_ENTRY(msg)     m_tqe;           /* link in send q / free q */
@@ -422,8 +422,6 @@ msg_handle_response(struct msg *req, struct msg *rsp)
     return req->rsp_handler(req, rsp);
 }
 
-int print_req(FILE *stream, struct msg *req);
-int print_rsp(FILE *stream, struct msg *rsp);
 size_t msg_free_queue_size(void);
 
 struct msg *msg_tmo_min(void);

--- a/src/dyn_proxy.c
+++ b/src/dyn_proxy.c
@@ -24,6 +24,7 @@
 
 #include "dyn_core.h"
 #include "dyn_server.h"
+#include "dyn_client.h"
 #include "dyn_proxy.h"
 
 static void
@@ -99,7 +100,7 @@ proxy_init(struct context *ctx)
     rstatus_t status;
     struct server_pool *pool = &ctx->pool;
 
-    struct conn *p = conn_get_proxy(pool);
+    struct conn *p = conn_get(pool, init_proxy_conn);
     if (!p) {
         return DN_ENOMEM;
     }
@@ -173,7 +174,7 @@ proxy_accept(struct context *ctx, struct conn *p)
         break;
     }
 
-    c = conn_get(p->owner, true);
+    c = conn_get(p->owner, init_client_conn);
     if (c == NULL) {
         log_error("get conn for CLIENT %d from %M failed: %s", sd, p,
                   strerror(errno));
@@ -256,6 +257,7 @@ struct conn_ops proxy_ops = {
 void
 init_proxy_conn(struct conn *conn)
 {
+    conn->dyn_mode = 0;
     conn->type = CONN_PROXY;
     conn->ops = &proxy_ops;
 }

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -126,7 +126,7 @@ static struct conn *
 server_conn(struct datastore *datastore)
 {
     if (!datastore->conn) {
-        return conn_get(datastore, false);
+        return conn_get(datastore, init_server_conn);
     }
     return datastore->conn;
 }
@@ -996,6 +996,7 @@ struct conn_ops server_ops = {
 void
 init_server_conn(struct conn *conn)
 {
+    conn->dyn_mode = 0;
     conn->type = CONN_SERVER;
     conn->ops = &server_ops;
 }

--- a/src/dyn_test.c
+++ b/src/dyn_test.c
@@ -445,12 +445,18 @@ aes_test(void)
     return DN_OK;
 }
 
+void
+init_peer_conn(struct conn *conn)
+{
+    conn->dyn_mode = 1;
+    conn->sd = 0;
+}
 /* Inspection test */
 static rstatus_t
 aes_msg_test(struct node *server)
 {
     //unsigned char* aes_key = generate_aes_key();
-    struct conn *conn = conn_get_peer(server, false);
+    struct conn *conn = conn_get(server, init_peer_conn);
     struct msg *msg = msg_get(conn, true, __FUNCTION__);
 
     struct mbuf *mbuf1 = mbuf_get();
@@ -586,7 +592,7 @@ main(int argc, char **argv)
     memset(peer, 0, sizeof(struct node));
     init_peer(peer);
 
-    struct conn *conn = conn_get_peer(peer, false);
+    struct conn *conn = conn_get(peer, init_peer_conn);
     struct msg *msg = msg_get(conn, true, __FUNCTION__);
 
     //test payload larger than mbuf_size

--- a/src/dyn_types.c
+++ b/src/dyn_types.c
@@ -1,0 +1,7 @@
+#include "dyn_types.h"
+
+void
+cleanup_charptr(const char **ptr) {
+    if (*ptr)
+        free(*ptr);
+}

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 typedef uint64_t msgid_t;
 typedef uint64_t msec_t;
 typedef uint64_t usec_t;
@@ -33,11 +34,7 @@ struct datacenter;
 struct rack;
 struct dyn_ring;
 
-static void
-cleanup_charptr(char **ptr) {
-    if (*ptr)
-        free(*ptr);
-}
+extern void cleanup_charptr(const char **ptr);
 
 #define SCOPED_CHARPTR(var) \
     char * var __attribute__ ((__cleanup__(cleanup_charptr))) 
@@ -48,3 +45,8 @@ typedef enum {
     OBJ_CONN,
     OBJ_POOL
 }object_type_t;
+
+typedef struct object {
+    object_type_t type;
+    int (*func_print)(FILE *stream, const struct object *obj);
+}object_t;


### PR DESCRIPTION
* Move static internal functions to dyn_connection_internal.c
* Make object printing more generic
* reduce 4 conn_get_* apis into one conn_get
* Move cleanup_charptr to a .c and reduce warnings by 50