### PR TITLE
Improve florida html parser

### DIFF
--- a/src/seedsprovider/dyn_florida.c
+++ b/src/seedsprovider/dyn_florida.c
@@ -92,7 +92,7 @@ florida_get_seeds(struct context * ctx, struct mbuf *seeds_buf) {
 
     struct sockaddr_in *remote;
     uint32_t sock;
-    uint32_t tmpres;
+    int32_t tmpres;
     uint8_t buf[BUFSIZ + 1];
 
     log_debug(LOG_VVERB, "Running florida_get_seeds!");


### PR DESCRIPTION
These changes help to deal with a case when HTML response might be unexpectedly splitted into parts directly on HTML content delimiter ("\r\n\r\n" sequence). The general idea here is below:
* before every parsing iteration read socket until getting all data or filling RX buffer
* if we don't get all data at current iteration and HTML content beginning still wasn't detected, last 3 received bytes will be copied to the beginning of the RX buffer and will be used on the next parsing iteration