### PR TITLE
Refactor test framework to easily expand on cluster management

### DIFF
--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -1,34 +1,23 @@
 #!/usr/bin/env python3
 from contextlib import ExitStack
-from tempfile import mkdtemp
 from time import sleep
 from urllib.request import urlopen
 import argparse
 import json
 import random
 import sys
+import yaml
 
-from plumbum import LocalPath
 from plumbum import local
 
 from dyno_cluster import DynoCluster
 from func_test import comparison_test
-from utils import generate_ips
+from utils import generate_ips, setup_temp_dir
 from redis_node import RedisNode
 
 REDIS_PORT = 1212
 STATS_PORT = 22222
 SETTLE_TIME = 5
-
-def setup_temp_dir():
-    tempdir = LocalPath(mkdtemp(dir='.', prefix='test_run.'))
-    (tempdir / 'logs').mkdir()
-    confdir = (tempdir / 'conf')
-    confdir.mkdir()
-
-    LocalPath('../../conf/dynomite.pem').symlink(confdir / 'dynomite.pem')
-
-    return tempdir
 
 def main():
     parser = argparse.ArgumentParser(

--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -1,188 +1,24 @@
 #!/usr/bin/env python3
-from collections import namedtuple
 from contextlib import ExitStack
-from contextlib import contextmanager
-from signal import SIGINT
 from tempfile import mkdtemp
 from time import sleep
 from urllib.request import urlopen
 import argparse
 import json
 import random
-import socket
 import sys
-import yaml
 
-from plumbum import FG
-from plumbum import BG
 from plumbum import LocalPath
 from plumbum import local
 
-from ip_util import quad2int
-from ip_util import int2quad
 from dyno_cluster import DynoCluster
-from dyno_node import DynoNode
 from func_test import comparison_test
+from utils import generate_ips
 from redis_node import RedisNode
 
-DYN_O_MITE_DEFAULTS = dict(
-    secure_server_option='datacenter',
-    pem_key_file='conf/dynomite.pem',
-    data_store=0,
-    datastore_connections=1,
-)
-INTERNODE_LISTEN = 8101
-CLIENT_LISTEN = 8102
 REDIS_PORT = 1212
 STATS_PORT = 22222
-BASE_IPADDRESS = quad2int('127.0.1.1')
-RING_SIZE = 2**32
-
 SETTLE_TIME = 5
-
-redis = local.get('./test/_binaries/redis-server', 'redis-server')
-dynomite = local.get('./test/_binaries/dynomite', 'src/dynomite')
-
-@contextmanager
-def launch_redis(ip):
-    logfile = 'logs/redis_{}.log'.format(ip)
-    f = (redis['--bind', ip, '--port', REDIS_PORT] > logfile) & BG(-9)
-    try:
-        yield RedisNode(ip, REDIS_PORT)
-    finally:
-        f.proc.kill()
-        f.wait()
-
-def pick_tokens(count, start_offset):
-    stride = RING_SIZE // count
-    token = start_offset
-    for i in range(count):
-        yield token % RING_SIZE
-        token += stride
-
-def tokens_for_rack(count):
-    offset = random.randrange(0, RING_SIZE)
-    return list(pick_tokens(count, offset))
-
-def tokens_for_dc(racks):
-    return [
-        (name, tokens_for_rack(count))
-        for name, count in racks
-    ]
-
-def tokens_for_cluster(dcs, seed):
-    if seed is not None:
-        random.seed(seed)
-
-    return [
-        (dc['name'], tokens_for_dc(dc['racks']))
-        for dc in dcs
-    ]
-
-
-def dc_count(dc):
-    return sum(count for rack, count in dc)
-
-def generate_ips():
-    state = BASE_IPADDRESS
-    while True:
-        yield int2quad(state)
-        state += 1
-
-class DynoSpec(namedtuple('DynoSpec', 'ip port dc rack token '
-    'local_connections remote_connections seed_string')):
-    """Specifies how to launch a dynomite node"""
-
-    def __new__(cls, ip, port, rack, dc, token, local_connections,
-                remote_connections):
-        seed_string = '{}:{}:{}:{}:{}'.format(ip, port, rack, dc, token)
-        return super(DynoSpec, cls).__new__(cls, ip, port, rack, dc, token,
-            local_connections, remote_connections, seed_string)
-
-    def _generate_config(self, seeds_list):
-        conf = dict(DYN_O_MITE_DEFAULTS)
-        conf['datacenter'] = self.dc
-        conf['rack'] = self.rack
-        dyn_listen = '{}:{}'.format(self.ip, self.port)
-        conf['dyn_listen'] = dyn_listen
-        conf['listen'] = '{}:{}'.format(self.ip, CLIENT_LISTEN)
-
-        # filter out our own seed string
-        conf['dyn_seeds'] = [s for s in seeds_list if s != self.seed_string]
-        conf['servers'] = ['{}:{}:0'.format(self.ip, REDIS_PORT)]
-        conf['stats_listen'] = '{}:{}'.format(self.ip, STATS_PORT)
-        conf['tokens'] = self.token
-        conf['local_peer_connections'] = self.local_connections
-        conf['remote_peer_connections'] = self.remote_connections
-        return dict(dyn_o_mite=conf)
-
-    def write_config(self, seeds_list):
-        config = self._generate_config(seeds_list)
-        filename = 'conf/{}:{}:{}.yml'.format(self.dc, self.rack, self.token)
-        with open(filename, 'w') as fh:
-            yaml.dump(config, fh, default_flow_style=False)
-        return filename
-
-    @contextmanager
-    def launch(self, seeds_list):
-        config_filename = self.write_config(seeds_list)
-
-        with launch_redis(self.ip):
-            logfile = 'logs/dynomite_{}.log'.format(self.ip)
-            dynomite_future = dynomite['-o', logfile, '-c', config_filename,
-                '-v6'] & BG(-9)
-
-            try:
-                yield DynoNode(self.ip)
-            finally:
-                dynomite_future.proc.kill()
-                dynomite_future.wait()
-
-
-@contextmanager
-def launch_dynomite(nodes):
-    seeds_list = [n.seed_string for n in nodes]
-    launched_nodes = [DynoNode(n.ip) for n in nodes]
-    with ExitStack() as stack:
-        launched_nodes = [
-            stack.enter_context(n.launch(seeds_list))
-            for n in nodes
-        ]
-
-        yield DynoCluster(launched_nodes)
-
-def dict_request(request):
-    """Converts the request into an easy to consume dict format.
-
-    We don't ingest the request in this format originally because dict
-    ordering is nondeterministic, and one of our goals is to deterministically
-    generate clusters."""
-    return dict(
-        (dc['name'], dict(dc['racks']))
-        for dc in request
-    )
-
-def sum_racks(dcs):
-    return dict(
-        (name, sum(racks.values()))
-        for name, racks in dcs.items()
-    )
-
-def generate_nodes(request, ips):
-    tokens = tokens_for_cluster(request, None)
-    counts_by_rack = dict_request(request)
-    counts_by_dc = sum_racks(counts_by_rack)
-    total_nodes = sum(counts_by_dc.values())
-    for dc, racks in tokens:
-        dc_count = counts_by_dc[dc]
-        rack_count = counts_by_rack[dc]
-        remote_count = total_nodes - dc_count
-        for rack, tokens in racks:
-            local_count = rack_count[rack] - 1
-            for token in tokens:
-                ip = next(ips)
-                yield DynoSpec(ip, INTERNODE_LISTEN, dc, rack, token,
-                    local_count, remote_count)
 
 def setup_temp_dir():
     tempdir = LocalPath(mkdtemp(dir='.', prefix='test_run.'))
@@ -202,26 +38,36 @@ def main():
         help='YAML file describing desired cluster', nargs='?')
     args = parser.parse_args()
 
-    with open(args.request_file, 'r') as fh:
-        request = yaml.load(fh)
-
+    # Setup a temporary directory to store logs and configs for this cluster.
     temp = setup_temp_dir()
 
+    # Generate IP addresses to be used by the nodes we will create.
     ips = generate_ips()
+
+    # Create a standalone Redis node.
     standalone_redis_ip = next(ips)
-    nodes = list(generate_nodes(request, ips))
+    standalone_redis = RedisNode(standalone_redis_ip, REDIS_PORT)
+
+    # Create a Dynomite cluster.
+    dynomite_cluster = DynoCluster(args.request_file, ips)
 
     with ExitStack() as stack:
-        with local.cwd(temp):
-            redis_info = stack.enter_context(launch_redis(standalone_redis_ip))
-            dynomite_info = stack.enter_context(launch_dynomite(nodes))
+        # Make sure to change the working directory to the temp dir before running the
+        # tests.
+        stack.enter_context(local.cwd(temp))
+        # Launch the standalone Redis node and the dynomite cluster.
+        stack.enter_context(standalone_redis)
+        stack.enter_context(dynomite_cluster)
 
-            sleep(SETTLE_TIME)
-            comparison_test(redis_info, dynomite_info, False)
+        # Wait for a while for the above nodes to start.
+        sleep(SETTLE_TIME)
 
-            random_node = random.choice(dynomite_info.nodes)
-            stats_url = 'http://{}:{}/info'.format(random_node.ip, STATS_PORT)
-            json.loads(urlopen(stats_url).read().decode('ascii'))
+        # Run all the functional comparison tests.
+        comparison_test(standalone_redis, dynomite_cluster, False)
+
+        random_node = random.choice(dynomite_cluster.nodes)
+        stats_url = 'http://{}:{}/info'.format(random_node.ip, STATS_PORT)
+        json.loads(urlopen(stats_url).read().decode('ascii'))
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -23,7 +23,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Autogenerates a Dynomite cluster and runs functional ' +
             'tests against it')
-    parser.add_argument('request_file', default='test/request.yaml',
+    parser.add_argument('request_file', default='test/no_quorum_request.yaml',
         help='YAML file describing desired cluster', nargs='?')
     args = parser.parse_args()
 

--- a/test/dyno_cluster.py
+++ b/test/dyno_cluster.py
@@ -1,10 +1,106 @@
 #!/usr/bin/env python3
+from collections import namedtuple
 import redis
 import random
+import yaml
+
+from dyno_node import DynoNode
+from utils import *
+
+DYN_O_MITE_DEFAULTS = dict(
+    secure_server_option='datacenter',
+    pem_key_file='conf/dynomite.pem',
+    data_store=0,
+    datastore_connections=1,
+)
+INTERNODE_LISTEN = 8101
+CLIENT_LISTEN = 8102
+REDIS_PORT = 1212
+STATS_PORT = 22222
+
+class DynoSpec(namedtuple('DynoSpec', 'ip port dc rack token '
+    'local_connections remote_connections seed_string')):
+    """Specifies how to launch a dynomite node"""
+
+    def __new__(cls, ip, port, rack, dc, token, local_connections,
+                remote_connections):
+        seed_string = '{}:{}:{}:{}:{}'.format(ip, port, rack, dc, token)
+        return super(DynoSpec, cls).__new__(cls, ip, port, rack, dc, token,
+            local_connections, remote_connections, seed_string)
+
+    def __init__(self, ip, port, rack, dc, token, local_connections,
+                 remote_connections):
+        self.dnode_port = INTERNODE_LISTEN
+        self.data_store_port = REDIS_PORT
+        self.stats_port = STATS_PORT
+
+    def _generate_config(self, seeds_list):
+        conf = dict(DYN_O_MITE_DEFAULTS)
+        conf['datacenter'] = self.dc
+        conf['rack'] = self.rack
+        dyn_listen = '{}:{}'.format(self.ip, self.dnode_port)
+        conf['dyn_listen'] = dyn_listen
+        conf['listen'] = '{}:{}'.format(self.ip, self.port)
+
+        # filter out our own seed string
+        conf['dyn_seeds'] = [s for s in seeds_list if s != self.seed_string]
+        conf['servers'] = ['{}:{}:0'.format(self.ip, self.data_store_port)]
+        conf['stats_listen'] = '{}:{}'.format(self.ip, self.stats_port)
+        conf['tokens'] = self.token
+        conf['local_peer_connections'] = self.local_connections
+        conf['remote_peer_connections'] = self.remote_connections
+        return dict(dyn_o_mite=conf)
+
+    def write_config(self, seeds_list):
+        config = self._generate_config(seeds_list)
+        filename = 'conf/{}:{}:{}.yml'.format(self.dc, self.rack, self.token)
+        with open(filename, 'w') as fh:
+            yaml.dump(config, fh, default_flow_style=False)
+        return filename
 
 class DynoCluster(object):
-    def __init__(self, nodes):
-        self.nodes = tuple(nodes)
+    def __init__(self, request_file, ips):
+        # Load the YAML file describing the cluster.
+        with open(request_file, 'r') as fh:
+            self.request = yaml.load(fh)
+        self.ips = ips
+        # Generate the specification for each node to be started in the cluster.
+        self.specs = list(self._generate_dynomite_specs())
+        self.nodes = []
+
+    def _generate_dynomite_specs(self):
+        tokens = tokens_for_cluster(self.request, None)
+        counts_by_rack = dict_request(self.request)
+        counts_by_dc = sum_racks(counts_by_rack)
+        total_nodes = sum(counts_by_dc.values())
+        for dc, racks in tokens:
+            dc_count = counts_by_dc[dc]
+            rack_count = counts_by_rack[dc]
+            remote_count = total_nodes - dc_count
+            for rack, tokens in racks:
+                local_count = rack_count[rack] - 1
+                for token in tokens:
+                    ip = next(self.ips)
+                    yield DynoSpec(ip, CLIENT_LISTEN, dc, rack, token,
+                        local_count, remote_count)
+
+    def launch(self):
+        # Get the list of seeds from the specification for each node.
+        seeds_list = [spec.seed_string for spec in self.specs]
+        # Launch each individual Dyno node.
+        self.nodes = [DynoNode(spec, seeds_list) for spec in self.specs]
+        for n in self.nodes:
+            n.launch()
+
+    def teardown(self):
+        for n in self.nodes:
+            n.teardown()
+
+    def __enter__(self):
+        self.launch()
+
+    def __exit__(self, type_, value, traceback):
+        self.teardown()
 
     def get_connection(self):
         node = random.choice(self.nodes)

--- a/test/dyno_cluster.py
+++ b/test/dyno_cluster.py
@@ -24,19 +24,18 @@ CLIENT_LISTEN = 8102
 REDIS_PORT = 1212
 STATS_PORT = 22222
 
-class DynoSpec(namedtuple('DynoSpec', 'ip port dc rack token '
+class DynoSpec(namedtuple('DynoSpec', 'ip dnode_port client_port rack dc token '
     'local_connections remote_connections seed_string req_conf')):
     """Specifies how to launch a dynomite node"""
 
-    def __new__(cls, ip, port, rack, dc, token, local_connections,
+    def __new__(cls, ip, dnode_port, client_port, rack, dc, token, local_connections,
                 remote_connections, req_conf):
-        seed_string = '{}:{}:{}:{}:{}'.format(ip, port, rack, dc, token)
-        return super(DynoSpec, cls).__new__(cls, ip, port, rack, dc, token,
-            local_connections, remote_connections, seed_string, req_conf)
+        seed_string = '{}:{}:{}:{}:{}'.format(ip, dnode_port, rack, dc, token)
+        return super(DynoSpec, cls).__new__(cls, ip, dnode_port, client_port, rack,
+            dc, token, local_connections, remote_connections, seed_string, req_conf)
 
-    def __init__(self, ip, port, rack, dc, token, local_connections,
+    def __init__(self, ip, dnode_port, client_port, rack, dc, token, local_connections,
                  remote_connections, req_conf):
-        self.dnode_port = INTERNODE_LISTEN
         self.data_store_port = REDIS_PORT
         self.stats_port = STATS_PORT
 
@@ -46,7 +45,7 @@ class DynoSpec(namedtuple('DynoSpec', 'ip port dc rack token '
         conf['rack'] = self.rack
         dyn_listen = '{}:{}'.format(self.ip, self.dnode_port)
         conf['dyn_listen'] = dyn_listen
-        conf['listen'] = '{}:{}'.format(self.ip, self.port)
+        conf['listen'] = '{}:{}'.format(self.ip, self.client_port)
 
         # filter out our own seed string
         conf['dyn_seeds'] = [s for s in seeds_list if s != self.seed_string]
@@ -92,7 +91,7 @@ class DynoCluster(object):
                 local_count = rack_count[rack] - 1
                 for token in tokens:
                     ip = next(self.ips)
-                    yield DynoSpec(ip, CLIENT_LISTEN, dc, rack, token,
+                    yield DynoSpec(ip, INTERNODE_LISTEN, CLIENT_LISTEN, rack, dc, token,
                         local_count, remote_count, self.request['conf'])
 
     def _get_cluster_desc_yaml(self):

--- a/test/dyno_node.py
+++ b/test/dyno_node.py
@@ -2,16 +2,49 @@
 import redis
 from node import Node
 from redis_node import RedisNode
-from dyno_cluster import DynoCluster
+
+from plumbum import BG
+from plumbum import local
+
+dynomite_bin = local.get('./test/_binaries/dynomite', 'src/dynomite')
 
 class DynoNode(Node):
-    def __init__(self, ip, port=8102,
-                 dnode_port=8101, data_store_port=1212):
-        super(DynoNode, self).__init__(ip, port)
+    #TODO: Decouple from Redis and make it more generic
+    def __init__(self, spec, seeds_list):
+        super(DynoNode, self).__init__(spec.ip, spec.port)
         self.name="Dyno" + self.name
         self.conf_file = None
-        self.dnode_port = dnode_port
-        self.data_store_node = RedisNode(ip, data_store_port)
+        self.spec = spec
+        self.seeds_list = seeds_list
+        self.dnode_port = spec.dnode_port
+        self.data_store_node = RedisNode(self.ip, spec.data_store_port)
+        self.logfile = 'logs/dynomite_{}.log'.format(self.ip)
+        self.proc_future = None
+
+    def launch(self):
+        # Write the configuration to a file according to 'self.spec'.
+        config_filename = self.spec.write_config(self.seeds_list)
+
+        # Launch the underlying data store process first.
+        self.data_store_node.launch()
+
+        # Launch the dynomite process
+        self.proc_future = dynomite_bin['-o', self.logfile, '-c', config_filename,
+            '-v6'] & BG(-9)
+
+    def teardown(self):
+        # First teardown the Dynomite node.
+        self.proc_future.proc.kill()
+        self.proc_future.wait()
+
+        # Lastly, teardown the storage node.
+        self.data_store_node.teardown()
+
+    def __enter__(self):
+        self.launch()
+
+    def __exit__(self, type_, value, traceback):
+        self.teardown()
 
     def get_connection(self):
         # should return the connection to the dyno port not the redis

--- a/test/dyno_node.py
+++ b/test/dyno_node.py
@@ -46,6 +46,12 @@ class DynoNode(Node):
     def __exit__(self, type_, value, traceback):
         self.teardown()
 
+    def get_dyno_node_pid(self):
+        return self.proc_future.proc.pid
+
+    def get_storage_node_pid(self):
+        return self.data_store_node.get_pid()
+
     def get_connection(self):
         # should return the connection to the dyno port not the redis
         print("returning connection at %s:%d" % (self.ip, self.port))

--- a/test/dyno_node.py
+++ b/test/dyno_node.py
@@ -11,7 +11,7 @@ dynomite_bin = local.get('./test/_binaries/dynomite', 'src/dynomite')
 class DynoNode(Node):
     #TODO: Decouple from Redis and make it more generic
     def __init__(self, spec, seeds_list):
-        super(DynoNode, self).__init__(spec.ip, spec.port)
+        super(DynoNode, self).__init__(spec.ip, spec.client_port)
         self.name="Dyno" + self.name
         self.conf_file = None
         self.spec = spec

--- a/test/kill_cluster.py
+++ b/test/kill_cluster.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import sys
+
+from utils import teardown_running_cluster
+
+def main():
+    teardown_running_cluster('running_cluster.yaml')
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/no_quorum_request.yaml
+++ b/test/no_quorum_request.yaml
@@ -1,3 +1,4 @@
+cluster_desc:
 - name: dc1
   racks:
   - [rack1, 1]
@@ -6,3 +7,6 @@
   - [rack1, 1]
   - [rack2, 2]
   - [rack3, 4]
+conf:
+  read_consistency: "DC_ONE"
+  write_consistency: "DC_ONE"

--- a/test/redis_node.py
+++ b/test/redis_node.py
@@ -17,6 +17,9 @@ class RedisNode(Node):
     def get_connection(self):
         return redis.StrictRedis(self.ip, self.port, db=0)
 
+    def get_pid(self):
+        return self.proc_future.proc.pid
+
     def launch(self):
         self.proc_future = \
             (redis_bin['--bind', self.ip, '--port', self.port] > self.logfile) & BG(-9)

--- a/test/redis_node.py
+++ b/test/redis_node.py
@@ -2,10 +2,31 @@
 import redis
 from node import Node
 
+from plumbum import BG
+from plumbum import local
+
+redis_bin = local.get('./test/_binaries/redis-server', 'redis-server')
+
 class RedisNode(Node):
     def __init__(self, ip, port):
         super(RedisNode, self).__init__(ip, port)
         self.name = "Redis" + self.name
+        self.logfile = 'logs/redis_{}.log'.format(self.ip)
+        self.proc_future = None
 
     def get_connection(self):
         return redis.StrictRedis(self.ip, self.port, db=0)
+
+    def launch(self):
+        self.proc_future = \
+            (redis_bin['--bind', self.ip, '--port', self.port] > self.logfile) & BG(-9)
+
+    def teardown(self):
+        self.proc_future.proc.kill()
+        self.proc_future.wait()
+
+    def __enter__(self):
+        self.launch()
+
+    def __exit__(self, type_, value, traceback):
+        self.teardown()

--- a/test/safe_quorum_request.yaml
+++ b/test/safe_quorum_request.yaml
@@ -2,11 +2,13 @@ cluster_desc:
 - name: dc1
   racks:
   - [rack1, 1]
+  - [rack2, 1]
+  - [rack3, 1]
 - name: dc2
   racks:
   - [rack1, 1]
-  - [rack2, 2]
-  - [rack3, 4]
+  - [rack2, 1]
+  - [rack3, 1]
 conf:
   read_consistency: "DC_SAFE_QUORUM"
   write_consistency: "DC_SAFE_QUORUM"

--- a/test/safe_quorum_request.yaml
+++ b/test/safe_quorum_request.yaml
@@ -1,0 +1,12 @@
+cluster_desc:
+- name: dc1
+  racks:
+  - [rack1, 1]
+- name: dc2
+  racks:
+  - [rack1, 1]
+  - [rack2, 2]
+  - [rack3, 4]
+conf:
+  read_consistency: "DC_SAFE_QUORUM"
+  write_consistency: "DC_SAFE_QUORUM"

--- a/test/start_cluster.py
+++ b/test/start_cluster.py
@@ -14,7 +14,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Autogenerates a Dynomite cluster and runs functional ' +
             'tests against it')
-    parser.add_argument('request_file', default='test/request.yaml',
+    parser.add_argument('request_file', default='test/safe_quorum_request.yaml',
         help='YAML file describing desired cluster', nargs='?')
     args = parser.parse_args()
 

--- a/test/start_cluster.py
+++ b/test/start_cluster.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+
+from plumbum import local
+from time import sleep
+
+from dyno_cluster import DynoCluster
+from utils import generate_ips, setup_temp_dir
+
+SETTLE_TIME = 5
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Autogenerates a Dynomite cluster and runs functional ' +
+            'tests against it')
+    parser.add_argument('request_file', default='test/request.yaml',
+        help='YAML file describing desired cluster', nargs='?')
+    args = parser.parse_args()
+
+    # Setup a temporary directory to store logs and configs for this cluster.
+    temp = setup_temp_dir()
+
+    # Generate IP addresses to be used by the nodes we will create.
+    ips = generate_ips()
+
+    # Create a Dynomite cluster.
+    dynomite_cluster = DynoCluster(args.request_file, ips)
+
+    # Make sure to change the working directory to the temp dir.
+    with local.cwd(temp):
+        # Launch the dynomite cluster.
+        dynomite_cluster.launch()
+
+        # Wait for a while for the above nodes to start.
+        sleep(SETTLE_TIME)
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,9 +1,71 @@
 #!/usr/bin/env python3
 import random
-import string 
+import string
+
+from ip_util import int2quad
+from ip_util import quad2int
+
+from itertools import count
+
+BASE_IPADDRESS = quad2int('127.0.1.1')
+RING_SIZE = 2**32
+
 
 def string_generator(size=6, chars=string.ascii_letters + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
 
 def number_generator(size=4, chars=string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
+
+def dict_request(request):
+    """Converts the request into an easy to consume dict format."""
+
+    # We don't ingest the request in this format originally because dict
+    # ordering is nondeterministic, and one of our goals is to deterministically
+    # generate clusters.
+    # TODO: Python 3.6+ has ordered dicts, so the above doesn't hold true from that
+    # version.
+    return dict(
+        (dc['name'], dict(dc['racks']))
+        for dc in request
+    )
+
+def sum_racks(dcs):
+    return dict(
+        (name, sum(racks.values()))
+        for name, racks in dcs.items()
+    )
+
+def pick_tokens(count, start_offset):
+    stride = RING_SIZE // count
+    token = start_offset
+    for i in range(count):
+        yield token % RING_SIZE
+        token += stride
+
+def tokens_for_rack(count):
+    offset = random.randrange(0, RING_SIZE)
+    return list(pick_tokens(count, offset))
+
+def tokens_for_dc(racks):
+    return [
+        (name, tokens_for_rack(count))
+        for name, count in racks
+    ]
+
+def tokens_for_cluster(dcs, seed):
+    if seed is not None:
+        random.seed(seed)
+
+    return [
+        (dc['name'], tokens_for_dc(dc['racks']))
+        for dc in dcs
+    ]
+
+
+def dc_count(dc):
+    return sum(count for rack, count in dc)
+
+def generate_ips():
+    for ip in count(start=BASE_IPADDRESS, step=1):
+        yield int2quad(ip)


### PR DESCRIPTION
This patch takes a lot of the code from test/cluster_generator.py
and refactors it into easily manageable classes which allows for
easily creating and destroying a dynomite cluster in a local test
environment. Refer to the last paragraph of this commit message for
the motivation behind this patch.

To create a dynomite cluster, now it's as simple as doing the following:

  cluster = DynoCluster(args.request_file, ips)
  cluster.launch()
  \# Run all the required tests
  cluster.teardown()

This patch does this by forming clear relations between DynoCluster,
DynoSpec, DynoNode and RedisNode.

DynoCluster --manages--> list(DynoSpec), list(DynoNode)
DynoNode    --manages--> RedisNode
DynoNode and DynoSpec have a 1:1 relationship.

In the future, we should decouple RedisNode and DynoNode and abstract
away specific storage node classes to a generic class.
Eg: 'RedisNode' implements 'StorageNode', and 'DynoNode' directly
uses only 'StorageNode'.

This patch also fixes a small bug where the incorrect port is used
for the client listening port.

This patch currently breaks other standalone scripts like func_test.py
and large_value_test.py. This will be cleaned up in a future commit,
and IMO it's not a serious issue as it's difficult to already use
those scripts since they assume that a cluster with a very specific
configuration is already setup (which is not that simple to do
manually today).

The initial motivation behind this patch is to create scripts to
_only start_ or _only stop_ a dynomite cluster for the purpose
of manual testing against a cluster. Before this patch,
cluster_generator.py always cleaned up the resources on exit. Future
commits will introduce new scripts like start_cluster.py and
teardown_cluster.py which will allow developers to just start a cluster
and run tests against it and then tear it down later. Other things
that this patch enables is to do hypothetical experiments like
dual running against 2 dynomite clusters with different
configurations, expanding the framework to run only a subset of tests
based on user flags passed to cluster_generator.py, etc.

Future TODO: Add code comments to classes and methods as necessary.