### PR TITLE
Fix omission of Debug flags via #include in dyn_queue.h

### DIFF
--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -23,64 +23,6 @@
 #ifndef _DYN_CORE_H_
 #define _DYN_CORE_H_
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
-#ifdef HAVE_DEBUG_LOG
-#define DN_DEBUG_LOG 1
-#endif
-
-#ifdef HAVE_ASSERT_PANIC
-#define DN_ASSERT_PANIC 1
-#endif
-
-#ifdef HAVE_ASSERT_LOG
-#define DN_ASSERT_LOG 1
-#endif
-
-#ifdef HAVE_STATS
-#define DN_STATS 1
-#else
-#define DN_STATS 0
-#endif
-
-#ifdef HAVE_EPOLL
-#define DN_HAVE_EPOLL 1
-#elif HAVE_KQUEUE
-#define DN_HAVE_KQUEUE 1
-#elif HAVE_EVENT_PORTS
-#define DN_HAVE_EVENT_PORTS 1
-#else
-#error missing scalable I/O event notification mechanism
-#endif
-
-#ifdef HAVE_LITTLE_ENDIAN
-#define DN_LITTLE_ENDIAN 1
-#endif
-
-#ifdef HAVE_BACKTRACE
-#define DN_HAVE_BACKTRACE 1
-#endif
-
-#include <errno.h>
-#include <inttypes.h>
-#include <limits.h>
-#include <pthread.h>
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-#include <time.h>
-#include <unistd.h>
-
-#include <netinet/in.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <sys/un.h>
-
 #include "dyn_array.h"
 #include "dyn_cbuf.h"
 #include "dyn_connection.h"

--- a/src/dyn_queue.h
+++ b/src/dyn_queue.h
@@ -51,11 +51,13 @@
  *    @(#)queue.h    8.5 (Berkeley) 8/20/94
  * $FreeBSD: src/sys/sys/queue.h,v 1.73 2010/02/20 01:05:30 emaste Exp $
  */
-#include <stdint.h>
-#include "dyn_log.h"
 
 #ifndef _DYN_QUEUE_H_
 #define _DYN_QUEUE_H_
+
+#include <stdint.h>
+#include "dyn_log.h"
+#include "dyn_types.h"
 
 #ifndef __offsetof
 #define __offsetof(type, field) ((size_t)(&((type *)NULL)->field))

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -1,6 +1,63 @@
 #pragma once
-#include <stdint.h>
+
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <pthread.h>
 #include <stdlib.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/un.h>
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#ifdef HAVE_DEBUG_LOG
+#define DN_DEBUG_LOG 1
+#endif
+
+#ifdef HAVE_ASSERT_PANIC
+#define DN_ASSERT_PANIC 1
+#endif
+
+#ifdef HAVE_ASSERT_LOG
+#define DN_ASSERT_LOG 1
+#endif
+
+#ifdef HAVE_STATS
+#define DN_STATS 1
+#else
+#define DN_STATS 0
+#endif
+
+#ifdef HAVE_EPOLL
+#define DN_HAVE_EPOLL 1
+#elif HAVE_KQUEUE
+#define DN_HAVE_KQUEUE 1
+#elif HAVE_EVENT_PORTS
+#define DN_HAVE_EVENT_PORTS 1
+#else
+#error missing scalable I/O event notification mechanism
+#endif
+
+#ifdef HAVE_LITTLE_ENDIAN
+#define DN_LITTLE_ENDIAN 1
+#endif
+
+#ifdef HAVE_BACKTRACE
+#define DN_HAVE_BACKTRACE 1
+#endif
+
 
 #define DN_NOOPS 1
 #define DN_OK 0


### PR DESCRIPTION
We ran into a very strange problem recently with full-debug mode
enabled. On any call to _conn_get(), we expected to get a 'struct conn'
object completely initialized with default values (mostly 0 & NULL).

However, immediately after returning from _conn_get(), certain members
of the object got completely corrupted after the 'retq' instruction
was executed on returning from _conn_get(). This was very confusing
as the retq instruction has no power to overwrite members of that
address which lived in the heap, and there was no overflow of the
stack as well.

Upon further investigation it was found that the size of the
'struct conn' object was completely different in _conn_get() and
in other parts of the code.

sizeof(struct conn) in _conn_get() : 544 bytes
sizeof(struct conn) in other files: 672 bytes

This led me to investigate all individual members of 'struct conn'.
My finding was that any member initialized by 'TAILQ_ENTRY(xyz)'
was basically a struct with a nested debug struct:

 #define TAILQ_ENTRY(type)                                          \
   struct {                                                         \
     struct type *tqe_next;  /* next element */                     \
     struct type **tqe_prev; /* address of previous next element */ \
     TRACEBUF                                                       \
   }

'TRACEBUF' is a struct that's only compiled in full-debug mode. So what
this means is that _conn_get() was interpreting 'struct conn' as the
release version of the object and the rest of the code was interpreting
'struct conn' as the debug version of the object. Hence, _conn_get()
would only allocate memory for the release version of 'struct conn'
which was much smaller than required, and the rest of the code expected
the debug version, hence overwriting other members of the 'struct conn'
returned by _conn_get().

The reason that _conn_get() was interpreting it as the release-version
even though full-debug mode was on, is that after the following commit:
https://github.com/Netflix/dynomite/commit/192af493431208e35f1f673780d29d672bff5072

, the dyn_queue.h file (which contains the definition of 'TRACEBUF'),
lost the connection to dyn_core.h which contained the initializations
of the Debug flags.

To fix this, I moved the debug flag definitions to dyn_types.h, since
we're treating that as the bare-minimum header required for most of the
files (since it doesn't depend on any other dyn_*** file), and included
that in dyn_queue.h. This now allows dyn_connection_internal.h/c to
be aware of Debug mode if it's enabled, hence fixing the above issue.