### PR TITLE
Fix memory corruption with peer array

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -54,7 +54,7 @@ core_print_peer_status(void *arg1)
             for (i = 0; i< rack->ncontinuum; i++) {
                 struct continuum *c = &rack->continuum[i];
                 uint32_t peer_index = c->index;
-                struct node *peer = array_get(&sp->peers, peer_index);
+                struct node *peer = *(struct node **)array_get(&sp->peers, peer_index);
                 if (!peer)
                     log_panic("peer is null. Topology not inited proerly");
 
@@ -71,7 +71,7 @@ void
 core_set_local_state(struct context *ctx, dyn_state_t state)
 {
     struct server_pool *sp = &ctx->pool;
-    struct node *peer = array_get(&sp->peers, 0);
+    struct node *peer = *(struct node **)array_get(&sp->peers, 0);
     ctx->dyn_state = state;
     peer->state = state;
 }
@@ -569,7 +569,7 @@ core_debug(struct context *ctx)
     uint32_t j, n;
     for (j = 0, n = array_n(&sp->peers); j < n; j++) {
         log_debug(LOG_VERB, "==============================================");
-        struct node *peer = (struct node *) array_get(&sp->peers, j);
+        struct node *peer = *(struct node **) array_get(&sp->peers, j);
         log_debug(LOG_VERB, "\tPeer DC            : '%.*s'",peer ->dc);
         log_debug(LOG_VERB, "\tPeer Rack          : '%.*s'", peer->rack);
 

--- a/src/dyn_gossip.c
+++ b/src/dyn_gossip.c
@@ -929,7 +929,7 @@ gossip_pool_init(struct context *ctx)
 
     uint32_t i, nelem;
     for (i = 0, nelem = array_n(&sp->peers); i < nelem; i++) {
-        struct node *peer = array_get(&sp->peers, i);
+        struct node *peer = *(struct node **)array_get(&sp->peers, i);
         struct gossip_dc *g_dc = dictFetchValue(gn_pool.dict_dc, &peer->dc);
         struct gossip_rack *g_rack = dictFetchValue(g_dc->dict_rack, &peer->rack);
         struct gossip_node *gnode = array_push(&g_rack->nodes);

--- a/src/dyn_node_snitch.c
+++ b/src/dyn_node_snitch.c
@@ -67,7 +67,7 @@ char *get_broadcast_address(struct server_pool *sp)
            return broadcast_address;
     }
 
-	struct node *peer = (struct node *) array_get(&sp->peers, 0);
+	struct node *peer = *(struct node **) array_get(&sp->peers, 0);
 	broadcast_address = (char *) peer->name.data;
 	return broadcast_address;
 }
@@ -87,7 +87,7 @@ char *get_public_hostname(struct server_pool *sp)
     	   return public_hostname;
 	}
 
-    struct node *peer = (struct node *) array_get(&sp->peers, 0);
+    struct node *peer = *(struct node **) array_get(&sp->peers, 0);
     char c = (char) peer->name.data[0];
     if ((peer != NULL) && (peer->name.data != NULL) && !isdigit(c) ) {
     	public_hostname = (char *) peer->name.data;
@@ -112,7 +112,7 @@ char *get_public_ip4(struct server_pool *sp)
 		   return public_ip4;
 	}
 
-    struct node *peer = (struct node *) array_get(&sp->peers, 0);
+    struct node *peer = *(struct node **) array_get(&sp->peers, 0);
     if ((peer != NULL) && (peer->name.data != NULL)) {
         char c = (char) peer->name.data[0];
         if (isdigit(c))

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1291,7 +1291,7 @@ stats_send_rsp(struct stats *st)
 
         //I think it is ok to keep this simple without a synchronization
         for (i = 0, len = array_n(&sp->peers); i < len; i++) {
-            struct node *peer = array_get(&sp->peers, i);
+            struct node *peer = *(struct node **)array_get(&sp->peers, i);
             log_debug(LOG_VERB, "peer '%.*s' ", peer->name);
 
             if (string_compare(&st_cmd.req_data, &all) == 0) {

--- a/src/dyn_vnode.c
+++ b/src/dyn_vnode.c
@@ -62,7 +62,7 @@ vnode_update(struct server_pool *sp)
 
     int i, len;
     for (i = 0, len = array_n(&sp->peers); i < len; i++) {
-        struct node *peer = array_get(&sp->peers, i);
+        struct node *peer = *(struct node **)array_get(&sp->peers, i);
 
         log_debug(LOG_VERB, "peer name       : '%.*s'", peer->name.len, peer->name.data);
         log_debug(LOG_VERB, "peer rack       : '%.*s'", peer->rack.len, peer->rack.data);


### PR DESCRIPTION
We create a peers array in the server pool which was an array of struct
node. The address of this struct was being handed all over which can
become invalid when the array resizes and reallocates the underlying
memory. The solution is to have arrays as an array of pointers and hand
over those pointers.

There is a need for a special type of array which will hold only
pointers. That will simplify a lot of code