### PR TITLE
Treat generated AES key as an array

### DIFF
--- a/src/dyn_connection_internal.c
+++ b/src/dyn_connection_internal.c
@@ -143,8 +143,12 @@ _conn_get(void)
     conn_set_write_consistency(conn, g_write_consistency);
     conn->type = CONN_UNSPECIFIED;
 
+    // Generate a new key for each connection
     unsigned char *aes_key = generate_aes_key();
-    strncpy((char *)conn->aes_key, (char *)aes_key, strlen((char *)aes_key)); //generate a new key for each connection
+    if (aes_key == NULL) {
+        return NULL;
+    }
+    memcpy(conn->aes_key, aes_key, AES_KEYLEN);
 
     return conn;
 }

--- a/src/dyn_connection_internal.c
+++ b/src/dyn_connection_internal.c
@@ -146,6 +146,7 @@ _conn_get(void)
     // Generate a new key for each connection
     unsigned char *aes_key = generate_aes_key();
     if (aes_key == NULL) {
+        dn_free(conn);
         return NULL;
     }
     memcpy(conn->aes_key, aes_key, AES_KEYLEN);

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -447,7 +447,7 @@ dyn_parse_req(struct msg *r, const struct string *hash_tag)
 			if (dmsg->mlen > 1) {
 				//Decrypt AES key
 				dyn_rsa_decrypt(dmsg->data, aes_decrypted_buf);
-				strncpy((char*)r->owner->aes_key, (char*)aes_decrypted_buf, strlen((char*)aes_decrypted_buf));
+				memcpy(r->owner->aes_key, aes_decrypted_buf, AES_KEYLEN);
 				SCOPED_CHARPTR(encoded_aes_key) = base64_encode(r->owner->aes_key, AES_KEYLEN);
 				if (encoded_aes_key)
 				    loga("AES decryption key: %s\n", (char*)encoded_aes_key);
@@ -563,8 +563,7 @@ void dyn_parse_rsp(struct msg *r, const struct string *UNUSED)
 			if (dmsg->mlen > 1) {
 				//Decrypt AES key
 				dyn_rsa_decrypt(dmsg->data, aes_decrypted_buf);
-				strncpy((char *)r->owner->aes_key, (char *)aes_decrypted_buf,
-                        strlen((char *)aes_decrypted_buf));
+				memcpy(r->owner->aes_key, aes_decrypted_buf, AES_KEYLEN);
 			}
 
 			// we have received all the remaining ecrypted data

--- a/src/dyn_test.c
+++ b/src/dyn_test.c
@@ -402,7 +402,7 @@ aes_test(void)
     unsigned char msg[MAX_MSG_LEN+1];
     print_banner("AES");
     unsigned char* aes_key = generate_aes_key();
-    SCOPED_CHARPTR(aes_key_print) = base64_encode(aes_key, strlen((char*)aes_key));
+    SCOPED_CHARPTR(aes_key_print) = base64_encode(aes_key, AES_KEYLEN);
     loga("aesKey is '%s'", aes_key_print);
 
     size_t i=0;


### PR DESCRIPTION
Due to a possibility of '\0' inside generated AES key we can't use "str-family" functions on key processing (e.g. strlen, strncpy etc.) and should treat key as an array. Otherwise, in some cases we get an error in dyn_aes_decrypt() routine ("Bad data in EVP_DecryptFinal_ex, crypto data with XX bytes of data").