### PR TITLE
Multikey operation optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The ultimate goal with Dynomite is to be able to implement high availability and
 
 ## Workflow
 
-The stable version of Dynomite is the [master]( https://github.com/Netflix/dynomite/tree/master ) branch. 
+Every branch numbered like v0.5.9, v0.5.8 etc is stable and safe to use in production unless marked as pre-release. The [dev]( https://github.com/Netflix/dynomite/tree/dev ) branch is the development unstable branch. Over time master branch has fallen behind and is not maintained. We will eventually delete it and may or may not recreate it.
 
 For questions or contributions, please consider reading [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/src/dyn_array.c
+++ b/src/dyn_array.c
@@ -188,18 +188,17 @@ array_sort(struct array *a, array_compare_t compare)
  * success. On failure short-circuits and returns the error status.
  */
 rstatus_t
-array_each(struct array *a, array_each_t func, void *data)
+array_each(struct array *a, array_each_t func)
 {
     uint32_t i, nelem;
 
-    ASSERT(array_n(a) != 0);
     ASSERT(func != NULL);
 
     for (i = 0, nelem = array_n(a); i < nelem; i++) {
         void *elem = array_get(a, i);
         rstatus_t status;
 
-        status = func(elem, data);
+        status = func(elem);
         if (status != DN_OK) {
             return status;
         }

--- a/src/dyn_array.h
+++ b/src/dyn_array.h
@@ -28,7 +28,7 @@
 
 
 typedef int (*array_compare_t)(const void *, const void *);
-typedef rstatus_t (*array_each_t)(void *elem, void *data1);
+typedef rstatus_t (*array_each_t)(void *elem);
 typedef rstatus_t (*array_each_2_t)(void *elem, void *data1, void *data2);
 
 struct array {
@@ -64,6 +64,12 @@ array_n(const struct array *a)
     return a->nelem;
 }
 
+static inline void
+array_reset(struct array *a)
+{
+    a->nelem = 0;
+}
+
 struct array *array_create(uint32_t n, size_t size);
 void array_destroy(struct array *a);
 rstatus_t array_init(struct array *a, uint32_t n, size_t size);
@@ -76,7 +82,7 @@ void *array_get(struct array *a, uint32_t idx);
 void *array_top(struct array *a);
 void array_swap(struct array *a, struct array *b);
 void array_sort(struct array *a, array_compare_t compare);
-rstatus_t array_each(struct array *a, array_each_t func, void *data);
+rstatus_t array_each(struct array *a, array_each_t func);
 rstatus_t array_each_2(struct array *a, array_each_2_t func, void *data1, void *data2);
 
 #endif

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -403,8 +403,8 @@ void
 req_forward_error(struct context *ctx, struct conn *conn, struct msg *req,
                   err_t error_code, err_t dyn_error_code)
 {
-    log_info("%M FORWARD FAILEED %M len %"PRIu32": %s", conn, req, req->mlen,
-             strerror(error_code));
+    log_info("%M FORWARD FAILED %M len %"PRIu32": %d:%s", conn, req, req->mlen,
+             error_code, dn_strerror(error_code));
 
     // Nothing to do if request is not expecting a reply.
     // The higher layer will take care of freeing the request

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -850,9 +850,12 @@ req_forward(struct context *ctx, struct conn *c_conn, struct msg *req)
         stats_pool_incr(ctx, client_write_requests);
 
     uint32_t keylen = 0;
-    uint8_t *key = msg_get_key(req, &pool->hash_tag, &keylen);
+    uint8_t *key = msg_get_tagged_key(req, 0, &keylen);
+    uint32_t full_keylen = 0;
+    uint8_t *full_key = msg_get_full_key(req, 0, &full_keylen);
 
-    log_info(">>>>>>>>>>>>>>>>>>>>>>> %M RECEIVED %M key '%.*s'", c_conn, req, keylen, key);
+    log_info(">>>>>>>>>>>>>>>>>>>>>>> %M RECEIVED %M key '%.*s' tagged key '%.*s'",
+             c_conn, req, full_keylen, full_key, keylen, key);
     // add the message to the dict
     dictAdd(c_conn->outstanding_msgs_dict, &req->id, req);
 

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -292,7 +292,7 @@ dnode_req_forward(struct context *ctx, struct conn *conn, struct msg *req)
     dictAdd(conn->outstanding_msgs_dict, &req->id, req);
 
     uint32_t keylen = 0;
-    uint8_t *key = msg_get_key(req, &pool->hash_tag, &keylen);
+    uint8_t *key = msg_get_tagged_key(req, 0, &keylen);
 
     ASSERT(req->dmsg != NULL);
     /* enqueue message (request) into client outq, if response is expected

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -483,7 +483,7 @@ dnode_rsp_send_next(struct context *ctx, struct conn *conn)
 
         if (log_loggable(LOG_VVERB)) {
             log_hexdump(LOG_VVERB, header_buf->pos, mbuf_length(header_buf), "resp dyn message - header: ");
-            msg_dump(rsp);
+            msg_dump(LOG_VVERB, rsp);
         }
 
     }

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -410,7 +410,7 @@ dyn_parse_req(struct msg *r)
 {
 	if (log_loggable(LOG_VVERB)) {
 		log_debug(LOG_VVERB, ":::::::::::::::::::::: In dyn_parse_req, start to process request :::::::::::::::::::::: ");
-		msg_dump(r);
+		msg_dump(LOG_VVERB, r);
 	}
 
 	bool done_parsing = false;
@@ -501,7 +501,7 @@ dyn_parse_req(struct msg *r)
 	//bad case
 	if (log_loggable(LOG_VVERB)) {
 		log_debug(LOG_VVERB, "Bad or splitted message");  //fix me to do something
-		msg_dump(r);
+		msg_dump(LOG_VVERB, r);
 	}
 	r->result = MSG_PARSE_AGAIN;
 }
@@ -511,7 +511,7 @@ void dyn_parse_rsp(struct msg *r)
 {
 	if (log_loggable(LOG_VVERB)) {
 		log_debug(LOG_VVERB, ":::::::::::::::::::::: In dyn_parse_rsp, start to process response :::::::::::::::::::::::: ");
-		msg_dump(r);
+		msg_dump(LOG_VVERB, r);
 	}
 
 	bool done_parsing = false;
@@ -588,7 +588,7 @@ void dyn_parse_rsp(struct msg *r)
 	//bad case
 	if (log_loggable(LOG_DEBUG)) {
 		log_debug(LOG_DEBUG, "Resp: bad message - cannot parse");  //fix me to do something
-		msg_dump(r);
+		msg_dump(LOG_DEBUG, r);
 	}
 
 	r->result = MSG_PARSE_AGAIN;

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -279,6 +279,7 @@ dyn_parse_core(struct msg *r)
 
       case DYN_DONE:
          log_debug(LOG_VVERB, "DYN_DONE");
+         r->mlen -= (p - r->pos);
          r->pos = p;
          dmsg->payload = p;
          r->dyn_parse_state = DYN_DONE;

--- a/src/dyn_dnode_msg.h
+++ b/src/dyn_dnode_msg.h
@@ -81,8 +81,8 @@ struct dmsg {
 TAILQ_HEAD(dmsg_tqh, dmsg);
 
 
-void dyn_parse_req(struct msg *r);
-void dyn_parse_rsp(struct msg *r);
+void dyn_parse_req(struct msg *r, const struct string *hash_tag);
+void dyn_parse_rsp(struct msg *r, const struct string *UNUSED);
 
 void dmsg_free(struct dmsg *dmsg);
 void dmsg_put(struct dmsg *dmsg);
@@ -97,8 +97,5 @@ rstatus_t dmsg_write(struct mbuf *mbuf, uint64_t msg_id, uint8_t type,
 rstatus_t dmsg_write_mbuf(struct mbuf *mbuf, uint64_t msg_id, uint8_t type,
 		                  struct conn *conn, uint32_t plen);
 bool dmsg_process(struct context *ctx, struct conn *conn, struct dmsg *dmsg);
-
-void data_store_parse_req(struct msg *r);
-void data_store_parse_rsp(struct msg *r);
 
 #endif

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -1019,10 +1019,10 @@ dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn, struct msg 
 
     if (log_loggable(LOG_VVERB)) {
         loga("%M Dumping content:", rsp);
-        msg_dump(rsp);
+        msg_dump(LOG_VVERB, rsp);
 
         loga("%M Dumping content:", req);
-        msg_dump(req);
+        msg_dump(LOG_VVERB, req);
     }
 
     conn_dequeue_outq(ctx, peer_conn, req);
@@ -1124,7 +1124,7 @@ dnode_rsp_forward(struct context *ctx, struct conn *peer_conn, struct msg *rsp)
 
         if (log_loggable(LOG_VVERB)) {
             loga("skipping req:   ");
-            msg_dump(req);
+            msg_dump(LOG_VVERB, req);
         }
 
 
@@ -1169,11 +1169,11 @@ dnode_rsp_recv_done(struct context *ctx, struct conn *conn,
 
     if (log_loggable(LOG_VVERB)) {
        loga("Dumping content for rsp:   ");
-       msg_dump(rsp);
+       msg_dump(LOG_VVERB, rsp);
 
        if (nmsg != NULL) {
           loga("Dumping content for nmsg :");
-          msg_dump(nmsg);
+          msg_dump(LOG_VVERB, nmsg);
        }
     }
 

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -466,7 +466,7 @@ dnode_peer_close(struct context *ctx, struct conn *conn)
 }
 
 static rstatus_t
-dnode_peer_each_preconnect(void *elem, void *data)
+dnode_peer_each_preconnect(void *elem)
 {
     struct node *peer = elem;
 
@@ -477,7 +477,7 @@ dnode_peer_each_preconnect(void *elem, void *data)
 }
 
 static rstatus_t
-dnode_peer_each_disconnect(void *elem, void *data)
+dnode_peer_each_disconnect(void *elem)
 {
     struct node *peer = elem;
 
@@ -662,7 +662,7 @@ dnode_peer_add_node(struct server_pool *sp, struct gossip_node *node)
     if (status != DN_OK)
         return status;
 
-    status = dnode_peer_each_preconnect(s, NULL);
+    status = dnode_peer_each_preconnect(s);
 
     return status;
 }
@@ -726,7 +726,7 @@ dnode_peer_replace(void *rmsg)
         log_notice("Found an old node to replace '%.*s'", s->name.len, s->name.data);
         log_notice("Replace with address '%.*s'", node->name.len, node->name.data);
 
-        dnode_peer_each_disconnect(s, NULL);
+        dnode_peer_each_disconnect(s);
         string_deinit(&s->endpoint.pname);
         string_deinit(&s->name);
         string_copy(&s->endpoint.pname, node->pname.data, node->pname.len);
@@ -745,7 +745,7 @@ dnode_peer_replace(void *rmsg)
 
         dnode_create_connection_pool(sp, s);
 
-        dnode_peer_each_preconnect(s, NULL);
+        dnode_peer_each_preconnect(s);
     } else {
         log_debug(LOG_INFO, "Unable to find any node matched the token");
     }
@@ -909,7 +909,7 @@ dnode_peer_pool_preconnect(struct context *ctx)
         return DN_OK;
     }
 
-    status = array_each(&sp->peers, dnode_peer_each_preconnect, NULL);
+    status = array_each(&sp->peers, dnode_peer_each_preconnect);
     if (status != DN_OK) {
         return status;
     }
@@ -924,7 +924,7 @@ dnode_peer_pool_disconnect(struct context *ctx)
     rstatus_t status;
     struct server_pool *sp = &ctx->pool;
 
-    status = array_each(&sp->peers, dnode_peer_each_disconnect, NULL);
+    status = array_each(&sp->peers, dnode_peer_each_disconnect);
     IGNORE_RET_VAL(status);
 }
 

--- a/src/dyn_dnode_peer.h
+++ b/src/dyn_dnode_peer.h
@@ -23,6 +23,8 @@ struct node *dnode_peer_pool_server(struct context *ctx, struct server_pool *poo
 struct conn *dnode_peer_get_conn(struct context *ctx, struct node *server, int tag);
 rstatus_t dnode_peer_pool_preconnect(struct context *ctx);
 void dnode_peer_pool_disconnect(struct context *ctx);
+uint32_t dnode_peer_idx_for_key_on_rack(struct server_pool *pool, struct rack *rack,
+                                        uint8_t *key, uint32_t keylen);
 rstatus_t dnode_peer_forward_state(void *rmsg);
 rstatus_t dnode_peer_add(void *rmsg);
 rstatus_t dnode_peer_replace(void *rmsg);

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -127,7 +127,7 @@ dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
 
     if (log_loggable(LOG_VVERB)) {
         log_hexdump(LOG_VVERB, header_buf->pos, mbuf_length(header_buf), "dyn message header: ");
-        msg_dump(req);
+        msg_dump(LOG_VVERB, req);
     }
 
     conn_enqueue_inq(ctx, p_conn, req);
@@ -260,7 +260,7 @@ dnode_peer_gossip_forward(struct context *ctx, struct conn *conn, struct mbuf *d
 
     if (log_loggable(LOG_VVERB)) {
         log_hexdump(LOG_VVERB, header_buf->pos, mbuf_length(header_buf), "dyn gossip message header: ");
-        msg_dump(msg);
+        msg_dump(LOG_VVERB, msg);
     }
 
     /* enqueue the message (request) into peer inq */

--- a/src/dyn_mbuf.c
+++ b/src/dyn_mbuf.c
@@ -144,6 +144,18 @@ mbuf_free_queue_size(void)
 }
 
 
+void mbuf_dump_pos(struct mbuf *mbuf)
+{
+     long int len;
+     uint8_t *p, *q;
+
+     p = mbuf->pos;
+     q = mbuf->last;
+     len = q - p;
+
+     loga_hexdump(p, len, "mbuf with %ld bytes of data", len);
+}
+
 void mbuf_dump(struct mbuf *mbuf)
 {
      long int len;

--- a/src/dyn_mbuf.c
+++ b/src/dyn_mbuf.c
@@ -144,24 +144,12 @@ mbuf_free_queue_size(void)
 }
 
 
-void mbuf_dump_pos(struct mbuf *mbuf)
-{
-     long int len;
-     uint8_t *p, *q;
-
-     p = mbuf->pos;
-     q = mbuf->last;
-     len = q - p;
-
-     loga_hexdump(p, len, "mbuf with %ld bytes of data", len);
-}
-
 void mbuf_dump(struct mbuf *mbuf)
 {
-     long int len;
      uint8_t *p, *q;
+     long int len;
 
-     p = mbuf->start;
+     p = mbuf->pos;
      q = mbuf->last;
      len = q - p;
 

--- a/src/dyn_mbuf.h
+++ b/src/dyn_mbuf.h
@@ -68,6 +68,7 @@ struct mbuf *mbuf_get(void);
 void mbuf_put(struct mbuf *mbuf);
 uint64_t mbuf_alloc_get_count(void);
 uint64_t mbuf_free_queue_size(void);
+void mbuf_dump_pos(struct mbuf *mbuf);
 void mbuf_dump(struct mbuf *mbuf);
 void mbuf_rewind(struct mbuf *mbuf);
 uint32_t mbuf_length(struct mbuf *mbuf);

--- a/src/dyn_mbuf.h
+++ b/src/dyn_mbuf.h
@@ -68,7 +68,6 @@ struct mbuf *mbuf_get(void);
 void mbuf_put(struct mbuf *mbuf);
 uint64_t mbuf_alloc_get_count(void);
 uint64_t mbuf_free_queue_size(void);
-void mbuf_dump_pos(struct mbuf *mbuf);
 void mbuf_dump(struct mbuf *mbuf);
 void mbuf_rewind(struct mbuf *mbuf);
 uint32_t mbuf_length(struct mbuf *mbuf);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -153,6 +153,7 @@ func_mbuf_copy_t     g_pre_splitcopy;   /* message pre-split copy */
 func_msg_post_splitcopy_t g_post_splitcopy;  /* message post-split copy */
 func_msg_coalesce_t  g_pre_coalesce;    /* message pre-coalesce */
 func_msg_coalesce_t  g_post_coalesce;   /* message post-coalesce */
+func_msg_fragment_t  g_fragment;   /* message post-coalesce */
 
 #define DEFINE_ACTION(_name) string(#_name),
 static struct string msg_type_strings[] = {
@@ -167,8 +168,8 @@ print_req(FILE *stream, const struct object *obj)
     ASSERT(obj->type == OBJ_REQ);
     struct msg *req = (struct msg *)obj;
     struct string *req_type = msg_type_string(req->type);
-    return fprintf(stream, "<REQ %p %lu:%lu %.*s>", req, req->id, req->parent_id,
-                   req_type->len, req_type->data);
+    return fprintf(stream, "<REQ %p %lu:%lu::%lu %.*s>", req, req->id, req->parent_id,
+                   req->frag_id, req_type->len, req_type->data);
 }
 
 static int
@@ -176,7 +177,8 @@ print_rsp(FILE *stream, const struct object *obj)
 {
     ASSERT(obj->type == OBJ_RSP);
     struct msg *rsp = (struct msg *)obj;
-    return fprintf(stream, "<RSP %p %lu:%lu>", rsp, rsp->id, rsp->parent_id);
+    return fprintf(stream, "<RSP %p %lu:%lu len:%u>", rsp, rsp->id,
+                   rsp->parent_id, rsp->mlen);
 }
 
 void
@@ -184,16 +186,14 @@ set_datastore_ops(void)
 {
     switch(g_data_store) {
         case DATA_REDIS:
-            g_pre_splitcopy = redis_pre_splitcopy;
-            g_post_splitcopy = redis_post_splitcopy;
             g_pre_coalesce = redis_pre_coalesce;
             g_post_coalesce = redis_post_coalesce;
+            g_fragment = redis_fragment;
             break;
         case DATA_MEMCACHE:
-            g_pre_splitcopy = memcache_pre_splitcopy;
-            g_post_splitcopy = memcache_post_splitcopy;
             g_pre_coalesce = memcache_pre_coalesce;
             g_post_coalesce = memcache_post_coalesce;
+            g_fragment = memcache_fragment;
             break;
         default:
             return;
@@ -349,14 +349,19 @@ done:
 
     msg->type = MSG_UNKNOWN;
 
-    msg->key_start = NULL;
-    msg->key_end = NULL;
+    msg->keys = array_create(1, sizeof(struct keypos));
+    if (msg->keys == NULL) {
+        dn_free(msg);
+        return NULL;
+    }
 
     msg->vlen = 0;
     msg->end = NULL;
 
     msg->frag_owner = NULL;
+    msg->frag_seq = NULL;
     msg->nfrag = 0;
+    msg->nfrag_done = 0;
     msg->frag_id = 0;
 
     msg->narg_start = NULL;
@@ -374,8 +379,6 @@ done:
     msg->expect_datastore_reply = 1;
     msg->done = 0;
     msg->fdone = 0;
-    msg->first_fragment = 0;
-    msg->last_fragment = 0;
     msg->swallow = 0;
     msg->dnode_header_prepended = 0;
     msg->rsp_sent = 0;
@@ -466,8 +469,6 @@ msg_clone(struct msg *src, struct mbuf *mbuf_start, struct msg *target)
     target->expect_datastore_reply = src->expect_datastore_reply;
     target->swallow = src->swallow;
     target->type = src->type;
-    target->key_start = src->key_start;
-    target->key_end = src->key_end;
     target->mlen = src->mlen;
     target->pos = src->pos;
     target->vlen = src->vlen;
@@ -606,6 +607,17 @@ msg_put(struct msg *msg)
         mbuf_put(mbuf);
     }
 
+    if (msg->frag_seq) {
+        dn_free(msg->frag_seq);
+        msg->frag_seq = NULL;
+    }
+
+    if (msg->keys) {
+        msg->keys->nelem = 0;
+        array_destroy(msg->keys);
+        msg->keys = NULL;
+    }
+
     TAILQ_INSERT_HEAD(&free_msgq, msg, m_tqe);
 }
 
@@ -654,7 +666,7 @@ msg_dump(struct msg *msg)
         uint8_t *p, *q;
         long int len;
 
-        p = mbuf->start;
+        p = mbuf->pos;
         q = mbuf->last;
         len = q - p;
 
@@ -709,7 +721,12 @@ msg_get_key(struct msg *req, const struct string *hash_tag, uint32_t *keylen)
 {
     uint8_t *key = NULL;
     *keylen = 0;
-    if (!string_empty(hash_tag)) {
+    if (array_n(req->keys) == 0)
+            return NULL;
+    struct keypos *kpos = array_get(req->keys, 0);
+    *keylen = (uint32_t)(kpos->end - kpos->start);
+    key = kpos->start;
+    /* if (!string_empty(hash_tag)) {
         uint8_t *tag_start, *tag_end;
 
         tag_start = dn_strchr(req->key_start, req->key_end, hash_tag->data[0]);
@@ -725,7 +742,7 @@ msg_get_key(struct msg *req, const struct string *hash_tag, uint32_t *keylen)
     if (*keylen == 0) {
         key = req->key_start;
         *keylen = (uint32_t)(req->key_end - req->key_start);
-    }
+    }*/
     return key;
 }
 
@@ -761,6 +778,12 @@ msg_payload_crc32(struct msg *rsp)
     }
     return crc;
 
+}
+
+inline uint64_t
+msg_gen_frag_id(void)
+{
+    return ++frag_id;
 }
 
 static rstatus_t
@@ -807,108 +830,6 @@ msg_parsed(struct context *ctx, struct conn *conn, struct msg *msg)
 }
 
 static rstatus_t
-msg_fragment(struct context *ctx, struct conn *conn, struct msg *msg)
-{
-    rstatus_t status;  /* return status */
-    struct msg *nmsg;  /* new message */
-    struct mbuf *nbuf; /* new mbuf */
-
-    ASSERT((conn->type == CONN_CLIENT) ||
-           (conn->type == CONN_DNODE_PEER_CLIENT));
-    ASSERT(msg->is_request);
-
-    nbuf = mbuf_split(&msg->mhdr, msg->pos, g_pre_splitcopy, msg);
-    if (nbuf == NULL) {
-        return DN_ENOMEM;
-    }
-
-    status = g_post_splitcopy(msg);
-    if (status != DN_OK) {
-        mbuf_put(nbuf);
-        return status;
-    }
-
-    nmsg = msg_get(msg->owner, msg->is_request, __FUNCTION__);
-    if (nmsg == NULL) {
-        mbuf_put(nbuf);
-        return DN_ENOMEM;
-    }
-    mbuf_insert(&nmsg->mhdr, nbuf);
-    nmsg->pos = nbuf->pos;
-
-    /* update length of current (msg) and new message (nmsg) */
-    nmsg->mlen = mbuf_length(nbuf);
-    msg->mlen -= nmsg->mlen;
-
-    /*
-     * Attach unique fragment id to all fragments of the message vector. All
-     * fragments of the message, including the first fragment point to the
-     * first fragment through the frag_owner pointer. The first_fragment and
-     * last_fragment identify first and last fragment respectively.
-     *
-     * For example, a message vector given below is split into 3 fragments:
-     *  'mget key1 key2 key3\r\n'
-     *  Or,
-     *  '*4\r\n$4\r\nmget\r\n$4\r\nkey1\r\n$4\r\nkey2\r\n$4\r\nkey3\r\n'
-     *
-     *   +--------------+
-     *   |  msg vector  |
-     *   |(original msg)|
-     *   +--------------+
-     *
-     *       frag_owner         frag_owner
-     *     /-----------+      /------------+
-     *     |           |      |            |
-     *     |           v      v            |
-     *   +--------------------+     +---------------------+
-     *   |   frag_id = 10     |     |   frag_id = 10      |
-     *   | first_fragment = 1 |     |  first_fragment = 0 |
-     *   | last_fragment = 0  |     |  last_fragment = 0  |
-     *   |     nfrag = 3      |     |      nfrag = 0      |
-     *   +--------------------+     +---------------------+
-     *               ^
-     *               |  frag_owner
-     *               \-------------+
-     *                             |
-     *                             |
-     *                  +---------------------+
-     *                  |   frag_id = 10      |
-     *                  |  first_fragment = 0 |
-     *                  |  last_fragment = 1  |
-     *                  |      nfrag = 0      |
-     *                  +---------------------+
-     *
-     *
-     */
-    if (msg->frag_id == 0) {
-        msg->frag_id = ++frag_id;
-        msg->first_fragment = 1;
-        msg->nfrag = 1;
-        msg->frag_owner = msg;
-    }
-    nmsg->frag_id = msg->frag_id;
-    msg->last_fragment = 0;
-    nmsg->last_fragment = 1;
-    nmsg->frag_owner = msg->frag_owner;
-    msg->frag_owner->nfrag++;
-
-    if (!conn->dyn_mode) {
-       stats_pool_incr(ctx, fragments);
-    } else {
-        
-    }
-
-    if (log_loggable(LOG_VERB)) {
-       log_debug(LOG_VERB, "fragment msg into %"PRIu64" and %"PRIu64" frag id "
-              "%"PRIu64"", msg->id, nmsg->id, msg->frag_id);
-    }
-
-    conn_recv_done(ctx, conn, msg, nmsg);
-
-    return DN_OK;
-}
-
-static rstatus_t
 msg_repair(struct context *ctx, struct conn *conn, struct msg *msg)
 {
     struct mbuf *nbuf;
@@ -941,11 +862,6 @@ msg_parse(struct context *ctx, struct conn *conn, struct msg *msg)
     case MSG_PARSE_OK:
         //log_debug(LOG_VVERB, "MSG_PARSE_OK");
         status = msg_parsed(ctx, conn, msg);
-        break;
-
-    case MSG_PARSE_FRAGMENT:
-        //log_debug(LOG_VVERB, "MSG_PARSE_FRAGMENT");
-        status = msg_fragment(ctx, conn, msg);
         break;
 
     case MSG_PARSE_REPAIR:

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -154,6 +154,7 @@ func_msg_coalesce_t  g_pre_coalesce;    /* message pre-coalesce */
 func_msg_coalesce_t  g_post_coalesce;   /* message post-coalesce */
 func_msg_fragment_t  g_fragment;   /* message post-coalesce */
 func_is_multikey_request g_is_multikey_request;
+func_reconcile_responses g_reconcile_responses;
 
 #define DEFINE_ACTION(_name) string(#_name),
 static struct string msg_type_strings[] = {
@@ -190,12 +191,14 @@ set_datastore_ops(void)
             g_post_coalesce = redis_post_coalesce;
             g_fragment = redis_fragment;
             g_is_multikey_request =  redis_is_multikey_request;
+            g_reconcile_responses = redis_reconcile_responses;
             break;
         case DATA_MEMCACHE:
             g_pre_coalesce = memcache_pre_coalesce;
             g_post_coalesce = memcache_post_coalesce;
             g_fragment = memcache_fragment;
             g_is_multikey_request =  memcache_is_multikey_request;
+            g_reconcile_responses = memcache_reconcile_responses;
             break;
         default:
             return;

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -663,14 +663,7 @@ msg_dump(struct msg *msg)
          msg->done, msg->is_error, msg->error_code);
 
     STAILQ_FOREACH(mbuf, &msg->mhdr, next) {
-        uint8_t *p, *q;
-        long int len;
-
-        p = mbuf->pos;
-        q = mbuf->last;
-        len = q - p;
-
-        loga_hexdump(p, len, "mbuf with %ld bytes of data", len);
+        mbuf_dump(mbuf);
     }
 
 }

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -490,7 +490,7 @@ msg_clone(struct msg *src, struct mbuf *mbuf_start, struct msg *target)
         }
         nbuf = mbuf_get();
         if (nbuf == NULL) {
-            return ENOMEM;
+            return DN_ENOMEM;
         }
 
         uint32_t len = mbuf_length(mbuf);
@@ -670,6 +670,7 @@ msg_dump(struct msg *msg)
     STAILQ_FOREACH(mbuf, &msg->mhdr, next) {
         mbuf_dump(mbuf);
     }
+    loga("=================================================");
 
 }
 

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -149,11 +149,11 @@ static struct rbtree tmo_rbt;    /* timeout rbtree */
 static struct rbnode tmo_rbs;    /* timeout rbtree sentinel */
 static size_t alloc_msgs_max;	 /* maximum number of allowed allocated messages */
 uint8_t g_timeout_factor = 1;
-func_mbuf_copy_t     g_pre_splitcopy;   /* message pre-split copy */
-func_msg_post_splitcopy_t g_post_splitcopy;  /* message post-split copy */
+
 func_msg_coalesce_t  g_pre_coalesce;    /* message pre-coalesce */
 func_msg_coalesce_t  g_post_coalesce;   /* message post-coalesce */
 func_msg_fragment_t  g_fragment;   /* message post-coalesce */
+func_is_multikey_request g_is_multikey_request;
 
 #define DEFINE_ACTION(_name) string(#_name),
 static struct string msg_type_strings[] = {
@@ -189,11 +189,13 @@ set_datastore_ops(void)
             g_pre_coalesce = redis_pre_coalesce;
             g_post_coalesce = redis_post_coalesce;
             g_fragment = redis_fragment;
+            g_is_multikey_request =  redis_is_multikey_request;
             break;
         case DATA_MEMCACHE:
             g_pre_coalesce = memcache_pre_coalesce;
             g_post_coalesce = memcache_post_coalesce;
             g_fragment = memcache_fragment;
+            g_is_multikey_request =  memcache_is_multikey_request;
             break;
         default:
             return;

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -508,7 +508,7 @@ msg_get_error(struct conn *conn, dyn_error_t dyn_err, err_t err)
     struct msg *rsp;
     struct mbuf *mbuf;
     int n;
-    char *errstr = err ? dn_strerror(err) : "unknown";
+    char *errstr = dyn_err ? dn_strerror(dyn_err) : "unknown";
     char *protstr = g_data_store == DATA_REDIS ? "-ERR" : "SERVER_ERROR";
     char *source = dyn_error_source(dyn_err);
 
@@ -653,9 +653,12 @@ uint32_t msg_length(struct msg *msg)
 }
 
 void
-msg_dump(struct msg *msg)
+msg_dump(int level, struct msg *msg)
 {
 
+    if (!log_loggable(level)) {
+        return;
+    }
     struct mbuf *mbuf;
 
     if (msg == NULL) {
@@ -1051,7 +1054,7 @@ msg_send_chain(struct context *ctx, struct conn *conn, struct msg *msg)
 
     if (log_loggable(LOG_VVERB)) {
        loga("About to dump out the content of msg");
-       msg_dump(msg);
+       msg_dump(LOG_VVERB, msg);
     }
 
     TAILQ_INIT(&send_msgq);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -178,8 +178,9 @@ print_rsp(FILE *stream, const struct object *obj)
 {
     ASSERT(obj->type == OBJ_RSP);
     struct msg *rsp = (struct msg *)obj;
-    return fprintf(stream, "<RSP %p %lu:%lu len:%u>", rsp, rsp->id,
-                   rsp->parent_id, rsp->mlen);
+    struct string *rsp_type = msg_type_string(rsp->type);
+    return fprintf(stream, "<RSP %p %lu:%lu %.*s len:%u>", rsp, rsp->id,
+                   rsp->parent_id, rsp_type->len, rsp_type->data, rsp->mlen);
 }
 
 void

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -39,15 +39,17 @@ typedef rstatus_t (*func_msg_fragment_t)(struct msg *, struct server_pool *,
                                          struct rack *, struct msg_tqh *);
 typedef void (*func_msg_coalesce_t)(struct msg *r);
 typedef rstatus_t (*msg_response_handler_t)(struct msg *req, struct msg *rsp);
-typedef rstatus_t (*func_msg_reply_t)(struct msg *r);
 typedef bool (*func_msg_failure_t)(struct msg *r);
 typedef bool (*func_is_multikey_request)(struct msg *r);
-void set_datastore_ops(void);
+typedef struct msg *(*func_reconcile_responses)(struct response_mgr *rspmgr);
+
 extern func_msg_coalesce_t  g_pre_coalesce;    /* message pre-coalesce */
 extern func_msg_coalesce_t  g_post_coalesce;   /* message post-coalesce */
 extern func_msg_fragment_t  g_fragment;   /* message fragment */
 extern func_is_multikey_request g_is_multikey_request;
+extern func_reconcile_responses g_reconcile_responses;
 
+void set_datastore_ops(void);
 
 typedef enum msg_parse_result {
     MSG_PARSE_OK,                         /* parsing ok */

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -444,7 +444,7 @@ void msg_put(struct msg *msg);
 uint32_t msg_mbuf_size(struct msg *msg);
 uint32_t msg_length(struct msg *msg);
 struct msg *msg_get_error(struct conn *conn, dyn_error_t dyn_err, err_t err);
-void msg_dump(struct msg *msg);
+void msg_dump(int level, struct msg *msg);
 bool msg_empty(struct msg *msg);
 rstatus_t msg_recv(struct context *ctx, struct conn *conn);
 rstatus_t msg_send(struct context *ctx, struct conn *conn);

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -249,6 +249,8 @@ dn_strerror(dyn_error_t err)
             return "Invalid request in Dynomite's admin mode";
         case DYNOMITE_NO_QUORUM_ACHIEVED:
             return "Failed to achieve Quorum";
+        case PEER_CONNECTION_REFUSE:
+            return "Peer Node refused connection";
         case PEER_HOST_DOWN:
             return "Peer Node is down";
         case PEER_HOST_NOT_CONNECTED:

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -34,7 +34,7 @@
 
 #define MAX_ALLOWABLE_PROCESSED_MSGS  500
 
-typedef void (*func_msg_parse_t)(struct msg *);
+typedef void (*func_msg_parse_t)(struct msg *, const struct string *hash_tag);
 typedef rstatus_t (*func_msg_fragment_t)(struct msg *, struct server_pool *,
                                          struct rack *, struct msg_tqh *);
 typedef void (*func_msg_coalesce_t)(struct msg *r);
@@ -327,6 +327,8 @@ get_msg_routing_string(msg_routing_t route)
 struct keypos {
     uint8_t              *start;          /* key start pos */
     uint8_t              *end;            /* key end pos */
+    uint8_t              *tag_start;      /* hashtagged key start pos */
+    uint8_t              *tag_end;        /* hashtagged key end pos */
 };
 
 struct msg {
@@ -457,7 +459,8 @@ rstatus_t msg_append(struct msg *msg, uint8_t *pos, size_t n);
 rstatus_t msg_prepend(struct msg *msg, uint8_t *pos, size_t n);
 rstatus_t msg_prepend_format(struct msg *msg, const char *fmt, ...);
 
-uint8_t *msg_get_key(struct msg *req, const struct string *hash_tag, uint32_t *keylen);
+uint8_t *msg_get_tagged_key(struct msg *req, uint32_t key_index, uint32_t *keylen);
+uint8_t *msg_get_full_key(struct msg *req, uint32_t key_index, uint32_t *keylen);
 
 struct msg *req_get(struct conn *conn);
 void req_put(struct msg *msg);

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -37,17 +37,16 @@
 typedef void (*func_msg_parse_t)(struct msg *);
 typedef rstatus_t (*func_msg_fragment_t)(struct msg *, struct server_pool *,
                                          struct rack *, struct msg_tqh *);
-typedef rstatus_t (*func_msg_post_splitcopy_t)(struct msg *);
 typedef void (*func_msg_coalesce_t)(struct msg *r);
 typedef rstatus_t (*msg_response_handler_t)(struct msg *req, struct msg *rsp);
 typedef rstatus_t (*func_msg_reply_t)(struct msg *r);
 typedef bool (*func_msg_failure_t)(struct msg *r);
+typedef bool (*func_is_multikey_request)(struct msg *r);
 void set_datastore_ops(void);
-extern func_mbuf_copy_t     g_pre_splitcopy;   /* message pre-split copy */
-extern func_msg_post_splitcopy_t g_post_splitcopy;  /* message post-split copy */
 extern func_msg_coalesce_t  g_pre_coalesce;    /* message pre-coalesce */
 extern func_msg_coalesce_t  g_post_coalesce;   /* message post-coalesce */
 extern func_msg_fragment_t  g_fragment;   /* message fragment */
+extern func_is_multikey_request g_is_multikey_request;
 
 
 typedef enum msg_parse_result {

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -70,7 +70,7 @@ req_put(struct msg *req)
 bool
 req_done(struct conn *conn, struct msg *req)
 {
-    struct msg *cmsg, *pmsg; /* current and previous message */
+    struct msg *cmsg; /* current and previous message */
     uint64_t id;             /* fragment id */
     uint32_t nfragment;      /* # fragment */
 
@@ -99,19 +99,18 @@ req_done(struct conn *conn, struct msg *req)
     if (frag_owner->nfrag_done < frag_owner->nfrag)
         return false;
 
-    /* check all fragments of the given request vector are done */
-    // when we reach here req is always the fragment owner.
-    for (pmsg = req, cmsg = TAILQ_PREV(req, msg_tqh, c_tqe);
+    // check all fragments of the given request vector are done.
+    for (cmsg = TAILQ_PREV(req, msg_tqh, c_tqe);
          cmsg != NULL && cmsg->frag_id == id;
-         pmsg = cmsg, cmsg = TAILQ_PREV(cmsg, msg_tqh, c_tqe)) {
+         cmsg = TAILQ_PREV(cmsg, msg_tqh, c_tqe)) {
 
         if (!cmsg->selected_rsp)
             return false;
     }
 
-    for (pmsg = req, cmsg = TAILQ_NEXT(req, c_tqe);
+    for (cmsg = TAILQ_NEXT(req, c_tqe);
          cmsg != NULL && cmsg->frag_id == id;
-         pmsg = cmsg, cmsg = TAILQ_NEXT(cmsg, c_tqe)) {
+         cmsg = TAILQ_NEXT(cmsg, c_tqe)) {
 
         if (!cmsg->selected_rsp)
             return false;
@@ -128,16 +127,16 @@ req_done(struct conn *conn, struct msg *req)
     req->fdone = 1;
     nfragment = 0;
 
-    for (pmsg = req, cmsg = TAILQ_PREV(req, msg_tqh, c_tqe);
+    for (cmsg = TAILQ_PREV(req, msg_tqh, c_tqe);
          cmsg != NULL && cmsg->frag_id == id;
-         pmsg = cmsg, cmsg = TAILQ_PREV(cmsg, msg_tqh, c_tqe)) {
+         cmsg = TAILQ_PREV(cmsg, msg_tqh, c_tqe)) {
         cmsg->fdone = 1;
         nfragment++;
     }
 
-    for (pmsg = req, cmsg = TAILQ_NEXT(req, c_tqe);
+    for (cmsg = TAILQ_NEXT(req, c_tqe);
          cmsg != NULL && cmsg->frag_id == id;
-         pmsg = cmsg, cmsg = TAILQ_NEXT(cmsg, c_tqe)) {
+         cmsg = TAILQ_NEXT(cmsg, c_tqe)) {
         cmsg->fdone = 1;
         nfragment++;
     }

--- a/src/dyn_request.c
+++ b/src/dyn_request.c
@@ -95,7 +95,8 @@ req_done(struct conn *conn, struct msg *req)
         return true;
     }
 
-    if (req->nfrag_done < req->nfrag)
+    struct msg *frag_owner = req->frag_owner;
+    if (frag_owner->nfrag_done < frag_owner->nfrag)
         return false;
 
     /* check all fragments of the given request vector are done */

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -29,7 +29,8 @@ rsp_get(struct conn *conn)
     struct msg *rsp;
 
     ASSERT((conn->type == CONN_DNODE_PEER_SERVER) ||
-           (conn->type == CONN_SERVER));
+           (conn->type == CONN_SERVER) ||
+           (conn->type == CONN_CLIENT));
 
     rsp = msg_get(conn, false, __FUNCTION__);
     if (rsp == NULL) {

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -103,7 +103,7 @@ rspmgr_get_response(struct response_mgr *rspmgr)
                   rspmgr->msg->id, rspmgr->err_rsp, rspmgr->good_responses,
                   rspmgr->quorum_responses);
         if (log_loggable(LOG_INFO))
-            msg_dump(rspmgr->err_rsp);
+            msg_dump(LOG_INFO, rspmgr->err_rsp);
         return rspmgr->err_rsp;
     }
 
@@ -122,16 +122,16 @@ rspmgr_get_response(struct response_mgr *rspmgr)
     rspmgr_incr_non_quorum_responses_stats(rspmgr);
     if (log_loggable(LOG_DEBUG)) {
         log_error("Request: ");
-        msg_dump(rspmgr->msg);
+        msg_dump(LOG_DEBUG, rspmgr->msg);
     }
     if (log_loggable(LOG_VVERB)) {
         log_error("Respone 0: ");
-        msg_dump(rspmgr->responses[0]);
+        msg_dump(LOG_VVERB, rspmgr->responses[0]);
         log_error("Respone 1: ");
-        msg_dump(rspmgr->responses[1]);
+        msg_dump(LOG_VVERB, rspmgr->responses[1]);
         if (rspmgr->good_responses == 3) {
             log_error("Respone 2: ");
-            msg_dump(rspmgr->responses[2]);
+            msg_dump(LOG_VVERB, rspmgr->responses[2]);
         }
     }
     return g_reconcile_responses(rspmgr);

--- a/src/dyn_response_mgr.h
+++ b/src/dyn_response_mgr.h
@@ -27,6 +27,6 @@ struct msg* rspmgr_get_response(struct response_mgr *rspmgr);
 void rspmgr_free_response(struct response_mgr *rspmgr, struct msg *dont_free);
 void rspmgr_free_other_responses(struct response_mgr *rspmgr, struct msg *dont_free);
 rstatus_t msg_local_one_rsp_handler(struct msg *req, struct msg *rsp);
-
+rstatus_t rspmgr_clone_responses(struct response_mgr *src, struct array *responses);
 
 #endif

--- a/src/dyn_response_mgr.h
+++ b/src/dyn_response_mgr.h
@@ -15,7 +15,7 @@ struct response_mgr {
     uint8_t     error_responses;    // error responses received
     struct msg  *err_rsp;           // first error response
     struct conn *conn;
-    struct msg *msg;
+    struct msg *msg;                // corresponding request
 };
 
 void init_response_mgr(struct response_mgr *rspmgr, struct msg*, bool is_read,

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -578,7 +578,7 @@ dc_init(struct datacenter *dc)
 }
 
 static rstatus_t
-rack_destroy(void *elem, void *data)
+rack_destroy(void *elem)
 {
 	struct rack *rack = elem;
 	return rack_deinit(rack);
@@ -587,7 +587,7 @@ rack_destroy(void *elem, void *data)
 static rstatus_t
 dc_deinit(struct datacenter *dc)
 {
-	array_each(&dc->racks, rack_destroy, NULL);
+	array_each(&dc->racks, rack_destroy);
 	string_deinit(dc->name);
 	//dictRelease(dc->dict_rack);
 	return DN_OK;

--- a/src/dyn_server.h
+++ b/src/dyn_server.h
@@ -24,7 +24,6 @@
 #define _DYN_SERVER_H_
 
 #include "dyn_core.h"
-#include "dyn_token.h"
 #include "dyn_dict.h"
 
 /*

--- a/src/dyn_test.c
+++ b/src/dyn_test.c
@@ -287,9 +287,11 @@ test_msg_recv_chain(struct conn *conn, struct msg *msg)
 
 
     bool is_done = false;
+    struct string hash_tag;
+    string_init(&hash_tag);
 
     for(;!is_done;) {
-        msg->parser(msg);
+        msg->parser(msg, &hash_tag);
 
         switch (msg->result) {
         case MSG_PARSE_OK:

--- a/src/dyn_types.c
+++ b/src/dyn_types.c
@@ -36,10 +36,10 @@ print_obj(FILE *stream, const struct printf_info *info, const void *const *args)
         return fprintf(stream, "<NULL>");
     }
     if (obj->magic != OBJECT_MAGIC) {
-        return fprintf(stream, "<CORRUPTION> MAGIC NUMBER 0x%x", obj->magic);
+        return fprintf(stream, "addr:%p <CORRUPTION> MAGIC NUMBER 0x%x", obj, obj->magic);
     }
     if ((obj->type >= 0) && (obj->type < OBJ_LAST))
        return obj->func_print(stream, obj);
     else
-        return fprintf(stream, "<CORRUPTION> INVALID TYPE %d", obj->type);
+        return fprintf(stream, "addr:%p <CORRUPTION> INVALID TYPE %d", obj, obj->type);
 }

--- a/src/dyn_vnode.c
+++ b/src/dyn_vnode.c
@@ -38,7 +38,7 @@ vnode_item_cmp(const void *t1, const void *t2)
 }
 
 static rstatus_t
-vnode_rack_verify_continuum(void *elem, void *data)
+vnode_rack_verify_continuum(void *elem)
 {
     struct rack *rack = elem;
     qsort(rack->continuum, rack->ncontinuum, sizeof(*rack->continuum),
@@ -110,7 +110,7 @@ vnode_update(struct server_pool *sp)
         }
 
         if (array_n(&dc->racks) != 0) {
-             rstatus_t status = array_each(&dc->racks, vnode_rack_verify_continuum, NULL);
+             rstatus_t status = array_each(&dc->racks, vnode_rack_verify_continuum);
              if (status != DN_OK) {
                   return status;
              }

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1580,3 +1580,29 @@ memcache_is_multikey_request(struct msg *r)
 {
     return false;
 }
+
+struct msg *
+memcache_reconcile_responses(struct response_mgr *rspmgr)
+{
+    if (rspmgr->msg->consistency == DC_QUORUM) {
+        log_info("none of the responses match, returning first");
+        return rspmgr->responses[0];
+    } else {
+        log_info("none of the responses match, returning error");
+        struct msg *rsp = msg_get(rspmgr->conn, false, __FUNCTION__);
+        rsp->is_error = 1;
+        rsp->error_code = DYNOMITE_NO_QUORUM_ACHIEVED;
+        rsp->dyn_error_code = DYNOMITE_NO_QUORUM_ACHIEVED;
+        // There is a case that when 1 out of three nodes are down, the
+        // response manager has 1 error response and 2 good responses.
+        // We reach here when the two responses differ and we want to return
+        // failed to achieve quorum. In this case, free the existing error
+        // response
+        if (rspmgr->err_rsp) {
+            rsp_put(rspmgr->err_rsp);
+        }
+        rspmgr->err_rsp = rsp;
+        rspmgr->error_responses++;
+        return rsp;
+    }
+}

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -142,7 +142,7 @@ memcache_touch(struct msg *r)
 }
 
 void
-memcache_parse_req(struct msg *r)
+memcache_parse_req(struct msg *r, const struct string *hash_tag)
 {
     struct mbuf *b;
     uint8_t *p, *m;
@@ -377,6 +377,21 @@ memcache_parse_req(struct msg *r)
                 if (kpos == NULL) {
                     goto enomem;
                 }
+                kpos->start = kpos->tag_start = r->token;
+                kpos->end = kpos->tag_end = p;
+                if (!string_empty(hash_tag)) {
+                    uint8_t *tag_start, *tag_end;
+
+                    tag_start = dn_strchr(kpos->start, kpos->end, hash_tag->data[0]);
+                    if (tag_start != NULL) {
+                        tag_end = dn_strchr(tag_start + 1, kpos->end, hash_tag->data[1]);
+                        if (tag_end != NULL) {
+                            kpos->tag_start = tag_start + 1;
+                            kpos->tag_end = tag_end;
+                        }
+                    }
+                }
+
                 kpos->start = r->token;
                 kpos->end = p;
 
@@ -766,7 +781,7 @@ error:
 }
 
 void
-memcache_parse_rsp(struct msg *r)
+memcache_parse_rsp(struct msg *r, const struct string *UNUSED)
 {
     struct mbuf *b;
     uint8_t *p, *m;

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1575,3 +1575,8 @@ memcache_reply(struct msg *r)
     return DN_OK;
 }
 
+bool
+memcache_is_multikey_request(struct msg *r)
+{
+    return false;
+}

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -33,17 +33,16 @@ void memcache_parse_req(struct msg *r);
 void memcache_parse_rsp(struct msg *r);
 void memcache_pre_coalesce(struct msg *r);
 void memcache_post_coalesce(struct msg *r);
+bool memcache_is_multikey_request(struct msg *r);
 rstatus_t memcache_fragment(struct msg *r, struct server_pool *pool, struct rack *rack,
                          struct msg_tqh *frag_msgq);
 
 void redis_parse_req(struct msg *r);
 void redis_parse_rsp(struct msg *r);
-bool redis_failure(struct msg *r);
-rstatus_t redis_reply(struct msg *r);
 void redis_pre_coalesce(struct msg *r);
 void redis_post_coalesce(struct msg *r);
+bool redis_is_multikey_request(struct msg *r);
 rstatus_t redis_fragment(struct msg *r, struct server_pool *pool, struct rack *rack,
                          struct msg_tqh *frag_msgq);
-void redis_swallow_msg(struct conn *conn, struct msg *pmsg, struct msg *msg);
 
 #endif

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -29,8 +29,8 @@
 
 
 
-void memcache_parse_req(struct msg *r);
-void memcache_parse_rsp(struct msg *r);
+void memcache_parse_req(struct msg *r, const struct string *hash_tag);
+void memcache_parse_rsp(struct msg *r, const struct string *UNUSED);
 void memcache_pre_coalesce(struct msg *r);
 void memcache_post_coalesce(struct msg *r);
 bool memcache_is_multikey_request(struct msg *r);
@@ -38,8 +38,8 @@ struct msg *memcache_reconcile_responses(struct response_mgr *rspmgr);
 rstatus_t memcache_fragment(struct msg *r, struct server_pool *pool, struct rack *rack,
                          struct msg_tqh *frag_msgq);
 
-void redis_parse_req(struct msg *r);
-void redis_parse_rsp(struct msg *r);
+void redis_parse_req(struct msg *r, const struct string *hash_tag);
+void redis_parse_rsp(struct msg *r, const struct string *UNUSED);
 void redis_pre_coalesce(struct msg *r);
 void redis_post_coalesce(struct msg *r);
 bool redis_is_multikey_request(struct msg *r);

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -34,6 +34,7 @@ void memcache_parse_rsp(struct msg *r);
 void memcache_pre_coalesce(struct msg *r);
 void memcache_post_coalesce(struct msg *r);
 bool memcache_is_multikey_request(struct msg *r);
+struct msg *memcache_reconcile_responses(struct response_mgr *rspmgr);
 rstatus_t memcache_fragment(struct msg *r, struct server_pool *pool, struct rack *rack,
                          struct msg_tqh *frag_msgq);
 
@@ -42,6 +43,7 @@ void redis_parse_rsp(struct msg *r);
 void redis_pre_coalesce(struct msg *r);
 void redis_post_coalesce(struct msg *r);
 bool redis_is_multikey_request(struct msg *r);
+struct msg *redis_reconcile_responses(struct response_mgr *rspmgr);
 rstatus_t redis_fragment(struct msg *r, struct server_pool *pool, struct rack *rack,
                          struct msg_tqh *frag_msgq);
 

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -31,19 +31,19 @@
 
 void memcache_parse_req(struct msg *r);
 void memcache_parse_rsp(struct msg *r);
-void memcache_pre_splitcopy(struct mbuf *mbuf, void *arg);
-rstatus_t memcache_post_splitcopy(struct msg *r);
 void memcache_pre_coalesce(struct msg *r);
 void memcache_post_coalesce(struct msg *r);
+rstatus_t memcache_fragment(struct msg *r, struct server_pool *pool, struct rack *rack,
+                         struct msg_tqh *frag_msgq);
 
 void redis_parse_req(struct msg *r);
 void redis_parse_rsp(struct msg *r);
 bool redis_failure(struct msg *r);
-void redis_pre_splitcopy(struct mbuf *mbuf, void *arg);
-rstatus_t redis_post_splitcopy(struct msg *r);
 rstatus_t redis_reply(struct msg *r);
 void redis_pre_coalesce(struct msg *r);
 void redis_post_coalesce(struct msg *r);
+rstatus_t redis_fragment(struct msg *r, struct server_pool *pool, struct rack *rack,
+                         struct msg_tqh *frag_msgq);
 void redis_swallow_msg(struct conn *conn, struct msg *pmsg, struct msg *msg);
 
 #endif

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -2448,7 +2448,7 @@ redis_copy_bulk(struct msg *dst, struct msg *src, bool log)
     for (; mbuf;) {
         if (log) {
             log_notice("dumping mbuf");
-            mbuf_dump_pos(mbuf);
+            mbuf_dump(mbuf);
         }
         if (mbuf_length(mbuf) <= len) {     /* steal this buf from src to dst */
             nbuf = STAILQ_NEXT(mbuf, next);

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -2978,4 +2978,16 @@ redis_fragment(struct msg *r, struct server_pool *pool, struct rack *rack, struc
     }
 }
 
-
+bool
+redis_is_multikey_request(struct msg *req)
+{
+    ASSERT(req->is_request);
+    switch (req->type) {
+    case MSG_REQ_REDIS_MGET:
+    case MSG_REQ_REDIS_DEL:
+    case MSG_REQ_REDIS_MSET:
+        return true;
+    default:
+        return false;
+    }
+}

--- a/travis.sh
+++ b/travis.sh
@@ -10,10 +10,12 @@ fi
 
 # parse options
 rebuild=true
+debug=false
 while [ "$#" -gt 0 ]; do
     arg=$1
     case $1 in
         -n|--no-rebuild) shift; rebuild=false;;
+        -d|--debug) shift; debug=true;;
         -*) usage_fatal "unknown option: '$1'";;
         *) break;; # reached the list of file names
     esac
@@ -98,7 +100,11 @@ fi
 echo "Cluster Deployed....."
 sleep 10
 
-./func_test.py
+if [[ "${debug}" == "true" ]]; then
+    sh -c ./func_test.py --debug
+else
+    sh -c ./func_test.py
+fi
 RESULT=$?
 echo $RESULT
 


### PR DESCRIPTION
This is a major change in the multi key operations like `MGET`, `MSET` and `DEL`.
It significantly reduces the latencies and message overhead by smartly splitting the multiple key requests across nodes. 
Basis:
For example in a rack with 3 nodes, and a request like `mget k1 k2 k3 k4 k5 k6 k7 k8 k9`, today, Dynomite would split the requests into 9 requests of `mget k1, mget k2`.... etc, one for each key. 
With the new changes, the request will be split at the max into as many requests as the number of nodes in the rack like mget k1 k4 k7, mget k2 k5 k8 & mget k3 k6 k9. This is significantly better than making one message per key and the performance advantage gets better with more keys in the query.

Quorum:
Of course, things get complicated with quorum. For example, a subquery of the previous query like this mget k1 k4 k7, can yield results from 3 replicas like v1 v4 nil, v1 nil v7, nil v4 v7. The checksums of the three responses will not match in which case, Dynomite will split the values and try to get a quorum on individual values (ex. v1, v1 and nil) and then assemble the final response for the subquery (mget k1 k4 k7) making it v1 v4 v7.

Error Scenarios:
In this pull request, Dynomite fails the entire request if one of the nodes fail. This is because Jedis fails to cast an intermediate error and throws an exception.
For example in case of a response like this:

127.0.0.1:8102> mget GetSet_140_81 GetSet_140_28 GetSet_140_71 GetSet_140_972 GetSet_140_87 GetSet_140_777
1) "GetSet_140_81__value__GetSet_140_81"
2) (error) ERR Peer: Peer Node is not connected
3) "GetSet_140_71__value__GetSet_140_71"
4) "GetSet_140_972__value__GetSet_140_972"
5) (error) ERR Peer: Peer Node is not connected
6) "GetSet_140_777__value__GetSet_140_777"
127.0.0.1:8102>

Jedis cannot handle this but redis-cli can. Since jedis is the most widely used client, I decided to fail the entire request instead like this:

127.0.0.1:8102> mget GetSet_140_81 GetSet_140_28 GetSet_140_71 GetSet_140_972 GetSet_140_87 GetSet_140_777
(error) ERR Peer: Peer Node is not connected

