### PR TITLE
Consistency for SMEMBERS when using DC_SAFE_QUORUM

### DIFF
--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -44,6 +44,8 @@ typedef rstatus_t (*msg_response_handler_t)(struct msg *req, struct msg *rsp);
 typedef bool (*func_msg_failure_t)(struct msg *r);
 typedef bool (*func_is_multikey_request)(struct msg *r);
 typedef struct msg *(*func_reconcile_responses)(struct response_mgr *rspmgr);
+typedef rstatus_t (*func_msg_rewrite_t)(struct msg *orig_msg, struct context* ctx,
+        bool* did_rewrite, struct msg** new_msg_ptr);
 
 extern func_msg_coalesce_t  g_pre_coalesce;    /* message pre-coalesce */
 extern func_msg_coalesce_t  g_post_coalesce;   /* message post-coalesce */
@@ -51,6 +53,7 @@ extern func_msg_fragment_t  g_fragment;   /* message fragment */
 extern func_msg_verify_t    g_verify_request;  /* message verify */
 extern func_is_multikey_request g_is_multikey_request;
 extern func_reconcile_responses g_reconcile_responses;
+extern func_msg_rewrite_t g_rewrite_query;            /* rewrite query in a msg if necessary */
 
 void set_datastore_ops(void);
 
@@ -484,6 +487,7 @@ rstatus_t msg_prepend_format(struct msg *msg, const char *fmt, ...);
 
 uint8_t *msg_get_tagged_key(struct msg *req, uint32_t key_index, uint32_t *keylen);
 uint8_t *msg_get_full_key(struct msg *req, uint32_t key_index, uint32_t *keylen);
+uint8_t* msg_get_full_key_copy(struct msg* msg, int idx, uint32_t *keylen);
 
 struct msg *req_get(struct conn *conn);
 void req_put(struct msg *msg);

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1623,3 +1623,12 @@ memcache_reconcile_responses(struct response_mgr *rspmgr)
         return rsp;
     }
 }
+
+/*
+ * Placeholder function for memcache query rewrites.
+ * No rewrites implemented toady.
+ */
+rstatus_t memcache_rewrite_query(struct msg* orig_msg, struct context* ctx, bool* did_rewrite,
+        struct msg** new_msg_ptr) {
+    return DN_OK;
+}

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -39,6 +39,8 @@ rstatus_t memcache_fragment(struct msg *r, struct server_pool *pool, struct rack
                          struct msg_tqh *frag_msgq);
 rstatus_t memcache_verify_request(struct msg *r, struct server_pool *pool,
                                   struct rack *rack);
+rstatus_t memcache_rewrite_query(struct msg* orig_msg, struct context* ctx, bool* did_rewrite,
+                              struct msg** new_msg_ptr);
 
 void redis_parse_req(struct msg *r, const struct string *hash_tag);
 void redis_parse_rsp(struct msg *r, const struct string *UNUSED);
@@ -50,5 +52,7 @@ rstatus_t redis_fragment(struct msg *r, struct server_pool *pool, struct rack *r
                          struct msg_tqh *frag_msgq);
 rstatus_t redis_verify_request(struct msg *r, struct server_pool *pool,
                                struct rack *rack);
+rstatus_t redis_rewrite_query(struct msg* orig_msg, struct context* ctx, bool* did_rewrite,
+                              struct msg** new_msg_ptr);
 
 #endif

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -369,6 +369,99 @@ redis_error(struct msg *r)
 }
 
 /*
+ * Detects the query and does a rewrite if applicable.
+ *
+ * Currently the following queries are rewritten:
+ * 1) SMEMBERS <set> -> SORT <myset> ALPHA (only when DC_SAFE_QUORUM=true)
+ *    We rewrite this query this way since when DC_SAFE_QUORUM is enabled,
+ *    we run this query on multiple nodes and take checksums and compare that
+ *    they're the same. Since SMEMBERS offers no ordering guarantee, even though
+ *    the elements are the same, the order of elements in the set might be
+ *    different causing the checksums to be different and hence causing the
+ *    query to fail. Rewriting it to a SORT query ensures ordering and thus
+ *    ensures that the checksum comparison succeeds.
+ *
+ * * Sets *did_rewrite='true' if a rewrite occured and 'false' if not.
+ * * Does not modify 'orig_msg' and sets 'new_msg_ptr' to point to the new 'msg' struct with the
+ *   rewritten query if 'did_rewrite' is true.
+ * * Caller must take ownership of the newly allocated msg '*new_msg_ptr'.
+ */
+rstatus_t redis_rewrite_query(struct msg* orig_msg, struct context* ctx, bool* did_rewrite,
+        struct msg** new_msg_ptr) {
+    const char* SMEMBERS_REWRITE_FMT_STRING = "*3\r\n$4\r\nsort\r\n$%d\r\n%s\r\n$5\r\nalpha\r\n";
+
+    ASSERT(orig_msg != NULL);
+    ASSERT(orig_msg->is_request);
+    ASSERT(did_rewrite != NULL);
+
+    *did_rewrite = false;
+
+    struct msg* new_msg = NULL;
+    uint8_t* key = NULL;
+    rstatus_t ret_status = DN_OK;
+    switch (orig_msg->type) {
+        case MSG_REQ_REDIS_SMEMBERS:
+
+            if (orig_msg->owner->read_consistency == DC_SAFE_QUORUM) {
+                // SMEMBERS should have only one key.
+                ASSERT(orig_msg->nkeys == 1);
+
+                // Get a new 'msg' structure.
+                new_msg = msg_get(orig_msg->owner, true, __FUNCTION__);
+                if (new_msg == NULL) {
+                    ret_status = DN_ENOMEM;
+                    goto error;
+                }
+
+                uint32_t keylen;
+                // Get a copy of the key from 'orig_msg'.
+                key = msg_get_full_key_copy(orig_msg, 0, &keylen);
+                if (key == NULL) {
+                    ret_status = DN_ENOMEM;
+                    goto error;
+                }
+
+                // Write the new command into 'new_msg'
+                rstatus_t prepend_status = msg_prepend_format(new_msg, SMEMBERS_REWRITE_FMT_STRING, keylen, key);
+                if (prepend_status != DN_OK) {
+                    ret_status = prepend_status;
+                    goto error;
+                }
+
+                {
+                    // Point the 'pos' pointer in 'new_msg' to the mbuf we've added.
+                    struct mbuf* new_mbuf = STAILQ_LAST(&new_msg->mhdr, mbuf, next);
+                    new_msg->pos = new_mbuf->pos;
+                }
+                // Parse the message 'new_msg' to populate all of its appropriate fields.
+                new_msg->parser(new_msg, &ctx->pool.hash_tag);
+                // Check if 'new_msg' was parsed successfully.
+                if (new_msg->result != MSG_PARSE_OK) {
+                    ret_status = DN_ERROR;
+                    goto error;
+                }
+
+                *new_msg_ptr = new_msg;
+                *did_rewrite = true;
+                goto done;
+            }
+            break;
+        default:
+            return DN_OK;
+    }
+
+error:
+    if (key != NULL) dn_free(key);
+    // Return the newly allocated message back to the free message queue.
+    if (new_msg != NULL) msg_put(new_msg);
+    return ret_status;
+
+done:
+    if (key != NULL) dn_free(key);
+    return DN_OK;
+}
+
+/*
  * Reference: http://redis.io/topics/protocol
  *
  * Redis >= 1.2 uses the unified protocol to send requests to the Redis


### PR DESCRIPTION
Although the data written to the same set in different replics will be
the same, the order in which they're returned in each replica might
be different. This causes the checksums of each replica set to be
different, causing SMEMBERS to fail under DC_SAFE_QUORUM.

This patch addresses this by rewriting all SMEMBERS calls to the
following (only when DC_SAFE_QUORUM is set):
 * SMEMBERS <set> -> SORT <set> ALPHA

This ensures that the returned set is in the same order across replicas
and hence ensures that their checksums match.

A mini-framework for rewriting queries is introduced to make future
query rewrites easier. Note that this is different from query
fragmenting which already exists today for queries like MGET.