### PR TITLE
Proper error propagation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -23,7 +23,7 @@ autoreconf -fvi
 if [ $OS == "Darwin" ] ; then
     ./configure --enable-debug=yes LDFLAGS="-L${SSL_LIBDIR}" CPPFLAGS="-I${SSL_INCLUDEDIR}"
 else
-    ./configure --enable-debug=log
+    ./configure --enable-debug=full
 fi
 
 make

--- a/conf/redis_rack1_node.yml
+++ b/conf/redis_rack1_node.yml
@@ -12,6 +12,6 @@ dyn_o_mite:
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem
   data_store: 0
-  read_consistency : DC_ONE
-  write_consistency : DC_ONE
-  stats_listen: 0.0.0.0:22222
+  read_consistency : DC_SAFE_QUORUM
+  write_consistency : DC_SAFE_QUORUM
+  stats_listen: 0.0.0.0:22221

--- a/conf/redis_rack2_node.yml
+++ b/conf/redis_rack2_node.yml
@@ -12,6 +12,6 @@ dyn_o_mite:
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem
   data_store: 0
-  read_consistency : DC_ONE
-  write_consistency : DC_ONE
+  read_consistency : DC_SAFE_QUORUM
+  write_consistency : DC_SAFE_QUORUM
   stats_listen: 0.0.0.0:22222

--- a/conf/redis_rack3_node.yml
+++ b/conf/redis_rack3_node.yml
@@ -12,6 +12,6 @@ dyn_o_mite:
   secure_server_option: datacenter
   pem_key_file: conf/dynomite.pem
   data_store: 0
-  read_consistency : DC_ONE
-  write_consistency : DC_ONE
-  stats_listen: 0.0.0.0:22222
+  read_consistency : DC_SAFE_QUORUM
+  write_consistency : DC_SAFE_QUORUM
+  stats_listen: 0.0.0.0:22223

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -417,12 +417,8 @@ req_forward_error(struct context *ctx, struct conn *conn, struct msg *req,
     // Create an appropriate response for the request so its propagated up;
     // This response gets dropped in rsp_make_error anyways. But since this is
     // an error path its ok with the overhead.
-    struct msg *rsp = msg_get(conn, false, __FUNCTION__);
-    rsp->type = MSG_RSP_REDIS_ERROR;
+    struct msg *rsp = msg_get_error(conn, dyn_error_code, error_code);
     rsp->peer = req;
-    rsp->is_error = 1;
-    rsp->error_code = error_code;
-    rsp->dyn_error_code = dyn_error_code;
     //TODO: Check if this is required in response
     rsp->dmsg = dmsg_get();
     rsp->dmsg->id =  req->id;

--- a/src/dyn_response.c
+++ b/src/dyn_response.c
@@ -86,6 +86,8 @@ rsp_make_error(struct context *ctx, struct conn *conn, struct msg *req)
 
     rsp = req->selected_rsp;
     if (rsp != NULL) {
+        if (rsp->is_error)
+            return rsp;
         ASSERT(!rsp->is_request && rsp->peer == req);
         req->selected_rsp = NULL;
         rsp->peer = NULL;
@@ -141,7 +143,7 @@ rsp_send_next(struct context *ctx, struct conn *conn)
         }
         rsp->peer = req;
         req->selected_rsp = rsp;
-        log_debug(LOG_VERB, "creating new error rsp %p", rsp);
+        log_debug(LOG_VERB, "creating new error rsp %M", rsp);
         if (conn->dyn_mode) {
       	  stats_pool_incr(ctx, peer_forward_error);
         } else {

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1604,10 +1604,7 @@ memcache_reconcile_responses(struct response_mgr *rspmgr)
         return rspmgr->responses[0];
     } else {
         log_info("none of the responses match, returning error");
-        struct msg *rsp = msg_get(rspmgr->conn, false, __FUNCTION__);
-        rsp->is_error = 1;
-        rsp->error_code = DYNOMITE_NO_QUORUM_ACHIEVED;
-        rsp->dyn_error_code = DYNOMITE_NO_QUORUM_ACHIEVED;
+        struct msg *rsp = msg_get_error(NULL, DYNOMITE_NO_QUORUM_ACHIEVED, 0);
         // There is a case that when 1 out of three nodes are down, the
         // response manager has 1 error response and 2 good responses.
         // We reach here when the two responses differ and we want to return

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -3222,10 +3222,7 @@ redis_reconcile_responses(struct response_mgr *rspmgr)
         return rspmgr->responses[0];
     } else {
         log_info("none of the responses match, returning error");
-        struct msg *rsp = msg_get(rspmgr->conn, false, __FUNCTION__);
-        rsp->is_error = 1;
-        rsp->error_code = DYNOMITE_NO_QUORUM_ACHIEVED;
-        rsp->dyn_error_code = DYNOMITE_NO_QUORUM_ACHIEVED;
+        struct msg *rsp = msg_get_error(NULL, DYNOMITE_NO_QUORUM_ACHIEVED, 0);
         // There is a case that when 1 out of three nodes are down, the
         // response manager has 1 error response and 2 good responses.
         // We reach here when the two responses differ and we want to return


### PR DESCRIPTION
Previously we were just keeping track of error codes in the request,
Instead create a error response and hang on to it. This will help in
better error reporting to client.