### PR TITLE
Error responses should contain mbufs with appropriate error strings

### DIFF
--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -302,7 +302,13 @@ static void dnode_peer_ack_err(struct context *ctx, struct conn *conn,
   // Create an appropriate response for the request so its propagated up;
   // This response gets dropped in rsp_make_error anyways. But since this is
   // an error path its ok with the overhead.
-  struct msg *rsp = msg_get(conn, false, __FUNCTION__);
+  struct msg *rsp = msg_get_error(conn, PEER_CONNECTION_REFUSE, conn->err);
+  if (rsp == NULL) {
+    // TODO: It's not clear how the peer should behave if we hit this error
+    // condition. Return an appropriate error instead.
+    log_warn("Could not allocate msg for notifying an error to peer");
+    return;
+  }
   req->done = 1;
   rsp->peer = req;
   rsp->is_error = req->is_error = 1;

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -182,9 +182,11 @@ static void server_ack_err(struct context *ctx, struct conn *conn,
   // Create an appropriate response for the request so its propagated up;
   // This response gets dropped in rsp_make_error anyways. But since this is
   // an error path its ok with the overhead.
-  struct msg *rsp = msg_get(conn, false, __FUNCTION__);
+  struct msg *rsp = msg_get_error(conn, STORAGE_CONNECTION_REFUSE, conn->err);
   if (rsp == NULL) {
-    log_warn("Could not allocate msg.");
+    // TODO: It's not clear how the client should behave if we hit this error
+    // condition. Return an appropriate error instead.
+    log_warn("Could not allocate msg for notifying an error to the client.");
     return;
   }
   req->done = 1;


### PR DESCRIPTION
We've noticed that when the outstanding message queue for a connection
(conn->omsg_q) reaches the MAX_CONN_QUEUE_SIZE, we set the
ENOTRECOVERABLE state. This eventually leads a server to call
server_ack_err() which sends a error response message (struct msg*)
back to the client. This message however does not contain a mbuf
with an error string, causing failures in the client.

Eg: The dyn_dnode_client tries to encrypt this empty message in
dnode_rsp_send_next(), which returns an error and eventually
leads to a crash later on.

This patch fixes this by filling in these error responses with
a valid mbuf which contains an error string.

No further cleanup is done here, however, some clean up needs to
be done around this code in the future.