### PR TITLE
Allow multi-buffer payload decryption

### DIFF
--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -908,8 +908,8 @@ static rstatus_t msg_recv_chain(struct context *ctx, struct conn *conn,
    * buffer.
    */
   if (mbuf == NULL || ((!encryption_detected) && mbuf_full(mbuf)) ||
-      (!encryption_detected && mbuf->last == mbuf->end_extra) ||
-      (!encryption_detected && mbuf_full(mbuf) &&
+      (encryption_detected && mbuf->last == mbuf->end_extra) ||
+      (encryption_detected && mbuf_full(mbuf) &&
        (mbuf->flags & MBUF_FLAGS_JUST_DECRYPTED))) {
     mbuf = mbuf_get();
     if (mbuf == NULL) {


### PR DESCRIPTION
In many cases, queries or responses that spanned multiple mbufs
would not get decrypted correctly causing cross-DC traffic to be
dropped silently which resulted in a failure to replicate data in
different DCs.

After a lot of debugging, this was found to be due to a typo
introduced in a previous commit:
https://github.com/Netflix/dynomite/commit/91e8fe38ea66b79b5241f02169fa04e2ad9a50ea

This typo is now fixed and multi-buffer decryption works seamlessly.