### PR TITLE
Remove code duplication in dyn_client, more code cleanup and misc bug…

### DIFF
--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -297,7 +297,7 @@ static void dnode_req_forward(struct context *ctx, struct conn *conn,
     // it to the local datastore
     dyn_error_t dyn_error_code = DN_OK;
     rstatus_t s =
-        local_req_forward(ctx, conn, req, key, keylen, &dyn_error_code);
+        req_forward_local_datastore(ctx, conn, req, key, keylen, &dyn_error_code);
     if (s != DN_OK) {
       req_forward_error(ctx, conn, req, s, dyn_error_code);
     }

--- a/src/dyn_dnode_request.c
+++ b/src/dyn_dnode_request.c
@@ -50,14 +50,13 @@ static void dnode_peer_req_forward_stats(struct context *ctx,
 /* Forward a client request over to a peer */
 rstatus_t dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
                                  struct conn *p_conn, struct msg *req,
-                                 struct rack *rack, uint8_t *key,
-                                 uint32_t keylen, dyn_error_t *dyn_error_code) {
+                                 uint8_t *key, uint32_t keylen,
+                                 dyn_error_t *dyn_error_code) {
   struct node *server = p_conn->owner;
   log_info("%s FORWARD %s to peer %s on rack '%.*s' dc '%.*s' ",
            print_obj(c_conn), print_obj(req), print_obj(p_conn),
-           rack->name->len, rack->name->data, server->dc.len, server->dc.data);
+           server->rack.len, server->rack.data, server->dc.len, server->dc.data);
 
-  struct string *dc = rack->dc;
   rstatus_t status;
 
   ASSERT(p_conn->type == CONN_DNODE_PEER_SERVER);
@@ -80,8 +79,8 @@ rstatus_t dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
   }
 
   struct server_pool *pool = c_conn->owner;
-  dmsg_type_t msg_type =
-      (string_compare(&pool->dc, dc) != 0) ? DMSG_REQ_FORWARD : DMSG_REQ;
+  dmsg_type_t msg_type = (string_compare(&pool->dc, &server->dc) != 0) ?
+      DMSG_REQ_FORWARD : DMSG_REQ;
 
   if (req->msg_routing == ROUTING_ALL_NODES_ALL_RACKS_ALL_DCS) {
     // If the routing type is 'ROUTING_ALL_NODES_ALL_RACKS_ALL_DCS', the server that

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -467,6 +467,7 @@ rstatus_t msg_clone(struct msg *src, struct mbuf *mbuf_start,
   target->vlen = src->vlen;
   target->is_read = src->is_read;
   target->consistency = src->consistency;
+  target->msg_routing = src->msg_routing;
 
   struct mbuf *mbuf, *nbuf;
   bool started = false;

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -540,20 +540,17 @@ void dnode_rsp_gos_syn(struct context *ctx, struct conn *p_conn,
 
 void req_forward_error(struct context *ctx, struct conn *conn, struct msg *req,
                        err_t error_code, err_t dyn_error_code);
-rstatus_t remote_req_forward(struct context *ctx, struct conn *c_conn,
-                             struct msg *msg, struct rack *rack, uint8_t *key,
-                             uint32_t keylen, dyn_error_t *dyn_error_code);
 void req_forward_all_local_racks(struct context *ctx, struct conn *c_conn,
                                  struct msg *req, struct mbuf *orig_mbuf,
                                  uint8_t *key, uint32_t keylen,
                                  struct datacenter *dc);
-rstatus_t local_req_forward(struct context *ctx, struct conn *c_conn,
+rstatus_t req_forward_local_datastore(struct context *ctx, struct conn *c_conn,
                             struct msg *msg, uint8_t *key, uint32_t keylen,
                             dyn_error_t *dyn_error_code);
 rstatus_t dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
                                  struct conn *p_conn, struct msg *msg,
-                                 struct rack *rack, uint8_t *key,
-                                 uint32_t keylen, dyn_error_t *dyn_error_code);
+                                 uint8_t *key, uint32_t keylen,
+                                 dyn_error_t *dyn_error_code);
 
 // void peer_gossip_forward(struct context *ctx, struct conn *conn, struct
 // string *data);

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -32,10 +32,11 @@
 static char *_print_datastore(const struct object *obj) {
   ASSERT(obj->type == OBJ_DATASTORE);
   struct datastore *ds = (struct datastore *)obj;
-  snprintf(obj->print_buff, PRINT_BUF_SIZE, "<DATASTORE %p %.*s>", ds,
+  snprintf((char*)obj->print_buff, PRINT_BUF_SIZE, "<DATASTORE %p %.*s>", ds,
            ds->endpoint.pname.len, ds->endpoint.pname.data);
-  return obj->print_buff;
+  return (char*)obj->print_buff;
 }
+
 static void server_ref(struct conn *conn, void *owner) {
   struct datastore *datastore = owner;
 
@@ -831,6 +832,7 @@ struct msg *req_send_next(struct context *ctx, struct conn *conn) {
   }
 
   req = conn->smsg;
+
   if (req != NULL) {
     ASSERT(req->is_request && !req->done);
     nmsg = TAILQ_NEXT(req, s_tqe);

--- a/src/dyn_types.h
+++ b/src/dyn_types.h
@@ -75,7 +75,7 @@
     }                                    \
   }
 
-#define IGNORE_RET_VAL(x) x;
+#define IGNORE_RET_VAL(x) (void)x;
 
 typedef uint64_t msgid_t;
 typedef uint64_t msec_t;


### PR DESCRIPTION
… fixes

There were multiple code paths with duplicated code to do the same
thing, namely copy the 'msg' and forward it to the right peer. This
patch introduces a new funciton req_forward_to_peer() which
encapsulates this functionality once.

This also fixes a bug which previously only compared rack strings to
figure out if they are the same rack, which could be wrong if racks
across DCs have the same name.

There are also multiple other small code cleanup changes including
more code comments.

A small but critical bug is fixed in msg_clone().