### PR TITLE
Fix /help REST endpoint

### DIFF
--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1025,9 +1025,6 @@ parse_request(int sd, struct stats_cmd *st_cmd)
                 } else if (strcmp(reqline[1], "/ping") == 0) {
                     st_cmd->cmd = CMD_PING;
                     return;
-                } else if (strcmp(reqline[1], "/describe") == 0) {
-                    st_cmd->cmd = CMD_DESCRIBE;
-                    return;
                 } else if (strncmp(reqline[1], "/setloglevel", dn_strlen("/setloglevel")) == 0) {
                     st_cmd->cmd = CMD_SET_LOG_LEVEL;
                     log_notice("Setting loglevel: %s", reqline[1]);

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1217,11 +1217,11 @@ stats_send_rsp(struct stats *st)
         }
     } else if (cmd == CMD_HELP) {
         char rsp[5120];
-        dn_sprintf(rsp, "/info\n/help\n/ping\n/cluster_describe\n/standby\n"\
-                        "/writes_only\n/setloglevel/<0-11>\n/loglevelup\n/logleveldown\n/historeset\n"\
-                        "/get_consistency\n/set_consistency/<read|write>/<dc_one|dc_quorum>\n"\
+        dn_sprintf(rsp, "/info\n/help\n/ping\n/cluster_describe\n"\
+                        "/setloglevel/<0-11>\n/loglevelup\n/logleveldown\n/historeset\n"\
+                        "/get_consistency\n/set_consistency/<read|write>/<dc_one|dc_quorum|dc_safe_quorum>\n"\
                         "/get_timeout_factor\n/set_timeout_factor/<1-10>\n/peer/<up|down|reset>\n"\
-                        "/state/<get_state|writes_only|normal|%s>\n\n", "resuming");
+                        "/state/<get_state|standby|writes_only|normal|%s>\n\n", "resuming");
         return stats_http_rsp(sd, rsp, dn_strlen(rsp));
     } else if (cmd == CMD_NORMAL) {
         core_set_local_state(st->ctx, NORMAL);


### PR DESCRIPTION
Change response from `/help` REST endpoint from

```
/info
/help
/ping
/cluster_describe
/standby
/writes_only
/loglevelup
/logleveldown
/historeset
/get_consistency
/set_consistency/<read|write>/<dc_one|dc_quorum>
/get_timeout_factor
/set_timeout_factor/<1-10>
/peer/<up|down|reset>
/state/<get_state|writes_only|normal|resuming>
```

to

```
/info
/help
/ping
/cluster_describe
/setloglevel/<0-11>
/loglevelup
/logleveldown
/historeset
/get_consistency
/set_consistency/<read|write>/<dc_one|dc_quorum|dc_safe_quorum>
/get_timeout_factor
/set_timeout_factor/<1-10>
/peer/<up|down|reset>
/state/<get_state|standby|writes_only|normal|resuming>
```

I've got a question about the `/describe` endpoint though. It appears in wiki and in the code

https://github.com/Netflix/dynomite/blob/09cbf9001824b034c46f98ee0e366ea806167a45/src/dyn_stats.c#L1028-L1030

but it doesn't seem to do anything

https://github.com/Netflix/dynomite/blob/09cbf9001824b034c46f98ee0e366ea806167a45/src/dyn_stats.c#L1193-L1321

I guess it is ok, that it is missing in the `/help` response? (And should probably be removed from the code and wiki?).