### PR TITLE
dyn_stats.c max_buf_size 65535

### DIFF
--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -980,7 +980,7 @@ stats_make_cl_desc_rsp(struct stats *st)
 static void
 parse_request(int sd, struct stats_cmd *st_cmd)
 {
-    size_t max_buf_size = 99999;
+    size_t max_buf_size = 65535;
     char mesg[max_buf_size], *reqline[3];
     int rcvd;
 


### PR DESCRIPTION
Fix https://github.com/Netflix/dynomite/issues/600 with support for Musl libc (e.g. for Alpine) with a 80k thread stack limit.

https://wiki.musl-libc.org/functional-differences-from-glibc.html#Thread_stack_size