### PR TITLE
Avoid implicit interpretation of return type for dyn_aes_encrypt_msg()

### DIFF
--- a/src/dyn_crypto.c
+++ b/src/dyn_crypto.c
@@ -388,12 +388,13 @@ dyn_aes_decrypt(unsigned char *enc_msg, size_t enc_msg_len, struct mbuf *mbuf, u
  *
  */
 rstatus_t
-dyn_aes_encrypt_msg(struct msg *msg, unsigned char *arg_aes_key)
+dyn_aes_encrypt_msg(struct msg *msg, unsigned char *arg_aes_key, size_t* outlen)
 {
     struct mhdr mhdr_tem;
     int count = 0;
 
     if (STAILQ_EMPTY(&msg->mhdr)) {
+        // 'msg' is empty. Nothing to encrypt.
         return DN_ERROR;
     }
 
@@ -409,8 +410,9 @@ dyn_aes_encrypt_msg(struct msg *msg, unsigned char *arg_aes_key)
 
         struct mbuf *nbuf = mbuf_get();
         if (nbuf == NULL) {
+            // Unable to obtain an 'mbuf'.
             mbuf_put(mbuf);
-            return DN_ERROR;
+            return DN_ENOMEM;
         }
 
         int n = dyn_aes_encrypt(mbuf->pos, mbuf_length(mbuf), nbuf, arg_aes_key);
@@ -438,7 +440,8 @@ dyn_aes_encrypt_msg(struct msg *msg, unsigned char *arg_aes_key)
         }
     }
 
-    return count;
+    *outlen = count;
+    return DN_OK;
 }
 
 

--- a/src/dyn_crypto.h
+++ b/src/dyn_crypto.h
@@ -41,7 +41,7 @@ rstatus_t dyn_aes_encrypt(const unsigned char *msg, size_t msgLen,
 rstatus_t dyn_aes_decrypt(unsigned char *encMsg, size_t encMsgLen,
 		                  struct mbuf *mbuf, unsigned char *aes_key);
 
-rstatus_t dyn_aes_encrypt_msg(struct msg *msg, unsigned char *aes_key);
+rstatus_t dyn_aes_encrypt_msg(struct msg *msg, unsigned char *aes_key, size_t* outlen);
 unsigned char* generate_aes_key(void);
 
 int dyn_rsa_size(void);


### PR DESCRIPTION
dyn_aes_encrypt_msg() returns a type of rstatus_t, however the function
returns a status only on an error and returns a 'count' on success
which the caller implicitly interprets as '# of bytes'. This pattern
is error prone and could lead to hard to track down bugs.

This patch also returns the right error code on the OOM case and also
adds checking on the caller side for this new error code DN_ENOMEM.

This was noticed while debugging a core dump. While this patch is only
for clean up, a future patch will change some more code in this area
to fix a crash bug.