### PR TITLE
Do not try to initialize crypto stuff if `secure_server_option` is

### DIFF
--- a/src/dyn_crypto.c
+++ b/src/dyn_crypto.c
@@ -159,6 +159,11 @@ aes_init(void)
 rstatus_t
 crypto_init(struct server_pool *sp)
 {
+    if (sp->secure_server_option == SECURE_OPTION_NONE) {
+        log_debug(LOG_NOTICE, "secure_server_option is none, skipping crypto_init()");
+        return DN_OK;
+    }
+
     //init AES
     THROW_STATUS(aes_init());
     //init RSA


### PR DESCRIPTION
`none`

Without this fix, you always have situation like this:

```
[2017-05-03 21:19:56.541] load_private_rsa_key_by_file:48 Error: file conf/dynomite.pem does not exist
[2017-05-03 21:19:56.541] load_private_rsa_key:123 failed load_private_rsa_key_by_file(&sp->pem_key_file)
[2017-05-03 21:19:56.541] crypto_init:170 failed load_private_rsa_key(sp)
[2017-05-03 21:19:56.541] core_crypto_init:183 failed crypto_init(&ctx->pool)
[2017-05-03 21:19:56.541] dn_run:626 failed core_start(nci)
[2017-05-03 21:19:56.541] dn_print_done:225 done, rabbit done
```