### PR TITLE
Fixed the compile error

### DIFF
--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -200,5 +200,5 @@ rspmgr_clone_responses(struct response_mgr *rspmgr, struct array *responses)
     return DN_OK;
 error:
     rsp_put(dst);
-    return ;
+    return s;
 }


### PR DESCRIPTION
```
gcc -DHAVE_CONFIG_H -I. -I..  -D_GNU_SOURCE -I ../src/hashkit -I ../src/proto -I ../src/event -I ../src/entropy -I ../src/seedsprovider -I ../contrib/yaml-0.1.4/include -I/usr/local/Cellar/openssl/1.0.2l/include -Wall -Wshadow -Wpointer-arith -Winline -Wunused-function -Wunused-variable -Wunused-value -Wno-unused-parameter -Wno-unused-value -Wconversion -Wsign-compare -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Wmissing-declarations -Wimplicit-function-declaration -I/usr/local/Cellar/openssl/1.0.2l/include/ -MT dyn_response_mgr.o -MD -MP -MF .deps/dyn_response_mgr.Tpo -c -o dyn_response_mgr.o dyn_response_mgr.c
dyn_response_mgr.c:203:5: error: non-void function 'rspmgr_clone_responses' should return a value [-Wreturn-type]
    return ;
    ^
1 error generated.
make[3]: *** [dyn_response_mgr.o] Error 1
make[2]: *** [all-recursive] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

Return the status variable `s` should resolve this error.