### PR TITLE
Fix crash when decrypting large payload data

### DIFF
--- a/src/dyn_dnode_msg.h
+++ b/src/dyn_dnode_msg.h
@@ -14,7 +14,7 @@ typedef enum dmsg_version {
     VERSION_10 = 1
 } dmsg_version_t;
 
-enum {
+typedef enum {
         DYN_START = 0,
         DYN_MAGIC_STRING = 1000,
         DYN_MSG_ID,
@@ -31,7 +31,7 @@ enum {
         DYN_DONE,
         DYN_POST_DONE,
         DYN_UNKNOWN
-} dyn_state;
+} dyn_parse_state_t;
 
 typedef enum dmsg_type {
     DMSG_UNKNOWN = 0,

--- a/src/dyn_mbuf.c
+++ b/src/dyn_mbuf.c
@@ -116,7 +116,7 @@ mbuf_get(void)
     mbuf->pos = mbuf->start;
     mbuf->last = mbuf->start;
 
-    mbuf->read_flip = 0;
+    mbuf->flags = 0;
 
     log_debug(LOG_VVERB, "get mbuf %p", mbuf);
 
@@ -153,7 +153,7 @@ void mbuf_dump(struct mbuf *mbuf)
      q = mbuf->last;
      len = q - p;
 
-     loga_hexdump(p, len, "mbuf with %ld bytes of data", len);
+     loga_hexdump(p, len, "mbuf %p with %ld bytes of data", mbuf, len);
 }
 
 void

--- a/src/dyn_mbuf.h
+++ b/src/dyn_mbuf.h
@@ -36,7 +36,7 @@ struct mbuf {
     uint8_t            *start;  /* start of buffer (const) */
     uint8_t            *end;    /* end of buffer (const) */
     uint8_t            *end_extra; /*end of the buffer - including the extra region */
-    uint32_t           read_flip; /* readable flag used in encryption/decryption mode */
+    uint32_t           flags; /* flags: readflip, just_decrypted etc */
     uint32_t           chunk_size;
 };
 
@@ -48,6 +48,10 @@ STAILQ_HEAD(mhdr, mbuf);
 #define MBUF_SIZE       16384
 #define MBUF_HSIZE      sizeof(struct mbuf)
 #define MBUF_ESIZE      16
+
+// FLAGS
+#define MBUF_FLAGS_READ_FLIP        0x00000001
+#define MBUF_FLAGS_JUST_DECRYPTED   0x00000002
 
 
 static inline bool

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -389,7 +389,7 @@ struct msg {
 
     //dynomite
     struct dmsg          *dmsg;          /* dyn message */
-    int                  dyn_parse_state;
+    dyn_parse_state_t    dyn_parse_state;
     dyn_error_t          dyn_error_code; /* error code for dynomite */
     msg_routing_t        msg_routing;
     unsigned             is_read:1;       /*  0 : write


### PR DESCRIPTION
This was occurring frequently in a production environment where large payload in the range of 40K was caused Dynomite to crash.