### PR TITLE
Disable ready queue

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -709,7 +709,7 @@ core_loop(struct context *ctx)
     }
 
     // go through all the ready queue and send each of them
-    struct server_pool *sp = &ctx->pool;
+    /*struct server_pool *sp = &ctx->pool;
     struct conn *conn, *nconn;
     TAILQ_FOREACH_SAFE(conn, &sp->ready_conn_q, ready_tqe, nconn) {
 		rstatus_t status = core_send(ctx, conn);
@@ -719,7 +719,7 @@ core_loop(struct context *ctx)
         } else {
             TAILQ_REMOVE(&sp->ready_conn_q, conn, ready_tqe);
         }
-    }
+    }*/
 	stats_swap(ctx->stats);
 
 	return DN_OK;


### PR DESCRIPTION
A bunch of people complained about this disable flush getting stuck at some point. 
I am guessing it is because we lose track of the connection in the ready queue and it never gets added back to epoll context leading to a request getting hung. I am going to disable this functionality for now and revisit it on the dev branch.