### PR TITLE
Add support for sysconfdir for default config place

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,19 +194,6 @@ AS_IF([test "x$disable_stats" = xyes],
   [AC_DEFINE([HAVE_STATS], [1], [Define to 1 if stats is not disabled])])
 AC_MSG_RESULT($disable_stats)
 
-AC_ARG_ENABLE([packaging],
-  [AS_HELP_STRING(
-    [--enable-packaging],
-    [apply packaging standards])
-  ],
-  [enable_packaging=yes],
-  [enable_packaging=no])
-AS_IF(
-  [test "x$enable_packaging" = xyes],
-  [AC_DEFINE([PACKAGING], [1], [Define to 1 if packaging is enabled])],
-  [])
-AC_MSG_RESULT($enable_packaging)
-
 # Untar the yaml-0.1.4 in contrib/ before config.status is rerun
 AC_CONFIG_COMMANDS_PRE([tar xvfz contrib/yaml-0.1.4.tar.gz -C contrib])
 

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,19 @@ AS_IF([test "x$disable_stats" = xyes],
   [AC_DEFINE([HAVE_STATS], [1], [Define to 1 if stats is not disabled])])
 AC_MSG_RESULT($disable_stats)
 
+AC_ARG_ENABLE([packaging],
+  [AS_HELP_STRING(
+    [--enable-packaging],
+    [apply packaging standards])
+  ],
+  [enable_packaging=yes],
+  [enable_packaging=no])
+AS_IF(
+  [test "x$enable_packaging" = xyes],
+  [AC_DEFINE([PACKAGING], [1], [Define to 1 if packaging is enabled])],
+  [])
+AC_MSG_RESULT($enable_packaging)
+
 # Untar the yaml-0.1.4 in contrib/ before config.status is rerun
 AC_CONFIG_COMMANDS_PRE([tar xvfz contrib/yaml-0.1.4.tar.gz -C contrib])
 
@@ -206,7 +219,7 @@ AC_CONFIG_FILES([Makefile
                  src/Makefile
                  src/hashkit/Makefile
                  src/proto/Makefile
-                 src/entropy/Makefile                 
+                 src/entropy/Makefile
                  src/seedsprovider/Makefile
                  src/event/Makefile
                  src/tools/Makefile])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,6 +4,7 @@ AM_CPPFLAGS =
 if !OS_SOLARIS
 AM_CPPFLAGS += -D_GNU_SOURCE
 endif
+AM_CPPFLAGS += -DSYSCONFDIR="\"$(sysconfdir)\""
 AM_CPPFLAGS += -I $(top_srcdir)/src/hashkit
 AM_CPPFLAGS += -I $(top_srcdir)/src/proto
 AM_CPPFLAGS += -I $(top_srcdir)/src/event

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -35,10 +35,10 @@
 #include "dyn_core.h"
 #include "dyn_signal.h"
 
-#if !defined(PACKAGING)
-#define DN_CONF_PATH "conf/dynomite.yml"
-#else
+#if defined(SYSCONFDIR)
 #define DN_CONF_PATH SYSCONFDIR "/dynomite.yml"
+#else
+#define DN_CONF_PATH "conf/dynomite.yml"
 #endif
 
 #define DN_LOG_DEFAULT LOG_NOTICE

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -35,7 +35,11 @@
 #include "dyn_core.h"
 #include "dyn_signal.h"
 
+#if !defined(PACKAGING)
 #define DN_CONF_PATH "conf/dynomite.yml"
+#else
+#define DN_CONF_PATH SYSCONFDIR "/dynomite.yml"
+#endif
 
 #define DN_LOG_DEFAULT LOG_NOTICE
 #define DN_LOG_MIN LOG_EMERG


### PR DESCRIPTION
By running of `./configure --sysconfdir="/etc/dynomite" --enable-packaging` default config will be another for now:
```
>±> ./src/dynomite -h  2>&1| grep conf-file
  -c, --conf-file=S            : set configuration file (default: /etc/dynomite/dynomite.yml)
```

This PR is related to #436 