### PR TITLE
Support SCRIPT LOAD and EVALSHA in Dynomite

### DIFF
--- a/notes/redis.md
+++ b/notes/redis.md
@@ -325,7 +325,7 @@
     +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+
     |    SCRIPT KILL    |    No      | SCRIPT KILL                                                                                                         |
     +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+
-    |    SCRIPT LOAD    |    No      | SCRIPT LOAD script                                                                                                  |
+    |    SCRIPT LOAD    |    Yes     | SCRIPT LOAD script                                                                                                  |
     +-------------------+------------+---------------------------------------------------------------------------------------------------------------------+
 
  * EVAL and EVALSHA support is limited to scripts that take at least 1 key. If multiple keys are used, all keys must hash to the same server. You can ensure this by using the same [hashtag](recommendation.md#hash-tags) for all keys. If you use more than 1 key, the proxy does no checking to verify that all keys hash to the same server, and the entire command is forwarded to the server that the first key hashes to

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -291,6 +291,7 @@ static void dnode_req_forward(struct context *ctx, struct conn *conn,
     conn_enqueue_outq(ctx, conn, req);
     req->rsp_handler = msg_local_one_rsp_handler;
   }
+
   if (req->dmsg->type == DMSG_REQ) {
     // This is a request received from a peer rack in the same DC, just forward
     // it to the local datastore

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -83,6 +83,15 @@ rstatus_t dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
   dmsg_type_t msg_type =
       (string_compare(&pool->dc, dc) != 0) ? DMSG_REQ_FORWARD : DMSG_REQ;
 
+  if (req->msg_routing == ROUTING_ALL_NODES_ALL_RACKS_ALL_DCS) {
+    // If the routing type is 'ROUTING_ALL_NODES_ALL_RACKS_ALL_DCS', the server that
+    // initiated the request will forward the request to all the nodes in the cluster
+    // globally. So, here we pretend as though the request is coming from the same DC,
+    // to avoid having the receiving DNODE from forwarding the request again to its
+    // peers in its local AZs.
+    // TODO: Prefer a 2 hop mechanism for cross-DC traffic.
+    msg_type = DMSG_REQ;
+  }
   // SMB: THere is some non trivial business happening here. Better refer to the
   // comment in dnode_rsp_send_next to understand the stuff here.
   // Note: THere MIGHT BE A NEED TO PORT THE dnode_header_prepended FIX FROM

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -211,25 +211,33 @@ typedef enum msg_parse_result {
   ACTION(REQ_REDIS_GEODIST)                                                    \
   ACTION(REQ_REDIS_GEOHASH)                                                    \
   ACTION(REQ_REDIS_GEOPOS)                                                     \
-  ACTION(REQ_REDIS_GEORADIUSBYMEMBER)							    \			
-                                     /* ACTION( REQ_REDIS_AUTH) */             \
-      /* ACTION( REQ_REDIS_SELECT)*/ /* only during init */                    \
-      ACTION(REQ_REDIS_PFADD)        /* redis requests - hyperloglog */        \
-      ACTION(REQ_REDIS_PFCOUNT) ACTION(RSP_REDIS_STATUS) /* redis response */  \
-      ACTION(RSP_REDIS_INTEGER) ACTION(RSP_REDIS_BULK)                         \
-          ACTION(RSP_REDIS_MULTIBULK) ACTION(REQ_REDIS_CONFIG) ACTION(         \
-              RSP_REDIS_ERROR) ACTION(RSP_REDIS_ERROR_ERR)                     \
-              ACTION(RSP_REDIS_ERROR_OOM) ACTION(RSP_REDIS_ERROR_BUSY) ACTION( \
-                  RSP_REDIS_ERROR_NOAUTH) ACTION(RSP_REDIS_ERROR_LOADING)      \
-                  ACTION(RSP_REDIS_ERROR_BUSYKEY)                              \
-                      ACTION(RSP_REDIS_ERROR_MISCONF)                          \
-                          ACTION(RSP_REDIS_ERROR_NOSCRIPT)                     \
-                              ACTION(RSP_REDIS_ERROR_READONLY)                 \
-                                  ACTION(RSP_REDIS_ERROR_WRONGTYPE) ACTION(    \
-                                      RSP_REDIS_ERROR_EXECABORT)               \
-                                      ACTION(RSP_REDIS_ERROR_MASTERDOWN)       \
-                                          ACTION(RSP_REDIS_ERROR_NOREPLICAS)   \
-                                              ACTION(SENTINEL)
+  ACTION(REQ_REDIS_GEORADIUSBYMEMBER)							                             \
+  ACTION(REQ_REDIS_PFADD)        /* redis requests - hyperloglog */            \
+  ACTION(REQ_REDIS_PFCOUNT)                                                    \
+  ACTION(RSP_REDIS_STATUS) /* redis response */                                \
+  ACTION(RSP_REDIS_INTEGER)                                                    \
+  ACTION(RSP_REDIS_BULK)                                                       \
+  ACTION(RSP_REDIS_MULTIBULK)                                                  \
+  ACTION(REQ_REDIS_CONFIG)                                                     \
+  ACTION(RSP_REDIS_ERROR)                                                      \
+  ACTION(RSP_REDIS_ERROR_ERR)                                                  \
+  ACTION(RSP_REDIS_ERROR_OOM)                                                  \
+  ACTION(RSP_REDIS_ERROR_BUSY)                                                 \
+  ACTION(RSP_REDIS_ERROR_NOAUTH)                                               \
+  ACTION(RSP_REDIS_ERROR_LOADING)                                              \
+  ACTION(RSP_REDIS_ERROR_BUSYKEY)                                              \
+  ACTION(RSP_REDIS_ERROR_MISCONF)                                              \
+  ACTION(RSP_REDIS_ERROR_NOSCRIPT)                                             \
+  ACTION(RSP_REDIS_ERROR_READONLY)                                             \
+  ACTION(RSP_REDIS_ERROR_WRONGTYPE)                                            \
+  ACTION(RSP_REDIS_ERROR_EXECABORT)                                            \
+  ACTION(RSP_REDIS_ERROR_MASTERDOWN)                                           \
+  ACTION(RSP_REDIS_ERROR_NOREPLICAS)                                           \
+  ACTION(SENTINEL)                                                             \
+  ACTION(REQ_REDIS_SCRIPT)                                                     \
+  ACTION(REQ_REDIS_SCRIPT_LOAD)                                                \
+  /* ACTION( REQ_REDIS_AUTH) */                                                \
+  /* ACTION( REQ_REDIS_SELECT)*/ /* only during init */
 
 #define DEFINE_ACTION(_name) MSG_##_name,
 typedef enum msg_type { MSG_TYPE_CODEC(DEFINE_ACTION) } msg_type_t;
@@ -322,11 +330,14 @@ extern uint8_t g_timeout_factor;
 
 typedef enum msg_routing {
   ROUTING_NORMAL = 0,
-  ROUTING_LOCAL_NODE_ONLY = 1, /* Ignore the key hashing */
-  ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY =
-      2, /* apply key hashing, but local rack only */
-  ROUTING_ALL_NODES_LOCAL_RACK_ONLY =
-      3, /* Ignore key hashing, local rack only */
+  // Ignore the key hashing
+  ROUTING_LOCAL_NODE_ONLY = 1,
+  // Apply key hashing, but only for the local rack.
+  ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY = 2,
+  // Ignore key hashing, but only for the local rack.
+  ROUTING_ALL_NODES_LOCAL_RACK_ONLY = 3,
+  // Ignore key hashing, and send to all nodes in all racks in all DCs.
+  ROUTING_ALL_NODES_ALL_RACKS_ALL_DCS = 4,
 } msg_routing_t;
 
 static inline char *get_msg_routing_string(msg_routing_t route) {
@@ -339,6 +350,8 @@ static inline char *get_msg_routing_string(msg_routing_t route) {
       return "ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY";
     case ROUTING_ALL_NODES_LOCAL_RACK_ONLY:
       return "ROUTING_ALL_NODES_LOCAL_RACK_ONLY";
+    case ROUTING_ALL_NODES_ALL_RACKS_ALL_DCS:
+      return "ROUTING_ALL_NODES_ALL_RACKS_ALL_DCS";
   }
   return "INVALID MSG ROUTING TYPE";
 }

--- a/test/func_test.py
+++ b/test/func_test.py
@@ -2,7 +2,7 @@
 import redis
 import argparse
 import random
-import string 
+import string
 import sys
 import time
 from utils import string_generator, number_generator
@@ -62,6 +62,22 @@ def run_multikey_test(c, max_keys=1000, max_payload=10):
             key = create_key(test_name, key_id)
             keys.append(key)
         c.run_verify("mget", keys)
+
+def run_script_tests(c):
+    TEST_NAME="SCRIPTS"
+    print("Running %s tests" % TEST_NAME)
+
+    # This script basically executes 'GET <key>'.
+    SCRIPT_BODY='{}'.format("return redis.call('get', KEYS[1])")
+
+    script_hash = c.run_verify("script_load", SCRIPT_BODY)
+
+    # Create a key to test with.
+    key = create_key(TEST_NAME, "key1")
+    c.run_verify("set", key, "value1")
+
+    # Verify that the result of the script is the same in both Dynomite and Redis.
+    c.run_verify("evalsha", script_hash, 1, key)
 
 def run_hash_tests(c, max_keys=10, max_fields=1000):
     def create_key_field(keyid=None, fieldid=None):
@@ -125,7 +141,7 @@ def run_hash_tests(c, max_keys=10, max_fields=1000):
     #next_index = 0;
     #while True:
         #result = c.run_verify("hscan", key, next_index)
-        #next_index = result[0] 
+        #next_index = result[0]
         #print next_index
         #if next_index == 0:
             #break
@@ -140,6 +156,7 @@ def comparison_test(redis, dynomite, debug):
     run_key_value_tests(c, max_keys=10, max_payload=5*1024*1024)
     run_multikey_test(c)
     run_hash_tests(c, max_keys=10, max_fields=100)
+    run_script_tests(c)
     print("All test ran fine")
 
 def main(args):


### PR DESCRIPTION
Dynomite has the ability to deal with scripts that take a single key
through EVAL. Users of Dynomite have requested the option of using
EVALSHA so as to not resend the script every time. This is made possible
by this patch which supports the saving of scripts through SCRIPT LOAD
and the execution of them through EVALSHA.

Adding support for SCRIPT LOAD poses a challenge because there is no
node(s) that have the right to store a script since the script doesn't
evaluate to a token in the token range managed by Dynomite.
To deal with this, we need to save the script to EVERY node in the
cluster. A new routing mechanism is introduced in Dynomite which sends
a message from one server to ALL other servers in the cluster; i.e. it
sends to to each node in each rack in each DC. In the future this mechanism
will be modified to have a 2 hop approach so as to avoid sending data to
multiple nodes across DCs.

Parsing "SCRIPT LOAD" also posed a challenge since the "SCRIPT
<LOAD/KILL/FLUSH/EXISTS>" commands are the only commands with a space as
part of the command. The parser has been modified to deal with this by
tricking the parser to process each keyword as though it is a new
command, and then figuring out after parsing the second word, which
command it is.

A test case has been added to test both SCRIPT LOAD and EVALSHA.