### PR TITLE
Record argument positions in query request

### DIFF
--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -356,6 +356,12 @@ done:
     return NULL;
   }
 
+  msg->args = array_create(1, sizeof(struct argpos));
+  if (msg->args == NULL) {
+    dn_free(msg);
+    return NULL;
+  }
+
   msg->vlen = 0;
   msg->end = NULL;
 
@@ -365,10 +371,10 @@ done:
   msg->nfrag_done = 0;
   msg->frag_id = 0;
 
-  msg->narg_start = NULL;
-  msg->narg_end = NULL;
-  msg->narg = 0;
-  msg->rnarg = 0;
+  msg->ntoken_start = NULL;
+  msg->ntoken_end = NULL;
+  msg->ntokens = 0;
+  msg->rntokens = 0;
   msg->nkeys = 0;
   msg->rlen = 0;
   msg->integer = 0;

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -380,6 +380,11 @@ struct keypos {
   uint8_t *tag_end;   /* hashtagged key end pos */
 };
 
+struct argpos {
+  uint8_t *start;     // Argument start position
+  uint8_t *end;       // Argument end position
+};
+
 struct msg {
   object_t object;
   TAILQ_ENTRY(msg) c_tqe; /* link in client q */
@@ -413,15 +418,16 @@ struct msg {
   msg_type_t type; /* message type */
 
   struct array *keys; /* array of keypos, for req */
+  struct array *args; /* array of keypos, for req */
 
   uint32_t vlen; /* value length (memcache) */
   uint8_t *end;  /* end marker (memcache) */
 
-  uint8_t *narg_start; /* narg start (redis) */
-  uint8_t *narg_end;   /* narg end (redis) */
-  uint32_t narg;       /* # arguments (redis) */
+  uint8_t *ntoken_start; /* ntoken start (redis) */
+  uint8_t *ntoken_end;   /* ntoken end (redis) */
+  uint32_t ntokens;       /* # tokens (redis) */
   uint32_t nkeys;      /* # keys in script (redis EVAL/EVALSHA) */
-  uint32_t rnarg;      /* running # arg used by parsing fsa (redis) */
+  uint32_t rntokens;      /* running # tokens used by parsing fsa (redis) */
   uint32_t rlen;       /* running length in parsing fsa (redis) */
   uint32_t integer;    /* integer reply value (redis) */
 

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -196,7 +196,7 @@ void memcache_parse_req(struct msg *r, const struct string *hash_tag) {
           m = r->token;
           r->token = NULL;
           r->type = MSG_UNKNOWN;
-          r->narg++;
+          r->ntokens++;
 
           switch (p - m) {
             case 3:
@@ -383,7 +383,7 @@ void memcache_parse_req(struct msg *r, const struct string *hash_tag) {
           kpos->start = r->token;
           kpos->end = p;
 
-          r->narg++;
+          r->ntokens++;
           r->token = NULL;
 
           /* get next state */
@@ -1325,7 +1325,7 @@ static rstatus_t memcache_fragment_retrieval(struct msg *r,
     }
     r->frag_seq[i] = sub_msg = sub_msgs[idx];
 
-    sub_msg->narg++;
+    sub_msg->ntokens++;
     status = memcache_append_key(sub_msg, kpos->start, kpos->end - kpos->start);
     if (status != DN_OK) {
       dn_free(sub_msgs);


### PR DESCRIPTION
Currently the Redis parser in Dynomite only records the position of
the initial key as a 'struct keypos', and passes along the remaining
arguments as is to Redis. This patch records the argument positions
as well during request parsing. This will allow us to easily refer back
to the arguments after the parsing stage for things like query rewrites,
further request analysis, etc. The newly introduced 'args' array is not
used in this patch, but will be used in upcoming patches motivated by
the read-repairs work.

This patch also renames the fields prefixed with "narg*" in 'struct msg'
to "ntoken*". This is because the code actually treats all 'narg's as
tokens and solely not as arguments. The rename is done to avoid
ambiguity between arguments and tokens.