### PR TITLE
Unnest core initialization functions and add extra error checking

### DIFF
--- a/src/dyn_crypto.c
+++ b/src/dyn_crypto.c
@@ -124,6 +124,10 @@ static rstatus_t aes_init(void) {
   aes_encrypt_ctx = (EVP_CIPHER_CTX *)malloc(sizeof(EVP_CIPHER_CTX));
   aes_decrypt_ctx = (EVP_CIPHER_CTX *)malloc(sizeof(EVP_CIPHER_CTX));
 
+  if (aes_encrypt_ctx == NULL || aes_decrypt_ctx == NULL) {
+    return DN_ENOMEM;
+  }
+
   EVP_CIPHER_CTX_init(aes_encrypt_ctx);
   EVP_CIPHER_CTX_init(aes_decrypt_ctx);
 #else
@@ -171,17 +175,23 @@ rstatus_t crypto_init(struct server_pool *sp) {
 }
 
 rstatus_t crypto_deinit(void) {
+  if (aes_encrypt_ctx != NULL) {
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
-  EVP_CIPHER_CTX_cleanup(aes_encrypt_ctx);
-  EVP_CIPHER_CTX_cleanup(aes_decrypt_ctx);
-  free(aes_encrypt_ctx);
-  free(aes_decrypt_ctx);
+    EVP_CIPHER_CTX_cleanup(aes_encrypt_ctx);
+    free(aes_encrypt_ctx);
 #else
-
-  EVP_CIPHER_CTX_free(aes_encrypt_ctx);
-  EVP_CIPHER_CTX_free(aes_decrypt_ctx);
+    EVP_CIPHER_CTX_free(aes_encrypt_ctx);
 #endif
+  }
 
+  if (aes_decrypt_ctx != NULL) {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    EVP_CIPHER_CTX_cleanup(aes_decrypt_ctx);
+    free(aes_decrypt_ctx);
+#else
+    EVP_CIPHER_CTX_free(aes_decrypt_ctx);
+#endif
+  }
   return DN_OK;
 }
 


### PR DESCRIPTION
The core_start() function intializes everything required for dynomite
to be setup correctly. However, the code had nested all the functions
within core_ctx_create(), which recursively initialized unrelated
structures.

This patch unnests the entire chain which allows for better readability
and it also adds some extra error checking to avoid segfaults when
we fail to allocate memory, etc.