### PR TITLE
magic number in object to detect corruptions

### DIFF
--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -422,10 +422,7 @@ conf_pool_transform(struct server_pool *sp, struct conf_pool *cp)
     ASSERT(cp->valid);
 
     memset(sp, 0, sizeof(struct server_pool));
-    sp->object = (object_t){
-        .type = OBJ_POOL,
-        .func_print = print_server_pool
-    };
+    init_object(&sp->object, OBJ_POOL, print_server_pool);
     sp->ctx = NULL;
     sp->p_conn = NULL;
     sp->dn_conn_q = 0;

--- a/src/dyn_connection_internal.c
+++ b/src/dyn_connection_internal.c
@@ -99,10 +99,7 @@ _conn_get(void)
         memset(conn, 0, sizeof(*conn));
     }
 
-    conn->object = (object_t){
-        .type = OBJ_CONN,
-        .func_print = _print_conn
-    };
+    init_object(&conn->object, OBJ_CONN, _print_conn);
     conn->owner = NULL;
 
     conn->sd = -1;

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -22,7 +22,6 @@
 
 #include <stdlib.h>
 #include <unistd.h>
-#include <printf.h>
 
 #include "dyn_core.h"
 #include "dyn_conf.h"
@@ -357,47 +356,6 @@ print_server_pool(FILE *stream, const struct object *obj)
     ASSERT(obj->type == OBJ_POOL);
     struct server_pool *sp = (struct server_pool *)obj;
     return fprintf(stream, "<POOL %p '%.*s'>", sp, sp->name.len, sp->name.data);
-}
-
-static int
-print_obj_arginfo(const struct printf_info *info, size_t n,
-                  int *argtypes)
-{
-      /* We always take exactly one argument and this is a pointer to the
-       *      structure.. */
-    if (n > 0)
-        argtypes[0] = PA_POINTER;
-    return 1;
-}
-
-static int
-print_obj(FILE *stream, const struct printf_info *info, const void *const *args)
-{
-    const object_t *obj;
-    const struct msg *msg;
-    const struct conn *conn;
-    const struct server_pool *sp;
-
-    obj = *((const object_t **) (args[0]));
-    if (obj == NULL) {
-        return fprintf(stream, "<NULL>");
-    }
-
-    switch (obj->type) {
-        case OBJ_REQ:
-        case OBJ_RSP:
-        case OBJ_CONN:
-        case OBJ_POOL:
-            return obj->func_print(stream, obj);
-        default:
-            return fprintf(stream, "<unknown %p>", obj);
-    }
-}
-
-int
-core_register_printf_function(void)
-{
-    return log_register_custom_specifier('M', print_obj, print_obj_arginfo);
 }
 
 /**

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -353,7 +353,6 @@ struct context {
 
 
 
-int core_register_printf_function(void);
 rstatus_t core_start(struct instance *nci);
 void core_stop(struct context *ctx);
 rstatus_t core_core(void *arg, uint32_t events);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -175,7 +175,7 @@ print_req(FILE *stream, const struct object *obj)
 static int
 print_rsp(FILE *stream, const struct object *obj)
 {
-    ASSERT(obj->type == OBJ_REQ);
+    ASSERT(obj->type == OBJ_RSP);
     struct msg *rsp = (struct msg *)obj;
     return fprintf(stream, "<RSP %p %lu:%lu>", rsp, rsp->id, rsp->parent_id);
 }
@@ -322,15 +322,9 @@ _msg_get(struct conn *conn, bool request, const char *const caller)
 done:
     /* c_tqe, s_tqe, and m_tqe are left uninitialized */
     if (request) {
-        msg->object = (object_t) {
-            .type = OBJ_REQ,
-            .func_print = print_req
-        };
+        init_object(&msg->object, OBJ_REQ, print_req);
     } else {
-        msg->object = (object_t) {
-            .type = OBJ_RSP,
-            .func_print = print_rsp
-        };
+        init_object(&msg->object, OBJ_RSP, print_rsp);
     }
 
     msg->id = ++msg_id;

--- a/src/dyn_types.c
+++ b/src/dyn_types.c
@@ -1,7 +1,45 @@
 #include "dyn_types.h"
 
+#define OBJECT_MAGIC 0xdead
+
 void
-cleanup_charptr(const char **ptr) {
+cleanup_charptr(char **ptr) {
     if (*ptr)
         free(*ptr);
+}
+
+void
+init_object(struct object *obj, object_type_t type, func_print_t print)
+{
+    obj->magic = OBJECT_MAGIC;
+    obj->type = type;
+    obj->func_print = print;
+}
+
+int
+print_obj_arginfo(const struct printf_info *info, size_t n, int *argtypes)
+{
+      /* We always take exactly one argument and this is a pointer to the
+       *      structure.. */
+    if (n > 0)
+        argtypes[0] = PA_POINTER;
+    return 1;
+}
+
+int
+print_obj(FILE *stream, const struct printf_info *info, const void *const *args)
+{
+    const object_t *obj;
+
+    obj = *((const object_t **) (args[0]));
+    if (obj == NULL) {
+        return fprintf(stream, "<NULL>");
+    }
+    if (obj->magic != OBJECT_MAGIC) {
+        return fprintf(stream, "<CORRUPTION> MAGIC NUMBER 0x%x", obj->magic);
+    }
+    if ((obj->type >= 0) && (obj->type < OBJ_LAST))
+       return obj->func_print(stream, obj);
+    else
+        return fprintf(stream, "<CORRUPTION> INVALID TYPE %d", obj->type);
 }

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h>
+#include <printf.h>
 typedef uint64_t msgid_t;
 typedef uint64_t msec_t;
 typedef uint64_t usec_t;
@@ -34,7 +34,7 @@ struct datacenter;
 struct rack;
 struct dyn_ring;
 
-extern void cleanup_charptr(const char **ptr);
+extern void cleanup_charptr(char **ptr);
 
 #define SCOPED_CHARPTR(var) \
     char * var __attribute__ ((__cleanup__(cleanup_charptr))) 
@@ -43,10 +43,19 @@ typedef enum {
     OBJ_REQ,
     OBJ_RSP,
     OBJ_CONN,
-    OBJ_POOL
+    OBJ_POOL,
+    OBJ_LAST
 }object_type_t;
 
+struct object;
+typedef int (*func_print_t)(FILE *stream, const struct object *obj);
 typedef struct object {
+    uint16_t    magic;
     object_type_t type;
-    int (*func_print)(FILE *stream, const struct object *obj);
+    func_print_t func_print;
 }object_t;
+
+void init_object(object_t *obj, object_type_t type, func_print_t func_print);
+
+int print_obj(FILE *stream, const struct printf_info *info, const void *const *args);
+int print_obj_arginfo(const struct printf_info *info, size_t n, int *argtypes);

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -613,7 +613,11 @@ main(int argc, char **argv)
 
     dn_coredump_init();
     dn_set_default_options(&nci);
-    core_register_printf_function();
+    status = log_register_custom_specifier('M', print_obj, print_obj_arginfo);
+    if (status != DN_OK) {
+        log_stderr("Failed to register custom format specifier");
+        exit(1);
+    }
 
     status = dn_get_options(argc, argv, &nci);
     if (status != DN_OK) {


### PR DESCRIPTION
Every object has a magic number in the beginning which is used during
printing to detect any pointer corruptions.
There is not need for the switch case of types. The value within the
range along with the magic number is a good enough check.
Move the printf registration from logs to types since its on an object
now.