### PR TITLE
[WIP] Read repairs for primary keys

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -47,9 +47,10 @@
 #include "dyn_dict_msg_id.h"
 #include "dyn_dnode_peer.h"
 #include "dyn_server.h"
+#include "dyn_util.h"
 
-static rstatus_t msg_quorum_rsp_handler(struct msg *req, struct msg *rsp);
-static msg_response_handler_t msg_get_rsp_handler(struct msg *req);
+static rstatus_t msg_quorum_rsp_handler(struct context *ctx, struct msg *req, struct msg *rsp);
+static msg_response_handler_t msg_get_rsp_handler(struct context *ctx, struct msg *req);
 
 static rstatus_t rewrite_query_if_necessary(struct msg **req,
                                             struct context *ctx);
@@ -230,7 +231,7 @@ static void client_close(struct context *ctx, struct conn *conn) {
  * request scenario and then use the post coalesce logic to cook up a combined
  * response
  */
-static rstatus_t client_handle_response(struct conn *conn, msgid_t reqid,
+static rstatus_t client_handle_response(struct context *ctx, struct conn *conn, msgid_t reqid,
                                         struct msg *rsp) {
   // now the handler owns the response.
   ASSERT(conn->type == CONN_CLIENT);
@@ -242,7 +243,7 @@ static rstatus_t client_handle_response(struct conn *conn, msgid_t reqid,
     return DN_OK;
   }
   // we have to submit the response irrespective of the unref status.
-  rstatus_t status = msg_handle_response(req, rsp);
+  rstatus_t status = msg_handle_response(ctx, req, rsp);
   if (conn->waiting_to_unref) {
     // don't care about the status.
     if (req->awaiting_rsps) return DN_OK;
@@ -336,6 +337,11 @@ struct msg *req_recv_next(struct context *ctx, struct conn *conn, bool alloc) {
     conn->rmsg = req;
   }
 
+  // Record timetamps if repairs are enabled.
+  // TODO: Consider requests that span multiple mbufs.
+  if (ctx->repairs_enabled) {
+    req->timestamp = current_timestamp_in_millis();
+  }
   return req;
 }
 
@@ -404,7 +410,7 @@ void req_forward_error(struct context *ctx, struct conn *conn, struct msg *req,
   rsp->dmsg = dmsg_get();
   rsp->dmsg->id = req->id;
 
-  rstatus_t status = conn_handle_response(
+  rstatus_t status = conn_handle_response(ctx,
       conn, req->parent_id ? req->parent_id : req->id, rsp);
   IGNORE_RET_VAL(status);
 }
@@ -825,7 +831,7 @@ static void req_forward_local_dc(struct context *ctx, struct conn *c_conn,
                                  uint8_t *key, uint32_t keylen,
                                  struct datacenter *dc) {
   struct server_pool *pool = c_conn->owner;
-  req->rsp_handler = msg_get_rsp_handler(req);
+  req->rsp_handler = msg_get_rsp_handler(ctx, req);
   if (request_send_to_all_local_racks(req)) {
     // send request to all local racks
     req_forward_all_local_racks(ctx, c_conn, req, orig_mbuf, key, keylen, dc);
@@ -970,6 +976,32 @@ rstatus_t rewrite_query_if_necessary(struct msg **req, struct context *ctx) {
 }
 
 /*
+ * Rewrites a query as a script that updates both the data and metadata.
+ *
+ * If a rewrite occured, it will replace '*req' with the new 'msg' that contains
+ * the new query and free up the original msg.
+ *
+ */
+rstatus_t rewrite_query_with_timestamp_md(struct msg **req, struct context *ctx) {
+
+  if (ctx->repairs_enabled == false) return DN_OK;
+
+  bool did_rewrite = false;
+  struct msg *new_req = NULL;
+  rstatus_t ret_status = g_rewrite_query_with_timestamp_md(
+      *req, ctx, &did_rewrite, &new_req);
+  THROW_STATUS(ret_status);
+
+  if (did_rewrite) {
+    // If we successfully did a rewrite, we need to recycle the memory used by
+    // the original request and point it to the 'new_req'.
+    msg_put(*req);
+    *req = new_req;
+  }
+  return DN_OK;
+}
+
+/*
  * Fragments a query if applicable.
  * 'frag_msgq' will be non-empty if the query is fragmented.
  */
@@ -1007,6 +1039,9 @@ void req_recv_done(struct context *ctx, struct conn *conn, struct msg *req,
   status = fragment_query_if_necessary(req, conn, &frag_msgq);
   if (status != DN_OK) goto error;
 
+  status = rewrite_query_with_timestamp_md(&req, ctx);
+  if (status != DN_OK) goto error;
+
   /* if no fragment happened */
   if (TAILQ_EMPTY(&frag_msgq)) {
     req_forward(ctx, conn, req);
@@ -1035,7 +1070,7 @@ error:
   return;
 }
 
-static msg_response_handler_t msg_get_rsp_handler(struct msg *req) {
+static msg_response_handler_t msg_get_rsp_handler(struct context *ctx, struct msg *req) {
   if (request_send_to_all_local_racks(req)) {
     // Request is being braoadcasted
     // Check if its quorum
@@ -1045,7 +1080,7 @@ static msg_response_handler_t msg_get_rsp_handler(struct msg *req) {
   return msg_local_one_rsp_handler;
 }
 
-rstatus_t msg_local_one_rsp_handler(struct msg *req, struct msg *rsp) {
+rstatus_t msg_local_one_rsp_handler(struct context *ctx, struct msg *req, struct msg *rsp) {
   ASSERT_LOG(!req->selected_rsp,
              "Received more than one response for dc_one.\
                %s prev %s new rsp %s",
@@ -1071,12 +1106,13 @@ static rstatus_t swallow_extra_rsp(struct msg *req, struct msg *rsp) {
   return DN_NOOPS;
 }
 
-static rstatus_t msg_quorum_rsp_handler(struct msg *req, struct msg *rsp) {
+static rstatus_t msg_quorum_rsp_handler(struct context *ctx, struct msg *req,
+    struct msg *rsp) {
   if (req->rspmgr.done) return swallow_extra_rsp(req, rsp);
   rspmgr_submit_response(&req->rspmgr, rsp);
   if (!rspmgr_check_is_done(&req->rspmgr)) return DN_EAGAIN;
   // rsp is absorbed by rspmgr. so we can use that variable
-  rsp = rspmgr_get_response(&req->rspmgr);
+  rsp = rspmgr_get_response(ctx, &req->rspmgr);
   ASSERT(rsp);
   rspmgr_free_other_responses(&req->rspmgr, rsp);
   rsp->peer = req;

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -270,6 +270,8 @@ static rstatus_t conf_pool_init(struct conf_pool *cp, struct string *name) {
     return status;
   }
 
+  cp->repairs_enabled = false;
+
   log_debug(LOG_VVERB, "init conf pool %p, '%.*s'", cp, name->len, name->data);
 
   return DN_OK;
@@ -1167,6 +1169,8 @@ static struct command conf_commands[] = {
     {string("remote_peer_connections"), conf_set_num,
      offsetof(struct conf_pool, remote_peer_connections)},
 
+    {string("repairs_enabled"), conf_set_bool,
+     offsetof(struct conf_pool, repairs_enabled)},
     null_command};
 
 static rstatus_t conf_handler(struct conf *cf, void *data) {

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -131,6 +131,9 @@ struct conf_pool {
   uint8_t datastore_connections;
   uint8_t local_peer_connections;
   uint8_t remote_peer_connections;
+
+  /* repairs enabled */
+  bool repairs_enabled;
 };
 
 struct conf {

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -63,7 +63,7 @@ typedef void (*func_ref_t)(struct conn *, void *);
 typedef void (*func_unref_t)(struct conn *);
 
 typedef void (*func_msgq_t)(struct context *, struct conn *, struct msg *);
-typedef rstatus_t (*func_response_handler)(struct conn *, msgid_t reqid,
+typedef rstatus_t (*func_response_handler)(struct context *ctx, struct conn *, msgid_t reqid,
                                            struct msg *rsp);
 struct conn_pool;
 
@@ -149,15 +149,16 @@ struct conn {
   connection_type_t type;
 };
 
-static inline rstatus_t conn_cant_handle_response(struct conn *conn,
+static inline rstatus_t conn_cant_handle_response(struct context *ctx, struct conn *conn,
                                                   msgid_t reqid,
                                                   struct msg *resp) {
   return DN_ENO_IMPL;
 }
 
-static inline rstatus_t conn_handle_response(struct conn *conn, msgid_t msgid,
+static inline rstatus_t conn_handle_response(struct context *ctx, struct conn *conn,
+                                             msgid_t msgid,
                                              struct msg *rsp) {
-  return conn->ops->rsp_handler(conn, msgid, rsp);
+  return conn->ops->rsp_handler(ctx, conn, msgid, rsp);
 }
 
 #define conn_recv(ctx, conn) (conn)->ops->recv(ctx, conn)

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -32,6 +32,7 @@
 #include "dyn_server.h"
 #include "dyn_task.h"
 #include "event/dyn_event.h"
+
 uint32_t admin_opt = 0;
 
 static void core_print_peer_status(void *arg1) {
@@ -308,6 +309,9 @@ rstatus_t core_start(struct instance *nci) {
   }
   // XXX: Gossip is currently not maintained actively, so ignore any failures.
   IGNORE_RET_VAL(core_gossip_pool_init(ctx));
+
+  // Set the repairs flag.
+  ctx->repairs_enabled = ctx->cf->pool.repairs_enabled;
 
   /**
    * Providing mbuf_size and alloc_msgs through the command line

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -276,6 +276,7 @@ struct context {
   dyn_state_t dyn_state;     /* state of the node.  Don't need volatile as
                                 it is ok to eventually get its new value */
   uint32_t admin_opt;        /* admin mode */
+  bool repairs_enabled;      /* Repairs out of sync replicas */
 };
 
 rstatus_t core_start(struct instance *nci);

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -200,7 +200,7 @@ static void dnode_client_close(struct context *ctx, struct conn *conn) {
   conn_unref(conn);
 }
 
-static rstatus_t dnode_client_handle_response(struct conn *conn, msgid_t reqid,
+static rstatus_t dnode_client_handle_response(struct context *ctx, struct conn *conn, msgid_t reqid,
                                               struct msg *rsp) {
   // Forward the response to the caller which is client connection.
   rstatus_t status = DN_OK;
@@ -218,7 +218,7 @@ static rstatus_t dnode_client_handle_response(struct conn *conn, msgid_t reqid,
   // client/coordinator. Hence all work for this request is done at this time
   ASSERT_LOG(!req->selected_rsp, "req %lu:%lu has selected_rsp set", req->id,
              req->parent_id);
-  status = msg_handle_response(req, rsp);
+  status = msg_handle_response(ctx, req, rsp);
   if (conn->waiting_to_unref) {
     dictDelete(conn->outstanding_msgs_dict, &reqid);
     log_info("Putting %s", print_obj(req));

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -320,7 +320,7 @@ static void dnode_peer_ack_err(struct context *ctx, struct conn *conn,
   log_info("%s Closing req %u:%u len %" PRIu32 " type %d %c %s",
            print_obj(conn), req->id, req->parent_id, req->mlen, req->type,
            conn->err ? ':' : ' ', conn->err ? strerror(conn->err) : " ");
-  rstatus_t status = conn_handle_response(
+  rstatus_t status = conn_handle_response(ctx,
       c_conn, req->parent_id ? req->parent_id : req->id, rsp);
   IGNORE_RET_VAL(status);
   if (req->swallow) req_put(req);
@@ -1005,7 +1005,7 @@ static void dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn,
 
   dnode_rsp_forward_stats(ctx, rsp);
   // c_conn owns respnse now
-  status = conn_handle_response(c_conn,
+  status = conn_handle_response(ctx, c_conn,
                                 req->parent_id ? req->parent_id : req->id, rsp);
   IGNORE_RET_VAL(status);
   if (req->swallow) {
@@ -1117,7 +1117,7 @@ static void dnode_rsp_forward(struct context *ctx, struct conn *peer_conn,
         "Peer connection s %d skipping request %u:%u, dummy err_rsp %u:%u",
         peer_conn->sd, req->id, req->parent_id, err_rsp->id,
         err_rsp->parent_id);
-    rstatus_t status = conn_handle_response(
+    rstatus_t status = conn_handle_response(ctx,
         c_conn, req->parent_id ? req->parent_id : req->id, err_rsp);
     IGNORE_RET_VAL(status);
     if (req->swallow) {

--- a/src/dyn_response_mgr.h
+++ b/src/dyn_response_mgr.h
@@ -1,6 +1,6 @@
-
 #ifndef _DYN_RESPONSE_MGR_H_
 #define _DYN_RESPONSE_MGR_H_
+
 #define MAX_REPLICAS_PER_DC 3
 struct response_mgr {
   bool is_read;
@@ -24,11 +24,11 @@ void init_response_mgr(struct response_mgr *rspmgr, struct msg *, bool is_read,
 // DN_OK if response was accepted
 rstatus_t rspmgr_submit_response(struct response_mgr *rspmgr, struct msg *rsp);
 bool rspmgr_check_is_done(struct response_mgr *rspmgr);
-struct msg *rspmgr_get_response(struct response_mgr *rspmgr);
+struct msg *rspmgr_get_response(struct context *ctx, struct response_mgr *rspmgr);
 void rspmgr_free_response(struct response_mgr *rspmgr, struct msg *dont_free);
 void rspmgr_free_other_responses(struct response_mgr *rspmgr,
                                  struct msg *dont_free);
-rstatus_t msg_local_one_rsp_handler(struct msg *req, struct msg *rsp);
+rstatus_t msg_local_one_rsp_handler(struct context *ctx, struct msg *req, struct msg *rsp);
 rstatus_t rspmgr_clone_responses(struct response_mgr *src,
                                  struct array *responses);
 

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -28,6 +28,7 @@
 #include "dyn_dnode_peer.h"
 #include "dyn_server.h"
 #include "dyn_token.h"
+#include "dyn_util.h"
 
 static char *_print_datastore(const struct object *obj) {
   ASSERT(obj->type == OBJ_DATASTORE);
@@ -201,7 +202,7 @@ static void server_ack_err(struct context *ctx, struct conn *conn,
   log_info("close %s req %s len %" PRIu32 " from %s %c %s", print_obj(conn),
            print_obj(req), req->mlen, print_obj(c_conn), conn->err ? ':' : ' ',
            conn->err ? strerror(conn->err) : " ");
-  rstatus_t status = conn_handle_response(
+  rstatus_t status = conn_handle_response(ctx,
       c_conn, req->parent_id ? req->parent_id : req->id, rsp);
   IGNORE_RET_VAL(status);
   if (req->swallow) req_put(req);
@@ -692,6 +693,11 @@ struct msg *rsp_recv_next(struct context *ctx, struct conn *conn, bool alloc) {
     conn->rmsg = rsp;
   }
 
+  // Record timetamps if repairs are enabled.
+  // TODO: Consider requests that span multiple mbufs.
+  if (ctx->repairs_enabled) {
+    rsp->timestamp = current_timestamp_in_millis();
+  }
   return rsp;
 }
 
@@ -785,7 +791,7 @@ static void server_rsp_forward(struct context *ctx, struct conn *s_conn,
 
   server_rsp_forward_stats(ctx, rsp);
   // handler owns the response now
-  status = conn_handle_response(c_conn, req->id, rsp);
+  status = conn_handle_response(ctx, c_conn, req->id, rsp);
   IGNORE_RET_VAL(status);
 }
 

--- a/src/dyn_util.c
+++ b/src/dyn_util.c
@@ -591,3 +591,16 @@ char *dn_unresolve_desc(int sd) {
 
   return dn_unresolve_addr(addr, addrlen);
 }
+
+int count_digits(uint64_t arg) {
+  return snprintf(NULL, 0, "%llu", arg) - (arg < 0);
+}
+
+uint64_t current_timestamp_in_millis() {
+  struct timeval t;
+  // Get the current time.
+  gettimeofday(&t, NULL);
+  uint64_t millis = (uint64_t)(t.tv_sec*1000LL + t.tv_usec/1000);
+
+  return millis;
+}

--- a/src/dyn_util.h
+++ b/src/dyn_util.h
@@ -380,4 +380,14 @@ unsigned int dict_string_hash(const void *key);
 int dict_string_key_compare(void *privdata, const void *key1, const void *key2);
 void dict_string_destructor(void *privdata, void *val);
 
+/*
+ * Counts the total number of digits in 'arg'.
+ */
+int count_digits(uint64_t arg);
+
+/*
+ * Returns the current timestamp in milliseconds.
+ */
+uint64_t current_timestamp_in_millis(void);
+
 #endif

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -35,6 +35,8 @@
 #include "dyn_core.h"
 #include "dyn_signal.h"
 
+#include "proto/dyn_proto.h"
+
 #if defined(SYSCONFDIR)
 #define DN_CONF_PATH SYSCONFDIR "/dynomite.yml"
 #else

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1608,11 +1608,25 @@ struct msg *memcache_reconcile_responses(struct response_mgr *rspmgr) {
   }
 }
 
+void memcache_init_datastore() {
+}
+
 /*
  * Placeholder function for memcache query rewrites.
  * No rewrites implemented toady.
  */
 rstatus_t memcache_rewrite_query(struct msg *orig_msg, struct context *ctx,
                                  bool *did_rewrite, struct msg **new_msg_ptr) {
+  return DN_OK;
+}
+
+rstatus_t memcache_rewrite_query_with_timestamp_md(struct msg *orig_msg,
+    struct context *ctx, bool *did_rewrite, struct msg **new_msg_ptr) {
+  return DN_OK;
+}
+
+rstatus_t memcache_make_repair_query(struct context *ctx, struct msg **new_msg_ptr,
+     struct conn *conn, uint64_t timestamp, uint32_t keylen, uint8_t *key,
+     uint32_t valuelen, uint8_t *value /* ,msg_type_t msg_type */) {
   return DN_OK;
 }

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 
+#include "../dyn_message.h"
 #include "../dyn_types.h"
 
 // Forward declarations
@@ -48,6 +49,13 @@ rstatus_t memcache_verify_request(struct msg *r, struct server_pool *pool,
                                   struct rack *rack);
 rstatus_t memcache_rewrite_query(struct msg *orig_msg, struct context *ctx,
                                  bool *did_rewrite, struct msg **new_msg_ptr);
+rstatus_t memcache_rewrite_query_with_timestamp_md(struct msg *orig_msg,
+    struct context *ctx, bool *did_rewrite, struct msg **new_msg_ptr);
+rstatus_t memcache_make_repair_query(struct context *ctx, struct msg **new_msg_ptr,
+    struct conn *conn, uint64_t timestamp, uint32_t keylen, uint8_t *key,
+    uint32_t valuelen, uint8_t *value /* ,msg_type_t msg_type */);
+void redis_init_datastore();
+
 
 void redis_parse_req(struct msg *r, const struct string *hash_tag);
 void redis_parse_rsp(struct msg *r, const struct string *UNUSED);
@@ -61,5 +69,10 @@ rstatus_t redis_verify_request(struct msg *r, struct server_pool *pool,
                                struct rack *rack);
 rstatus_t redis_rewrite_query(struct msg *orig_msg, struct context *ctx,
                               bool *did_rewrite, struct msg **new_msg_ptr);
-
+rstatus_t redis_rewrite_query_with_timestamp_md(struct msg *orig_msg,
+    struct context *ctx, bool *did_rewrite, struct msg **new_msg_ptr);
+rstatus_t redis_make_repair_query(struct context *ctx, struct conn *conn,
+    uint64_t timestamp, uint32_t keylen, uint8_t *key, struct msg *orig_msg,
+    struct msg **new_msg_ptr);
+void memcache_init_datastore();
 #endif


### PR DESCRIPTION
This patch adds read repairs for primary keys. It specifically works
only with the following commands at the moment:
 - SET
 - GET
 - DEL
 - APPEND

Repiars need to be enabled under a flag in the YAML configuration. It is
enabled only if 'repairs_enabled: true' is specified.

This current implementation of repairs is not supported and returns the
values in a custom format:
1) E/N (exists or not-exists)
2) Value itself
3) Timestamp of value

This custom format will be removed in future patches to standardize on
the regular Redis wire protocol.

Currently the timestamp is generated on the server side. Client side
timestamp support will be added in future patches.

TODO:-
 - Add client side timestamp support.
 - Add repair support for secondary keys.
 - Remove custom result format.
 - Add support for tracking expired keys.
 - Add background repir process.
 - Add documentation on repair implementation.