### PR TITLE
Fix some cyclic #includes and remove global dependence on dyn_core.h

### DIFF
--- a/src/dyn_array.c
+++ b/src/dyn_array.c
@@ -20,9 +20,12 @@
  * limitations under the License.
  */
 
+#include "dyn_array.h"
+
 #include <stdlib.h>
 
 #include "dyn_core.h"
+#include "dyn_util.h"
 
 struct array *
 array_create(uint32_t n, size_t size)

--- a/src/dyn_array.h
+++ b/src/dyn_array.h
@@ -20,12 +20,10 @@
  * limitations under the License.
  */
 
-#include "dyn_core.h"
-
-
 #ifndef _DYN_ARRAY_H_
 #define _DYN_ARRAY_H_
 
+#include "dyn_types.h"
 
 typedef int (*array_compare_t)(const void *, const void *);
 typedef rstatus_t (*array_each_t)(void *elem);

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -27,17 +27,18 @@
  * Set default configuration values, parse dynomite.yaml, and update the various
  * configuration structs including connections and server pool.
  */
+#ifndef _DYN_CONF_H_
+#define _DYN_CONF_H_
+
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <yaml.h>
 
-#include "dyn_core.h"
+#include "dyn_array.h"
+#include "dyn_string.h"
+#include "dyn_util.h"
 #include "hashkit/dyn_hashkit.h"
-
-
-#ifndef _DYN_CONF_H_
-#define _DYN_CONF_H_
 
 #define CONF_DEFAULT_PEERS                   200
 #define CONF_DEFAULT_ENV                     "aws"

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -36,7 +36,13 @@
  
 #ifndef _DYN_CONNECTION_H_
 #define _DYN_CONNECTION_H_
-#include "dyn_core.h"
+
+#include <sys/socket.h>
+
+#include "dyn_message.h"
+#include "dyn_queue.h"
+#include "dyn_string.h"
+#include "dyn_types.h"
 
 #define MAX_CONN_QUEUE_SIZE           20000
 #define MAX_CONN_ALLOWABLE_NON_RECV   5

--- a/src/dyn_connection_internal.c
+++ b/src/dyn_connection_internal.c
@@ -19,6 +19,9 @@
 
 #include "dyn_connection_internal.h"
 #include "dyn_connection_pool.h"
+#include "dyn_core.h"
+#include "dyn_setting.h"
+#include "dyn_util.h"
 #include "event/dyn_event.h"
 
 static uint32_t nfree_connq;       /* # free conn q */

--- a/src/dyn_connection_internal.h
+++ b/src/dyn_connection_internal.h
@@ -1,5 +1,11 @@
 #pragma once
-#include "dyn_core.h"
+
+#include "dyn_types.h"
+
+// Forward declarations.
+struct conn;
+struct context;
+
 extern void _conn_deinit(void);
 extern void _conn_init(void);
 extern struct conn *_conn_get(void);

--- a/src/dyn_connection_pool.h
+++ b/src/dyn_connection_pool.h
@@ -2,6 +2,7 @@
 
 #include "dyn_connection.h"
 #include "dyn_types.h"
+
 //struct conn_pool;
 typedef struct conn_pool conn_pool_t;
 

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -63,68 +63,46 @@
 # define DN_HAVE_BACKTRACE 1
 #endif
 
-#define DN_NOOPS     1
-#define DN_OK        0
-#define DN_ERROR    -1
-#define DN_EAGAIN   -2
-#define DN_ENOMEM   -3
-#define DN_ENO_IMPL -4
-
-
-typedef int rstatus_t; /* return type */
-typedef int err_t;     /* error type */
-
-#define THROW_STATUS(s)                                             \
-                {                                                   \
-                    rstatus_t __ret = (s);                          \
-                    if (__ret != DN_OK) {                           \
-                        log_debug(LOG_WARN, "failed "#s);           \
-                        return __ret;                               \
-                    }                                               \
-                }
-
-#define IGNORE_RET_VAL(x) x;
-
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <pthread.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <stdbool.h>
-#include <inttypes.h>
 #include <string.h>
-#include <errno.h>
-#include <limits.h>
 #include <time.h>
 #include <unistd.h>
-#include <pthread.h>
 
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <sys/time.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/un.h>
 
-#include "dyn_types.h"
 #include "dyn_array.h"
-#include "dyn_dict.h"
-#include "dyn_string.h"
-#include "dyn_queue.h"
-#include "dyn_rbtree.h"
-#include "dyn_log.h"
-#include "dyn_util.h"
-#include "dyn_stats.h"
-#include "dyn_mbuf.h"
-#include "dyn_message.h"
+#include "dyn_cbuf.h"
 #include "dyn_connection.h"
 #include "dyn_connection_pool.h"
-#include "dyn_cbuf.h"
-#include "dyn_ring_queue.h"
 #include "dyn_crypto.h"
+#include "dyn_dict.h"
+#include "dyn_log.h"
+#include "dyn_mbuf.h"
+#include "dyn_message.h"
+#include "dyn_queue.h"
+#include "dyn_rbtree.h"
+#include "dyn_ring_queue.h"
 #include "dyn_setting.h"
+#include "dyn_stats.h"
+#include "dyn_string.h"
+#include "dyn_types.h"
+#include "dyn_util.h"
+#include "hashkit/dyn_hashkit.h"
 
 #include "entropy/dyn_entropy.h"
 
 #define ENCRYPTION 1
-typedef rstatus_t (*hash_func_t)(const unsigned char *, size_t, struct dyn_token *);
 
 typedef enum dyn_state {
 	INIT        = 0,

--- a/src/dyn_crypto.h
+++ b/src/dyn_crypto.h
@@ -21,11 +21,15 @@
 #include <openssl/rand.h>
 
 
-#include "dyn_core.h"
+#include "dyn_types.h"
 
 
 #define AES_KEYLEN 32
 
+// Forward declarations
+struct mbuf;
+struct msg;
+struct server_pool;
 
 rstatus_t crypto_init(struct server_pool *sp);
 rstatus_t crypto_deinit(void);

--- a/src/dyn_dnode_client.h
+++ b/src/dyn_dnode_client.h
@@ -3,11 +3,11 @@
  * Copyright (C) 2014 Netflix, Inc.
  */ 
 
-#include "dyn_core.h"
-
-
 #ifndef _DYN_DNODE_CLIENT_H_
 #define _DYN_DNODE_CLIENT_H_
+
+// Forward declarations
+struct conn;
 
 void init_dnode_client_conn(struct conn *conn);
 

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -5,9 +5,10 @@
 
 #include <ctype.h>
 
+#include "dyn_dnode_msg.h"
+
 #include "dyn_core.h"
 #include "dyn_crypto.h"
-#include "dyn_dnode_msg.h"
 #include "dyn_server.h"
 #include "proto/dyn_proto.h"
 

--- a/src/dyn_dnode_msg.h
+++ b/src/dyn_dnode_msg.h
@@ -3,12 +3,13 @@
  * Copyright (C) 2014 Netflix, Inc.
  */ 
 
-#include "dyn_core.h"
-
-
 #ifndef _DYN_DNODE_MSG_H_
 #define _DYN_DNODE_MSG_H_
 
+#include <stdbool.h>
+
+#include "dyn_queue.h"
+#include "dyn_types.h"
 
 typedef enum dmsg_version {
     VERSION_10 = 1

--- a/src/dyn_dnode_peer.h
+++ b/src/dyn_dnode_peer.h
@@ -2,15 +2,20 @@
  * Dynomite - A thin, distributed replication layer for multi non-distributed storages.
  * Copyright (C) 2014 Netflix, Inc.
  */ 
-#include "dyn_core.h"
-#include "dyn_server.h"
-
 
 #ifndef _DYN_DNODE_PEER_H_
 #define _DYN_DNODE_PEER_H_
 
+#include "dyn_message.h"
+#include "dyn_types.h"
+
 #define MAX_WAIT_BEFORE_RECONNECT_IN_SECS    10
 #define WAIT_BEFORE_UPDATE_PEERS_IN_MILLIS   30000
+
+// Forward declarations
+struct context;
+struct msg;
+struct rack;
 
 msec_t dnode_peer_timeout(struct msg *msg, struct conn *conn);
 rstatus_t dnode_initialize_peers(struct context *ctx);

--- a/src/dyn_dnode_proxy.h
+++ b/src/dyn_dnode_proxy.h
@@ -4,13 +4,17 @@
  */ 
 
 
-#include "dyn_core.h"
-
 #ifndef _DYN_DNODE_SERVER_H_
 #define _DYN_DNODE_SERVER_H_
+
+#include "dyn_types.h"
+
+//Forward declarations
+struct conn;
+struct context;
 
 rstatus_t dnode_proxy_init(struct context *ctx);
 void dnode_proxy_deinit(struct context *ctx);
 void init_dnode_proxy_conn(struct conn *conn);
-#endif
 
+#endif

--- a/src/dyn_gossip.h
+++ b/src/dyn_gossip.h
@@ -1,9 +1,10 @@
-#include "hashkit/dyn_token.h"
-#include "dyn_core.h"
-#include "dyn_dict.h"
-
 #ifndef DYN_GOSSIP_H_
 #define DYN_GOSSIP_H_
+
+#include "hashkit/dyn_token.h"
+#include "dyn_array.h"
+#include "dyn_dict.h"
+#include "dyn_string.h"
 
 
 #define GOS_NOOPS     1

--- a/src/dyn_mbuf.h
+++ b/src/dyn_mbuf.h
@@ -19,12 +19,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dyn_core.h"
 
 #ifndef _DYN_MBUF_H_
 #define _DYN_MBUF_H_
 
+#include <stdio.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
+#include "dyn_queue.h"
 
 typedef void (*func_mbuf_copy_t)(struct mbuf *, void *);
 

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -23,8 +23,13 @@
 #ifndef _DYN_MESSAGE_H_
 #define _DYN_MESSAGE_H_
 
-#include "dyn_core.h"
+#include <string.h>
+
+#include "dyn_dict.h"
 #include "dyn_dnode_msg.h"
+#include "dyn_queue.h"
+#include "dyn_mbuf.h"
+#include "dyn_rbtree.h"
 #include "dyn_response_mgr.h"
 #include "dyn_types.h"
 

--- a/src/dyn_node_snitch.h
+++ b/src/dyn_node_snitch.h
@@ -1,10 +1,9 @@
 
-#include "dyn_core.h"
-
-
 #ifndef _DYN_SNITCH_H_
 #define _DYN_SNITCH_H_
 
+// Forward declarations
+struct server_pool;
 
 unsigned char *get_broadcast_address(struct server_pool *sp);
 char *get_public_hostname(struct server_pool *sp);

--- a/src/dyn_proxy.h
+++ b/src/dyn_proxy.h
@@ -19,11 +19,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "dyn_core.h"
-
 
 #ifndef _DYN_PROXY_H_
 #define _DYN_PROXY_H_
+
+#include "dyn_types.h"
+
+// Forward declarations
+struct conn;
+struct context;
 
 rstatus_t proxy_init(struct context *ctx);
 void proxy_deinit(struct context *ctx);

--- a/src/dyn_server.h
+++ b/src/dyn_server.h
@@ -23,8 +23,14 @@
 #ifndef _DYN_SERVER_H_
 #define _DYN_SERVER_H_
 
-#include "dyn_core.h"
 #include "dyn_dict.h"
+#include "dyn_types.h"
+
+// Forward declarations
+struct conf_pool;
+struct context;
+struct datastore;
+struct server_pool;
 
 /*
  * server_pool is a collection of servers and their continuum. Each

--- a/src/dyn_signal.h
+++ b/src/dyn_signal.h
@@ -21,11 +21,10 @@
  */
 
 
-#include "dyn_core.h"
-
 #ifndef _DYN_SIGNAL_H_
 #define _DYN_SIGNAL_H_
 
+#include "dyn_types.h"
 
 /**
  * @brief POSIX signal

--- a/src/dyn_stats.h
+++ b/src/dyn_stats.h
@@ -20,14 +20,16 @@
  * limitations under the License.
  */
 
-#include "dyn_core.h"
-#include "dyn_histogram.h"
-
-
 #ifndef _DYN_STATS_H_
 #define _DYN_STATS_H_
 
+#include "dyn_array.h"
+#include "dyn_histogram.h"
+#include "dyn_string.h"
 
+// Forward declarations
+struct context;
+struct server_pool;
 
 #define STATS_POOL_CODEC(ACTION)                                                                                          \
     /* client behavior */                                                                                                 \

--- a/src/dyn_string.h
+++ b/src/dyn_string.h
@@ -23,9 +23,10 @@
 #ifndef _DYN_STRING_H_
 #define _DYN_STRING_H_
 
+#include <stdbool.h>
 #include <string.h>
 
-#include "dyn_core.h"
+#include "dyn_types.h"
 
 struct string {
     uint32_t len;   /* string length */

--- a/src/dyn_task.c
+++ b/src/dyn_task.c
@@ -1,5 +1,9 @@
 #include "dyn_task.h"
 
+#include <stdbool.h>
+
+#include "dyn_util.h"
+
 /**
  * This is a generic task manager. There was a increasing demand in Dynomite to
  * create a module to schedule task a specific times. For example reconnecting

--- a/src/dyn_task.h
+++ b/src/dyn_task.h
@@ -1,6 +1,8 @@
+#ifndef _DYN_TASK_H_
+#define _DYN_TASK_H_
+
 #include "dyn_rbtree.h"
 #include "dyn_types.h"
-#include "dyn_core.h"
 
 struct task;
 
@@ -29,3 +31,5 @@ void execute_expired_tasks(uint32_t limit);
 /* Cancel the provided task. The caller should keep track of the tasks scheduled
  * and use it to cancel */
 void cancel_task(struct task *task);
+
+#endif /* _DYN_TASK_H_ */

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -1,10 +1,33 @@
 #pragma once
 #include <stdint.h>
 #include <stdlib.h>
+
+#define DN_NOOPS     1
+#define DN_OK        0
+#define DN_ERROR    -1
+#define DN_EAGAIN   -2
+#define DN_ENOMEM   -3
+#define DN_ENO_IMPL -4
+
+
+#define THROW_STATUS(s)                                             \
+                {                                                   \
+                    rstatus_t __ret = (s);                          \
+                    if (__ret != DN_OK) {                           \
+                        log_debug(LOG_WARN, "failed "#s);           \
+                        return __ret;                               \
+                    }                                               \
+                }
+
+#define IGNORE_RET_VAL(x) x;
+
 typedef uint64_t msgid_t;
 typedef uint64_t msec_t;
 typedef uint64_t usec_t;
 typedef uint64_t sec_t;
+
+typedef int rstatus_t; /* return type */
+typedef int err_t;     /* error type */
 
 typedef enum {
     SECURE_OPTION_NONE,

--- a/src/dyn_util.h
+++ b/src/dyn_util.h
@@ -23,7 +23,11 @@
 #ifndef _DYN_UTIL_H_
 #define _DYN_UTIL_H_
 
+#include <netinet/in.h>
+#include <stdbool.h>
 #include <stdarg.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 #define LF                  (uint8_t) 10
 #define CR                  (uint8_t) 13

--- a/src/entropy/dyn_entropy.h
+++ b/src/entropy/dyn_entropy.h
@@ -16,8 +16,11 @@
  */
 
 
+#ifndef _DYN_ENTROPY_H_
+#define _DYN_ENTROPY_H_
 
-#include "dyn_core.h"
+#include "../dyn_string.h"
+#include "../dyn_types.h"
 
 #define ENTROPY_ADDR      "127.0.0.1"
 #define ENTROPY_PORT      8105
@@ -57,4 +60,4 @@ rstatus_t entropy_key_iv_load(struct context *ctx);
 rstatus_t entropy_snd_start(int peer_socket, int header_size, int buffer_size, int cipher_size);
 rstatus_t entropy_rcv_start(int peer_socket, int header_size, int buffer_size, int cipher_size);
 
-
+#endif /* _DYN_ENTROPY_H_ */

--- a/src/event/dyn_event.h
+++ b/src/event/dyn_event.h
@@ -20,11 +20,11 @@
  * limitations under the License.
  */
 
-#include <dyn_core.h>
-
 #ifndef _DN_EVENT_H_
 #define _DN_EVENT_H_
 
+// Forward declarations
+struct conn;
 
 #define EVENT_SIZE  1024
 

--- a/src/hashkit/dyn_crc32.c
+++ b/src/hashkit/dyn_crc32.c
@@ -27,9 +27,10 @@
  * src/usr.bin/cksum/crc32.c.
  */
 
-#include <dyn_core.h>
-#include <dyn_token.h>
 #include <ctype.h>
+
+#include "dyn_token.h"
+#include "../dyn_types.h"
 
 static const uint32_t crc32tab[256] = {
     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba,

--- a/src/hashkit/dyn_hashkit.c
+++ b/src/hashkit/dyn_hashkit.c
@@ -1,5 +1,7 @@
 #include "dyn_hashkit.h"
 
+#include "../dyn_string.h"
+
 #define DEFINE_ACTION(_hash, _name) string(#_name),
 struct string hash_strings[] = {
     HASH_CODEC( DEFINE_ACTION )

--- a/src/hashkit/dyn_hashkit.h
+++ b/src/hashkit/dyn_hashkit.h
@@ -19,12 +19,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <dyn_core.h>
-#include <dyn_server.h>
-
 
 #ifndef _DYN_HASHKIT_H_
 #define _DYN_HASHKIT_H_
+
+#include "../dyn_types.h"
+
+// Forward declarations
+struct dyn_token;
+struct string;
+
+typedef rstatus_t (*hash_func_t)(const unsigned char *, size_t, struct dyn_token *);
 
 void md5_signature(const unsigned char *key, unsigned int length, unsigned char *result);
 

--- a/src/hashkit/dyn_md5.c
+++ b/src/hashkit/dyn_md5.c
@@ -20,8 +20,7 @@
  * limitations under the License.
  */
 
-#include <dyn_token.h>
-#include <dyn_core.h>
+#include "dyn_token.h"
 
 /*
  * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.

--- a/src/hashkit/dyn_token.c
+++ b/src/hashkit/dyn_token.c
@@ -23,6 +23,10 @@
 #include <stdint.h>
 #include <stddef.h>
 #include "dyn_token.h"
+#include "../dyn_array.h"
+#include "../dyn_log.h"
+#include "../dyn_string.h"
+#include "../dyn_util.h"
 
 /* bitsPerDigit radix of 10 multiplied by 1024, rounded up to avoid underallocation */
 #define BITS_PER_DIGIT 3402

--- a/src/hashkit/dyn_token.h
+++ b/src/hashkit/dyn_token.h
@@ -4,11 +4,13 @@
  */ 
 
 
-#include "dyn_core.h"
-
 #ifndef _DYN_TOKEN_H_
 #define _DYN_TOKEN_H_
 
+#include "../dyn_types.h"
+
+// Forward declarations
+struct array;
 
 struct dyn_token {
     uint32_t signum;

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -20,13 +20,21 @@
  * limitations under the License.
  */
 
-#include <dyn_core.h>
-
-
 #ifndef _DN_PROTO_H_
 #define _DN_PROTO_H_
 
+#include <stdbool.h>
 
+#include "../dyn_types.h"
+
+// Forward declarations
+struct context;
+struct msg;
+struct msg_tqh;
+struct rack;
+struct response_mgr;
+struct server_pool;
+struct string;
 
 
 void memcache_parse_req(struct msg *r, const struct string *hash_tag);

--- a/src/seedsprovider/dyn_seeds_provider.h
+++ b/src/seedsprovider/dyn_seeds_provider.h
@@ -1,12 +1,12 @@
 
-#include "dyn_core.h"
-
-
 #ifndef _DYN_SEEDS_PROVIDER_H_
 #define _DYN_SEEDS_PROVIDER_H_
 
-
 #define SEEDS_CHECK_INTERVAL  (30 * 1000) /* in msec */
+
+// Forward declarations
+struct context;
+struct mbuf;
 
 
 uint8_t florida_get_seeds(struct context * ctx, struct mbuf *seeds_buf);

--- a/src/tools/dyn_hash_tool.c
+++ b/src/tools/dyn_hash_tool.c
@@ -1,6 +1,11 @@
-#include<stdio.h>
+#include <errno.h>
 #include <getopt.h>
-#include <dyn_token.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "../dyn_log.h"
+#include "../hashkit/dyn_token.h"
+
 static struct option long_options[] = {
     { "help",                 no_argument,        NULL,   'h' },
     { "outputkey",           no_argument,        NULL,   'k' },


### PR DESCRIPTION
The way we do #includes is completely broken as a result of forking
from twemproxy. A few of the issues I noticed and fixed are:

* Cyclic includes:
    dyn_core.h includes every other header and every other header
    includes dyn_core.h. I fixed this by moving fundamental types
    like rstatus_t and DN_* error codes to dyn_types.h.
    dyn_types.h contains the fundamental types used by most files
    and all these files include dyn_types.h now instead. dyn_types.h
    does not include any other Dynomite file.

* Forward declarations where possible:
    A lot of files were unnecessarily including headers that they don't
    use or need. I removed as many as I noticed and added forward
    declares where necessary.

* Added missing include guards
* Changed to using relative path for #includes that are Dynomite
  specific:
    Eg: #include <dyn_token.h> changed to #include "dyn_token.h"

* Moved #includes inside include guards.

As the project matures, following these best practices will keep
the compilation times reasonably low, and avoid surprise
compilation issues while adding new files/directories.