### PR TITLE
spop should use count parameter

### DIFF
--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -85,7 +85,6 @@ redis_arg0(struct msg *r)
 
     case MSG_REQ_REDIS_SCARD:
     case MSG_REQ_REDIS_SMEMBERS:
-    case MSG_REQ_REDIS_SPOP:
     case MSG_REQ_REDIS_SRANDMEMBER:
 
     case MSG_REQ_REDIS_ZCARD:
@@ -251,6 +250,7 @@ redis_argn(struct msg *r)
     case MSG_REQ_REDIS_SUNION:
     case MSG_REQ_REDIS_SUNIONSTORE:
     case MSG_REQ_REDIS_SSCAN:
+    case MSG_REQ_REDIS_SPOP:
 
     case MSG_REQ_REDIS_ZADD:
     case MSG_REQ_REDIS_ZINTERSTORE:


### PR DESCRIPTION
in https://redis.io/commands/spop
spop can get count parameter
but currently dynomite can't handle this
so I moved MSG_REQ_REDIS_SPOP from redis_arg0 to redis_argn
