### PR TITLE
Redis PFCOUNT command should be considered a write operation

### DIFF
--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -1061,7 +1061,7 @@ redis_parse_req(struct msg *r, const struct string *hash_tag)
                 }
                 if (str7icmp(m, 'p', 'f', 'c', 'o', 'u', 'n', 't')) {
                     r->type = MSG_REQ_REDIS_PFCOUNT;
-                    r->is_read = 1;
+                    r->is_read = 0;
                     break;
                 }
 


### PR DESCRIPTION
Although the Redis PFCOUNT command sounds like it should be a read operation, it does mutate the underlying HLL data-structure.

From https://redis.io/commands/pfcount:

> Note: as a side effect of calling this function, it is possible that the HyperLogLog is modified, since the last 8 bytes encode the latest computed cardinality for caching purposes. So PFCOUNT is technically a write command.