### PR TITLE
Upgrade to Python 3 + plumb cluster_generator into func_test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: c
 script: bash ./travis.sh
+
+addons:
+  apt:
+   packages:
+   - python3
+   - python3-pip

--- a/scripts/dynomite/dyn_mc_test.py
+++ b/scripts/dynomite/dyn_mc_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from optparse import OptionParser
 import configparser

--- a/scripts/dynomite/dyn_mc_test.py
+++ b/scripts/dynomite/dyn_mc_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from optparse import OptionParser
-import ConfigParser
+import configparser
 import logging
 import time
 import os
@@ -62,7 +62,7 @@ def main():
                       help="Number of keys\n")
 
     if len(sys.argv) == 1:
-         print "Learn some usages: " + sys.argv[0] + " -h"
+         print("Learn some usages: " + sys.argv[0] + " -h")
          sys.exit(1)
 
 
@@ -78,7 +78,7 @@ def main():
     #fh.setFormatter(formatter)
     #logger.addHandler(fh)
 
-    print options
+    print(options)
 
     logging.basicConfig(level=logging.DEBUG,
                         format='%(asctime)s %(levelname)s %(message)s',
@@ -91,7 +91,7 @@ def main():
     numkeys = int(options.numkeys)
     start = int(options.skipkeys)
     end   = int(options.numkeys)
-    print 'start: ' + str(start) + ' and end: ' + str(end)
+    print('start: ' + str(start) + ' and end: ' + str(end))
 
     if 'write' == options.operation :
        for i in range(start, end ) :
@@ -103,14 +103,14 @@ def main():
           value = mc.get('key_' + str(i))
           if value is None:
              error_count = error_count + 1
-             print 'No value for key: ' + 'key_' + str(i)
+             print('No value for key: ' + 'key_' + str(i))
           else :
-             print 'key_' + str(i) + ' has value : ' + value
-       print 'Errour count: ' + str(error_count)
+             print('key_' + str(i) + ' has value : ' + value)
+       print('Errour count: ' + str(error_count))
     elif 'mread' == options.operation :
        n = (end - start) / 10
        n = min(n, 10)
-       print n
+       print(n)
        keys = []
        i = 0
        while (i < n) :
@@ -119,13 +119,13 @@ def main():
            if key not in keys :
               keys.append(key)
               i = i + 1
-       print keys
+       print(keys)
 
       #values = mc.get_multi(['key_1', 'key_2', 'key_3'])
        while (len(keys) > 0) :
          values = mc.get_multi(keys)
-         print values
-         for key in values.keys() :
+         print(values)
+         for key in values.keys():
              keys.remove(key)
 
 
@@ -143,7 +143,7 @@ def main():
            if value != None :
                is_stop = True
 
-         print 'Estimated elapsed time : ' + str(current_milli_time() - int(value))
+         print('Estimated elapsed time : ' + str(current_milli_time() - int(value)))
 
     elif 'sdel' == options.operation :
         mc.delete('key_time')

--- a/scripts/dynomite/dyn_redis_purge.py
+++ b/scripts/dynomite/dyn_redis_purge.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from optparse import OptionParser
 import configparser

--- a/scripts/dynomite/dyn_redis_purge.py
+++ b/scripts/dynomite/dyn_redis_purge.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from optparse import OptionParser
-import ConfigParser
+import configparser
 import logging
 import time
 import os
@@ -40,7 +40,7 @@ class OperationThread (threading.Thread):
         host = self.options.host
         port = self.options.port
 
-        print "Starting thread: " + self.name +  ", filename: " + self.filename
+        print("Starting thread: " + self.name +  ", filename: " + self.filename)
 
         # Get lock to synchronize threads
         #threadLock.acquire()
@@ -69,7 +69,7 @@ def rebalance_ops(filename, host, port, db):
     i = 0
     for line in open(filename,'r').readlines():
         if line != '':
-          print line
+          print(line)
           line = line.strip('\n')
           if line == '':
             continue
@@ -81,7 +81,7 @@ def rebalance_ops(filename, host, port, db):
             if (i % 5000 == 0):
               time.sleep(1)
           except redis.exceptions.ResponseError:
-            print "reconnecting ..."
+            print("reconnecting ...")
             r1 = redis.StrictRedis(host, port, db=0)
 
 
@@ -123,13 +123,13 @@ def main():
 
 
     if len(sys.argv) == 1:
-         print "Learn some usages: " + sys.argv[0] + " -h"
+         print("Learn some usages: " + sys.argv[0] + " -h")
          sys.exit(1)
 
 
     (options, args) = parser.parse_args()
 
-    print options
+    print(options)
 
     num_threads = int(options.th)
 
@@ -147,7 +147,7 @@ def main():
     for t in threads:
        t.join()
 
-    print ""
+    print()
 
 
 if  __name__ == '__main__':

--- a/scripts/dynomite/dyn_redis_test.py
+++ b/scripts/dynomite/dyn_redis_test.py
@@ -5,7 +5,7 @@
 #  Install https://github.com/andymccurdy/redis-py
 
 from optparse import OptionParser
-import ConfigParser
+import configparser
 import logging
 import time
 import os
@@ -48,7 +48,7 @@ class OperationThread (threading.Thread):
         delay = self.options.delay
         start = self.start_num
         end   = self.end_num
-        print "Starting thread: " + self.name +  ", start: " + str(start) + " and end: " + str(end)
+        print("Starting thread: " + self.name +  ", start: " + str(start) + " and end: " + str(end))
 
         # Get lock to synchronize threads
         #threadLock.acquire()
@@ -77,7 +77,7 @@ class OperationThread (threading.Thread):
               if value != None :
                  is_stop = True
 
-           print 'Estimated elapsed time : ' + str(current_milli_time() - int(value))
+           print('Estimated elapsed time : ' + str(current_milli_time() - int(value)))
         elif 'sdel' == operation :
            r = redis.StrictRedis(host, port, db=0)
            r.delete('key_time')
@@ -103,8 +103,8 @@ def write_ops(skipkeys, numkeys, delay, host, port, db):
     conns = get_conns(host, port, db, num_conn)
     start = int(skipkeys)
     end   = int(numkeys)
-    print 'start: ' + str(start) + ' and end: ' + str(end)
-    print 'payload_prefix: ' + payload_prefix
+    print('start: ' + str(start) + ' and end: ' + str(end))
+    print('payload_prefix: ' + payload_prefix)
 
     for i in range(start, end ) :
         r = conns[i % num_conn]
@@ -114,7 +114,7 @@ def write_ops(skipkeys, numkeys, delay, host, port, db):
            r.set('key_' + str(i), generate_value(i))
            time.sleep(int(delay))
         except redis.exceptions.ResponseError:
-           print "reconnecting ..."
+           print("reconnecting ...")
            r = redis.StrictRedis(host, port, db=0)
            conns[i % num_conn] = r
 
@@ -125,7 +125,7 @@ def read_ops(skipkeys, numkeys, delay, host, port, db):
     start = int(skipkeys)
     end   = int(numkeys)
      
-    print 'start: ' + str(start) + ' and end: ' + str(end)
+    print('start: ' + str(start) + ' and end: ' + str(end))
     error_count = 0
     for i in range(start, end ) :
         r = conns[i % num_conn]
@@ -133,17 +133,17 @@ def read_ops(skipkeys, numkeys, delay, host, port, db):
             value = r.get('key_' + str(i))
             time.sleep(int(delay))
         except redis.exceptions.ResponseError:
-            print "reconnecting ..."
+            print("reconnecting ...")
             r = redis.StrictRedis(host, port, db=0)
 
         if value is None:
             error_count = error_count + 1
-            print 'No value for key: ' + 'key_' + str(i)
+            print('No value for key: ' + 'key_' + str(i))
         elif value != generate_value(i):
-            print 'key_' + str(i) + ' has incorrect value '
+            print('key_' + str(i) + ' has incorrect value ')
             error_count += 1
 
-    print 'Error count: ' + str(error_count) 
+    print('Error count: ' + str(error_count))
 
 
 def del_ops(skipkeys, numkeys, delay, host, port, db):
@@ -152,7 +152,7 @@ def del_ops(skipkeys, numkeys, delay, host, port, db):
     start = int(skipkeys)
     end   = int(numkeys)
 
-    print 'start: ' + str(start) + ' and end: ' + str(end)   
+    print('start: ' + str(start) + ' and end: ' + str(end))
 
     for i in range(start, end ) :
        r = conns[i % num_conn]
@@ -163,7 +163,7 @@ def del_ops(skipkeys, numkeys, delay, host, port, db):
            r.delete('key_' + str(i))
            time.sleep(int(delay))
        except redis.exceptions.ResponseError:
-           print "reconnecting ..."
+           print("reconnecting ...")
            r = redis.StrictRedis(host, port, db=0) 
 
 
@@ -172,11 +172,11 @@ def mread_ops(skipkeys, numkeys, delay, host, port, db):
        start = int(skipkeys)
        end   = int(numkeys)
 
-       print 'start: ' + str(start) + ' and end: ' + str(end)   
+       print('start: ' + str(start) + ' and end: ' + str(end))
 
        n = (end - start) / 10
        n = min(n, 10)
-       print n
+       print(n)
        keys = []
        i = 0
        while (i < n) :
@@ -185,13 +185,13 @@ def mread_ops(skipkeys, numkeys, delay, host, port, db):
            if key not in keys :
               keys.append(key)
               i = i + 1
-       print keys
+       print(keys)
 
        while (len(keys) > 0) :
           values = r.mget(keys)
-          print values
+          print(values)
           time.sleep(int(delay))
-          for key in values.keys() :
+          for key in values.keys():
               keys.remove(key)
 
 
@@ -247,13 +247,13 @@ def main():
 
 
     if len(sys.argv) == 1:
-         print "Learn some usages: " + sys.argv[0] + " -h"
+         print("Learn some usages: " + sys.argv[0] + " -h")
          sys.exit(1)
 
 
     (options, args) = parser.parse_args()
 
-    print options
+    print(options)
     start = int(options.skipkeys)
     end   = int(options.numkeys)
     global payload_prefix
@@ -263,7 +263,7 @@ def main():
 
     step = (end - start) / num_threads
 
-    print "step " + str(step)
+    print("step " + str(step))
 
     for i in range(0, num_threads):
        if (i != num_threads-1):
@@ -278,7 +278,7 @@ def main():
     for t in threads:
        t.join()
 
-    print ""
+    print()
 
 
 if  __name__ == '__main__':

--- a/scripts/dynomite/dyn_redis_test.py
+++ b/scripts/dynomite/dyn_redis_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 #Requirement: 

--- a/scripts/dynomite/generate_yamls.py
+++ b/scripts/dynomite/generate_yamls.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 '''
 script for generating dynomite yaml files for every node in a cluster.

--- a/scripts/redis/redis-check.py
+++ b/scripts/redis/redis-check.py
@@ -7,17 +7,17 @@ port=22121
 r = redis.StrictRedis(host='localhost', port=port, db=0)
 
 # lrange
-print [r.lrange('lfoo', 0, x) for x in xrange(1, range)]
-print [r.lpush('lfoo', str(x)*factor) for x in xrange(1, range)]
-print [r.lrange('lfoo', 0, x) for x in xrange(1, range)]
-print r.delete('lfoo')
+print([r.lrange('lfoo', 0, x) for x in range(1, range)])
+print([r.lpush('lfoo', str(x)*factor) for x in range(1, range)])
+print([r.lrange('lfoo', 0, x) for x in range(1, range)])
+print(r.delete('lfoo'))
 
 # del
-print [r.set('foo' + str(x), str(x)*factor) for x in xrange(1, range)]
-keys = ['foo' + str(x) for x in xrange(1, range)]
-print [r.delete(keys) for x in xrange(1, range)]
+print([r.set('foo' + str(x), str(x)*factor) for x in range(1, range)])
+keys = ['foo' + str(x) for x in range(1, range)]
+print([r.delete(keys) for x in range(1, range)])
 
 # mget
-print [r.set('foo' + str(x), str(x)*100) for x in xrange(1, range)]
-keys = ['foo' + str(x) for x in xrange(1, range)]
-print [r.mget(keys) for x in xrange(1, range)]
+print([r.set('foo' + str(x), str(x)*100) for x in range(1, range)])
+keys = ['foo' + str(x) for x in range(1, range)]
+print([r.mget(keys) for x in range(1, range)])

--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -93,7 +93,7 @@ class DynoSpec(namedtuple('DynoNode', 'ip port dc rack token '
         conf['listen'] = '{}:{}'.format(self.ip, CLIENT_LISTEN)
 
         # filter out our own seed string
-        conf['dyn_seeds'] = filter(lambda s: s != self.seed_string, seeds_list)
+        conf['dyn_seeds'] = [s for s in seeds_list if s != self.seed_string]
         conf['servers'] = ['{}:{}:0'.format(self.ip, REDIS_PORT)]
         conf['stats_listen'] = '{}:{}'.format(self.ip, STATS_PORT)
         conf['tokens'] = self.token
@@ -179,7 +179,7 @@ def main():
     ips = generate_ips()
     standalone_redis_ip = next(ips)
     nodes = list(generate_nodes(request, ips))
-    seeds_list = list(map(lambda n: n.seed_string, nodes))
+    seeds_list = [n.seed_string for n in nodes]
 
     dynomites = []
     redises = []

--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from collections import namedtuple
 from signal import SIGINT
 from tempfile import mkdtemp

--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python3
 from collections import namedtuple
+from contextlib import ExitStack
+from contextlib import contextmanager
 from signal import SIGINT
 from tempfile import mkdtemp
 from time import sleep
+from urllib.request import urlopen
 import argparse
+import json
 import random
 import socket
 import sys
@@ -16,6 +20,10 @@ from plumbum import local
 
 from ip_util import quad2int
 from ip_util import int2quad
+from dyno_cluster import DynoCluster
+from dyno_node import DynoNode
+from func_test import comparison_test
+from redis_node import RedisNode
 
 DYN_O_MITE_DEFAULTS = dict(
     secure_server_option='datacenter',
@@ -35,12 +43,18 @@ SETTLE_TIME = 5
 redis = local.get('./test/_binaries/redis-server', 'redis-server')
 dynomite = local.get('./test/_binaries/dynomite', 'src/dynomite')
 
+@contextmanager
 def launch_redis(ip):
     logfile = 'logs/redis_{}.log'.format(ip)
-    return (redis['--bind', ip, '--port', REDIS_PORT] > logfile) & BG
+    f = (redis['--bind', ip, '--port', REDIS_PORT] > logfile) & BG(-9)
+    try:
+        yield RedisNode(ip, REDIS_PORT)
+    finally:
+        f.proc.kill()
+        f.wait()
 
 def pick_tokens(count, start_offset):
-    stride = RING_SIZE / count
+    stride = RING_SIZE // count
     token = start_offset
     for i in range(count):
         yield token % RING_SIZE
@@ -75,8 +89,9 @@ def generate_ips():
         yield int2quad(state)
         state += 1
 
-class DynoSpec(namedtuple('DynoNode', 'ip port dc rack token '
+class DynoSpec(namedtuple('DynoSpec', 'ip port dc rack token '
     'local_connections remote_connections seed_string')):
+    """Specifies how to launch a dynomite node"""
 
     def __new__(cls, ip, port, rack, dc, token, local_connections,
                 remote_connections):
@@ -108,16 +123,33 @@ class DynoSpec(namedtuple('DynoNode', 'ip port dc rack token '
             yaml.dump(config, fh, default_flow_style=False)
         return filename
 
+    @contextmanager
     def launch(self, seeds_list):
         config_filename = self.write_config(seeds_list)
 
-        redis_future = launch_redis(self.ip)
+        with launch_redis(self.ip):
+            logfile = 'logs/dynomite_{}.log'.format(self.ip)
+            dynomite_future = dynomite['-o', logfile, '-c', config_filename,
+                '-v6'] & BG(-9)
 
-        logfile = 'logs/dynomite_{}.log'.format(self.ip)
-        # dynomite will exit with status 1 if we SIGINT it
-        dynomite_future = dynomite['-o', logfile, '-c', config_filename,
-            '-v6'] & BG(1)
-        return dynomite_future, redis_future
+            try:
+                yield DynoNode(self.ip)
+            finally:
+                dynomite_future.proc.kill()
+                dynomite_future.wait()
+
+
+@contextmanager
+def launch_dynomite(nodes):
+    seeds_list = [n.seed_string for n in nodes]
+    launched_nodes = [DynoNode(n.ip) for n in nodes]
+    with ExitStack() as stack:
+        launched_nodes = [
+            stack.enter_context(n.launch(seeds_list))
+            for n in nodes
+        ]
+
+        yield DynoCluster(launched_nodes)
 
 def dict_request(request):
     """Converts the request into an easy to consume dict format.
@@ -162,7 +194,6 @@ def setup_temp_dir():
 
     return tempdir
 
-
 def main():
     parser = argparse.ArgumentParser(
         description='Autogenerates a Dynomite cluster and runs functional ' +
@@ -171,7 +202,7 @@ def main():
         help='YAML file describing desired cluster', nargs='?')
     args = parser.parse_args()
 
-    with open('test/request.yaml', 'r') as fh:
+    with open(args.request_file, 'r') as fh:
         request = yaml.load(fh)
 
     temp = setup_temp_dir()
@@ -179,33 +210,18 @@ def main():
     ips = generate_ips()
     standalone_redis_ip = next(ips)
     nodes = list(generate_nodes(request, ips))
-    seeds_list = [n.seed_string for n in nodes]
 
-    dynomites = []
-    redises = []
-    try:
+    with ExitStack() as stack:
         with local.cwd(temp):
-            redises.append(launch_redis(standalone_redis_ip))
-            for n in nodes:
-                d, r = n.launch(seeds_list)
-                dynomites.append(d)
-                redises.append(r)
+            redis_info = stack.enter_context(launch_redis(standalone_redis_ip))
+            dynomite_info = stack.enter_context(launch_dynomite(nodes))
 
-        sleep(SETTLE_TIME)
-        local['test/func_test.py'] & FG
-        local['test/supplemental.sh'] & FG
-    finally:
-        for f in dynomites:
-            f.proc.send_signal(SIGINT)
+            sleep(SETTLE_TIME)
+            comparison_test(redis_info, dynomite_info, False)
 
-        for f in redises:
-            f.proc.send_signal(SIGINT)
-
-        for f in dynomites:
-            f.wait()
-
-        for f in redises:
-            f.wait()
+            random_node = random.choice(dynomite_info.nodes)
+            stats_url = 'http://{}:{}/info'.format(random_node.ip, STATS_PORT)
+            json.loads(urlopen(stats_url).read().decode('ascii'))
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/test/dual_run.py
+++ b/test/dual_run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import redis
 
 class ResultMismatchError(Exception):

--- a/test/dual_run.py
+++ b/test/dual_run.py
@@ -33,19 +33,19 @@ class dual_run():
             try:
                 d_result = d_func(*args)
                 if i > 0:
-                    print "\tSucceeded in attempt {}".format(i+1)
+                    print("\tSucceeded in attempt {}".format(i+1))
                 break
-            except redis.exceptions.ResponseError, e:
+            except redis.exceptions.ResponseError as e:
                 if "Peer Node is not connected" in str(e):
                     i = i + 1
-                    print "\tGot error '{}' ... Retry effort {}/{}\n\tQuery '{} {}'".format(e, i, retry_limit, func, str(args))
+                    print("\tGot error '{}' ... Retry effort {}/{}\n\tQuery '{} {}'".format(e, i, retry_limit, func, str(args)))
                     continue
-                print "\tGot error '{}'\n\tQuery '{} {}'".format(e, func, str(args))
+                print("\tGot error '{}'\n\tQuery '{} {}'".format(e, func, str(args)))
                 break
         if self.debug:
-            print "Query: %s %s" % (func, str(args))
-            print "Redis: %s" % str(r_result)
-            print "Dyno : %s" % str(d_result)
+            print("Query: %s %s" % (func, str(args)))
+            print("Redis: %s" % str(r_result))
+            print("Dyno : %s" % str(d_result))
         if r_result != d_result:
             raise ResultMismatchError(r_result, d_result, func, *args)
         return d_result

--- a/test/dyno_cluster.py
+++ b/test/dyno_cluster.py
@@ -4,7 +4,8 @@ import random
 
 class DynoCluster(object):
     def __init__(self, nodes):
-        self.nodes = nodes
+        self.nodes = tuple(nodes)
+
     def get_connection(self):
         node = random.choice(self.nodes)
         return node.get_connection()

--- a/test/dyno_cluster.py
+++ b/test/dyno_cluster.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import redis
 import random
 

--- a/test/dyno_node.py
+++ b/test/dyno_node.py
@@ -5,15 +5,15 @@ from redis_node import RedisNode
 from dyno_cluster import DynoCluster
 
 class DynoNode(Node):
-    def __init__(self, host="localhost", ip="127.0.0.1", port=8102,
-                 dnode_port=8101, data_store_port=22122):
-        super(DynoNode, self).__init__(host, ip, port)
+    def __init__(self, ip, port=8102,
+                 dnode_port=8101, data_store_port=1212):
+        super(DynoNode, self).__init__(ip, port)
         self.name="Dyno" + self.name
         self.conf_file = None
         self.dnode_port = dnode_port
-        self.data_store_node = RedisNode(host, ip, data_store_port)
+        self.data_store_node = RedisNode(ip, data_store_port)
 
     def get_connection(self):
         # should return the connection to the dyno port not the redis
-        print("returning connection at %s:%d" % (self.host, self.port))
-        return redis.StrictRedis(self.host, self.port, db=0)
+        print("returning connection at %s:%d" % (self.ip, self.port))
+        return redis.StrictRedis(self.ip, self.port, db=0)

--- a/test/dyno_node.py
+++ b/test/dyno_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import redis
 from node import Node
 from redis_node import RedisNode

--- a/test/dyno_node.py
+++ b/test/dyno_node.py
@@ -15,5 +15,5 @@ class DynoNode(Node):
 
     def get_connection(self):
         # should return the connection to the dyno port not the redis
-        print "returning connection at %s:%d" % (self.host, self.port)
+        print("returning connection at %s:%d" % (self.host, self.port))
         return redis.StrictRedis(self.host, self.port, db=0)

--- a/test/func_test.py
+++ b/test/func_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import redis
 import argparse
 import random

--- a/test/func_test.py
+++ b/test/func_test.py
@@ -23,7 +23,7 @@ def create_key(test_name, key_id):
 def run_key_value_tests(c, max_keys=1000, max_payload=1024):
     #Set some
     test_name="KEY_VALUE"
-    print "Running %s tests" % test_name
+    print("Running %s tests" % test_name)
     for x in range(0, max_keys):
         key = create_key(test_name, x)
         c.run_verify("set", key, string_generator(size=random.randint(1, max_payload)))
@@ -39,13 +39,13 @@ def run_key_value_tests(c, max_keys=1000, max_payload=1024):
     # expire a few
     key = create_key(test_name, random.randint(0, max_keys-1))
     c.run_verify("expire", key, 5)
-    time.sleep(7);
+    time.sleep(7)
     c.run_verify("exists", key)
 
 def run_multikey_test(c, max_keys=1000, max_payload=10):
     #Set some
     test_name="MULTIKEY"
-    print "Running %s tests" % test_name
+    print("Running %s tests" % test_name)
     for n in range(0, 100):
         kv_pairs = {}
         len = random.randint(1, 50)
@@ -69,12 +69,12 @@ def run_hash_tests(c, max_keys=10, max_fields=1000):
             keyid = random.randint(0, max_keys - 1)
         if fieldid is None:
             fieldid = random.randint(0, max_fields- 1)
-        key = create_key(test_name, keyid);
-        field = create_key("_field", fieldid);
+        key = create_key(test_name, keyid)
+        field = create_key("_field", fieldid)
         return (key, key + field)
 
     test_name="HASH_MAP"
-    print "Running %s tests" % test_name
+    print("Running %s tests" % test_name)
 
     #hset
     for key_iter in range(0, max_keys):
@@ -151,9 +151,9 @@ def main(args):
         run_key_value_tests(c, max_keys=10, max_payload=5*1024*1024)
         run_multikey_test(c)
         run_hash_tests(c, max_keys=10, max_fields=100)
-        print "All test ran fine"
+        print("All test ran fine")
     except ResultMismatchError as r:
-        print r;
+        print(r)
         return 1
     return 0
 

--- a/test/load.py
+++ b/test/load.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 ##
 # A very simple basic program that will load data in a dynomite/redis server.

--- a/test/node.py
+++ b/test/node.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 
 class Node(object):
-    def __init__(self, host="localhost", ip="127.0.0.1", port=1212):
-        self.host=host
+    def __init__(self, ip, port):
+        self.ip = ip
         self.port=port
-        self.name="Node: %s:%d" % (host, port)
+        self.name="Node: %s:%d" % (ip, port)
 
     def __name__(self):
         return self.name

--- a/test/node.py
+++ b/test/node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 class Node(object):
     def __init__(self, host="localhost", ip="127.0.0.1", port=1212):

--- a/test/redis_node.py
+++ b/test/redis_node.py
@@ -3,9 +3,9 @@ import redis
 from node import Node
 
 class RedisNode(Node):
-    def __init__(self, host, ip, port):
-        super(RedisNode, self).__init__(host, ip, port)
+    def __init__(self, ip, port):
+        super(RedisNode, self).__init__(ip, port)
         self.name = "Redis" + self.name
 
     def get_connection(self):
-        return redis.StrictRedis(self.host, self.port, db=0)
+        return redis.StrictRedis(self.ip, self.port, db=0)

--- a/test/redis_node.py
+++ b/test/redis_node.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import redis
 from node import Node
 

--- a/test/run_loop.py
+++ b/test/run_loop.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import subprocess, time
 
 def run_command(cmd):
@@ -16,14 +16,14 @@ def run_command(cmd):
 def main():
     cmd = "bash travis.sh -n"
     for i in range(0, 50):
-        print"Running loop {}".format(i+1)
+        print("Running loop {}".format(i+1))
         success, proc = run_command(cmd)
         if not success:
             for line in iter(proc.stderr.readline, b''):
-                print("--- " + line.rstrip())
+                print(("--- " + line.rstrip()))
             break
         else:
-            print "...........................Success\n"
+            print("...........................Success\n")
         time.sleep(30)
 
 if __name__ == "__main__":

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 import random
 import string 
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -2,7 +2,7 @@
 import random
 import string 
 
-def string_generator(size=6, chars=string.letters + string.digits):
+def string_generator(size=6, chars=string.ascii_letters + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
 
 def number_generator(size=4, chars=string.digits):

--- a/travis.sh
+++ b/travis.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -n "$TRAVIS" ]; then
-    sudo pip install redis plumbum pyyaml
+    sudo pip3 install redis plumbum pyyaml
 fi
 
 


### PR DESCRIPTION
This PR is based on the branch in #494. It achieves the second and third follow-ups from #494's PR message.

### Follow-up 2: Plumbing

I hooked up the cluster_generator module into func_test by exposing a new method in func_test which allows for a RedisNode and a DynoCluster to be passed in, and runs tests with the connection information from those objects.

### Follow-up 3: Python 3 + ExitStack

I ran 2to3 (Python 2 -> 3 conversion tool) and then fixed a few straggler issues that it didn't (one was strings.letters -> ascii_letters; another was a change in how Python handles division).

 