### PR TITLE
Avoid accessing 'ctx->stats' if it was never created

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -229,8 +229,9 @@ core_crypto_init(struct context *ctx)
     /* crypto init */
     THROW_STATUS(crypto_init(&ctx->pool));
     rstatus_t status = core_stats_create(ctx);
-    if (status != DN_OK)
-	stats_destroy(ctx->stats);
+    if (status != DN_OK) {
+        if (ctx->stats) stats_destroy(ctx->stats);
+    }
     
     return status;
 }
@@ -267,6 +268,7 @@ core_ctx_create(struct instance *nci)
         loga("Failed to create context!!!");
         return DN_ERROR;
     }
+
     nci->ctx = ctx;
     ctx->instance = nci;
     ctx->cf = NULL;

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -144,8 +144,10 @@ static void
 server_failure(struct context *ctx, struct datastore *server)
 {
     conn_pool_notify_conn_errored(server->conn_pool);
-    stats_server_set_ts(ctx, server_ejected_at, dn_msec_now());
-    stats_pool_incr(ctx, server_ejects);
+    if (ctx->stats) {
+        stats_server_set_ts(ctx, server_ejected_at, dn_msec_now());
+        stats_pool_incr(ctx, server_ejects);
+    }
 }
 
 static void
@@ -230,7 +232,9 @@ server_close(struct context *ctx, struct conn *conn)
     ASSERT(conn->type == CONN_SERVER);
     struct datastore *datastore = conn->owner;
 
-    server_close_stats(ctx, datastore, conn->err, conn->eof, conn->connected);
+    if (ctx->stats) {
+        server_close_stats(ctx, datastore, conn->err, conn->eof, conn->connected);
+    }
 
 	if (conn->sd < 0) {
 		conn_unref(conn);
@@ -261,7 +265,7 @@ server_close(struct context *ctx, struct conn *conn)
         server_ack_err(ctx, conn, req);
         in_counter++;
 
-		stats_server_incr(ctx, server_dropped_requests);
+		if (ctx->stats) stats_server_incr(ctx, server_dropped_requests);
 	}
 	ASSERT(TAILQ_EMPTY(&conn->imsg_q));
 

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1787,6 +1787,8 @@ stats_server_to_metric(struct context *ctx,
                        stats_server_field_t fidx)
 {
    struct stats *st = ctx->stats;
+   ASSERT(st != NULL);
+
    struct stats_pool *stp = &st->current;
    struct stats_server *sts = &stp->server;
    struct stats_metric *stm = array_get(&sts->metric, fidx);


### PR DESCRIPTION
If a call to 'stats_create()' fails from 'core_stats_create()', we
still access the 'stats' structure on the teardown path in multiple
places. This causes Dynomite to crash in multiple places.

This patch fixes the crashes by avoiding accessing the invalid memory
if it wasn't allocated in the first place.