### PR TITLE
Print test cluster topology information

### DIFF
--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -12,7 +12,7 @@ from plumbum import local
 
 from dyno_cluster import DynoCluster
 from func_test import comparison_test
-from utils import generate_ips, setup_temp_dir
+from utils import generate_ips, setup_temp_dir, sleep_with_animation
 from redis_node import RedisNode
 
 REDIS_PORT = 1212
@@ -49,7 +49,7 @@ def main():
         stack.enter_context(dynomite_cluster)
 
         # Wait for a while for the above nodes to start.
-        sleep(SETTLE_TIME)
+        sleep_with_animation(SETTLE_TIME, "Waiting for cluster to start")
 
         # Run all the functional comparison tests.
         comparison_test(standalone_redis, dynomite_cluster, False)

--- a/test/dyno_cluster.py
+++ b/test/dyno_cluster.py
@@ -115,6 +115,19 @@ class DynoCluster(object):
         with open(CLUSTER_DESC_FILEPATH, 'w') as outfile:
             yaml.dump(yaml_cluster_desc, outfile, default_flow_style=False)
 
+    def _print_cluster_topology(self):
+        tokens = tokens_for_cluster(self.request['cluster_desc'], None)
+        print("Cluster topology:-");
+        for dc, racks in tokens:
+            print("\tDC: %s" % dc)
+            for rack, tokens in racks:
+                print("\t\tRack: %s" % rack)
+                # Nested loop is okay here since the #nodes will always be small.
+                for node in self.nodes:
+                    if node.spec.dc == dc and node.spec.rack == rack:
+                        print("\t\t\tNode: %s  || PID: %s" % (node.name, \
+                            node.get_dyno_node_pid()))
+
     def _delete_running_cluster_file(self):
         os.remove(CLUSTER_DESC_FILEPATH)
 
@@ -129,6 +142,7 @@ class DynoCluster(object):
 
         # Now that the cluster is up, write its description to a file.
         self._write_running_cluster_file()
+        self._print_cluster_topology()
 
     def teardown(self):
         for n in self.nodes:

--- a/test/start_cluster.py
+++ b/test/start_cluster.py
@@ -6,7 +6,7 @@ from plumbum import local
 from time import sleep
 
 from dyno_cluster import DynoCluster
-from utils import generate_ips, setup_temp_dir
+from utils import generate_ips, setup_temp_dir, sleep_with_animation
 
 SETTLE_TIME = 5
 
@@ -33,7 +33,7 @@ def main():
         dynomite_cluster.launch()
 
         # Wait for a while for the above nodes to start.
-        sleep(SETTLE_TIME)
+        sleep_with_animation(SETTLE_TIME, "Waiting for cluster to start")
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,6 +4,8 @@ import os
 import signal
 import string
 import yaml
+import time
+import sys
 
 from ip_util import int2quad
 from ip_util import quad2int
@@ -15,7 +17,22 @@ from itertools import count
 
 BASE_IPADDRESS = quad2int('127.0.1.1')
 RING_SIZE = 2**32
+TEARDOWN_SETTLE_TIME = 1
 
+
+def sleep_with_animation(seconds, optional_msg=""):
+    ticker = "|/-\\"
+    print("\n")
+    for i in range(seconds * 10):
+        time.sleep(0.1)
+        sys.stdout.write(\
+            "\r" + ticker[i % len(ticker)] + \
+            "\t" + ticker[i % len(ticker)] + \
+            "\t" + optional_msg + \
+            "\t" + ticker[i % len(ticker)] + \
+            "\t" + ticker[i % len(ticker)])
+        sys.stdout.flush()
+    print("\n")
 
 def string_generator(size=6, chars=string.ascii_letters + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
@@ -56,6 +73,7 @@ def teardown_running_cluster(cluster_desc_filepath, delete_test_dir=False):
                 # Delete the test directory of this cluster.
                 shutil.rmtree(yaml_desc['test_dir'])
         os.remove(cluster_desc_filepath)
+        sleep_with_animation(TEARDOWN_SETTLE_TIME, "Tearing down cluster")
 
 def setup_temp_dir():
     tempdir = LocalPath(mkdtemp(dir='.', prefix='test_run.'))


### PR DESCRIPTION
This patch prints the cluster topology information when starting
a test cluster, along with the PIDs of each Dyno node which is
useful for quicker debugging (attaching GDB to process, etc.).