### PR TITLE
Support remaining SCRIPT commands. (EXISTS, KILL, FLUSH)

### DIFF
--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -236,6 +236,9 @@ typedef enum msg_parse_result {
   ACTION(SENTINEL)                                                             \
   ACTION(REQ_REDIS_SCRIPT)                                                     \
   ACTION(REQ_REDIS_SCRIPT_LOAD)                                                \
+  ACTION(REQ_REDIS_SCRIPT_EXISTS)                                              \
+  ACTION(REQ_REDIS_SCRIPT_FLUSH)                                               \
+  ACTION(REQ_REDIS_SCRIPT_KILL)                                                \
   /* ACTION( REQ_REDIS_AUTH) */                                                \
   /* ACTION( REQ_REDIS_SELECT)*/ /* only during init */
 

--- a/test/dual_run.py
+++ b/test/dual_run.py
@@ -44,8 +44,31 @@ class dual_run():
                 break
         if self.debug:
             print("Query: %s %s" % (func, str(args)))
-            print("Redis: %s" % str(r_result))
-            print("Dyno : %s" % str(d_result))
+            print("Redis result: %s" % str(r_result))
+            print("Dyno result: %s" % str(d_result))
         if r_result != d_result:
             raise ResultMismatchError(r_result, d_result, func, *args)
+        return d_result
+
+    def run_dynomite_only(self, func, *args):
+        d_result = None
+        d_func = getattr(self.d, func)
+        i = 0
+        retry_limit = 3
+        while i < retry_limit:
+            try:
+                d_result = d_func(*args)
+                if i > 0:
+                    print("\tSucceeded in attempt {}".format(i+1))
+                break
+            except redis.exceptions.ResponseError as e:
+                if "Peer Node is not connected" in str(e):
+                    i = i + 1
+                    print("\tGot error '{}' ... Retry effort {}/{}\n\tQuery '{} {}'".format(e, i, retry_limit, func, str(args)))
+                    continue
+                print("\tGot error '{}'\n\tQuery '{} {}'".format(e, func, str(args)))
+                break
+        if self.debug:
+            print("Query: %s %s" % (func, str(args)))
+            print("Dyno result: %s" % str(d_result))
         return d_result


### PR DESCRIPTION
This patch adds support for the remaining SCRIPT commands.

SCRIPT FLUSH will clear the script caches of all the Redis instances
managed by Dynomite.

SCRIPT KILL will kill ANY script running on ANY instance of Redis
managed by Dynomite. This could prove tricky for multi-tenant use
cases where multiple users may be executing multiple scripts from
different nodes. Under this rare case, ALL running scripts will be
terminated.

SCRIPT EXISTS works as one would expect from Redis.

Tests have been added to test all the above except SCRIPT KILL. It's
tricky to write an automated test for this, but it has been manually
tested.

A new method is introduced to the test framework to allow execution of
commands only through Dynomite as opposed to always running it against
Redis and Dynomite.