### PR TITLE
Update Dockerfile to install software-properties-common instead of python-software-properties.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,16 +25,18 @@ FROM ubuntu
 MAINTAINER Ioannis Papapanagiotou - dynomite@netflix.com
 
 # Update the repository sources list and Install package Build Essential
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && \
+	export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y \
 	autoconf \
 	build-essential \
 	dh-autoreconf \
 	git \
 	libssl-dev \
 	libtool \
-	python-software-properties \
+	software-properties-common \
 	redis-server \
-	tcl8.5
+	tcl8.5 
 
 # Clone the Dynomite Git
 RUN git clone https://github.com/Netflix/dynomite.git


### PR DESCRIPTION
If you try to build docker images using the present Dockerfile you will find this error:
E: Package 'python-software-properties' has no installation candidate

It seems that python-software-properties is not available in ubuntu >= 12.10.

To fix this issue I changed the Dockerfile to use the software-properties-common package which is an alternative to python-software-properties.