### PR TITLE
[Unsupported] Read repairs implementation

### DIFF
--- a/docker/scripts/startup.sh
+++ b/docker/scripts/startup.sh
@@ -3,4 +3,4 @@
 #Start redis server on 22122
 redis-server --port 22122 &
 
-src/dynomite --conf-file=conf/redis_single.yml -v11
+src/dynomite --conf-file=conf/redis_single.yml -v5

--- a/src/dyn_client.h
+++ b/src/dyn_client.h
@@ -27,4 +27,8 @@
 
 void init_client_conn(struct conn *conn);
 
+rstatus_t req_forward_to_peer(struct context *ctx, struct conn *c_conn,
+     struct msg *req, struct node *peer, uint8_t* key, uint32_t keylen,
+     struct mbuf *orig_mbuf, bool force_copy, dyn_error_t *dyn_error_code);
+
 #endif

--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -270,6 +270,8 @@ static rstatus_t conf_pool_init(struct conf_pool *cp, struct string *name) {
     return status;
   }
 
+  cp->read_repairs_enabled = false;
+
   log_debug(LOG_VVERB, "init conf pool %p, '%.*s'", cp, name->len, name->data);
 
   return DN_OK;
@@ -1167,6 +1169,8 @@ static struct command conf_commands[] = {
     {string("remote_peer_connections"), conf_set_num,
      offsetof(struct conf_pool, remote_peer_connections)},
 
+    {string("read_repairs_enabled"), conf_set_bool,
+     offsetof(struct conf_pool, read_repairs_enabled)},
     null_command};
 
 static rstatus_t conf_handler(struct conf *cf, void *data) {

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -131,6 +131,9 @@ struct conf_pool {
   uint8_t datastore_connections;
   uint8_t local_peer_connections;
   uint8_t remote_peer_connections;
+
+  /* repairs enabled */
+  bool read_repairs_enabled;
 };
 
 struct conf {

--- a/src/dyn_connection.h
+++ b/src/dyn_connection.h
@@ -63,7 +63,7 @@ typedef void (*func_ref_t)(struct conn *, void *);
 typedef void (*func_unref_t)(struct conn *);
 
 typedef void (*func_msgq_t)(struct context *, struct conn *, struct msg *);
-typedef rstatus_t (*func_response_handler)(struct conn *, msgid_t reqid,
+typedef rstatus_t (*func_response_handler)(struct context *ctx, struct conn *, msgid_t reqid,
                                            struct msg *rsp);
 struct conn_pool;
 
@@ -149,15 +149,16 @@ struct conn {
   connection_type_t type;
 };
 
-static inline rstatus_t conn_cant_handle_response(struct conn *conn,
+static inline rstatus_t conn_cant_handle_response(struct context *ctx, struct conn *conn,
                                                   msgid_t reqid,
                                                   struct msg *resp) {
   return DN_ENO_IMPL;
 }
 
-static inline rstatus_t conn_handle_response(struct conn *conn, msgid_t msgid,
+static inline rstatus_t conn_handle_response(struct context *ctx, struct conn *conn,
+                                             msgid_t msgid,
                                              struct msg *rsp) {
-  return conn->ops->rsp_handler(conn, msgid, rsp);
+  return conn->ops->rsp_handler(ctx, conn, msgid, rsp);
 }
 
 #define conn_recv(ctx, conn) (conn)->ops->recv(ctx, conn)

--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -32,6 +32,7 @@
 #include "dyn_server.h"
 #include "dyn_task.h"
 #include "event/dyn_event.h"
+
 uint32_t admin_opt = 0;
 
 static void core_print_peer_status(void *arg1) {
@@ -308,6 +309,9 @@ rstatus_t core_start(struct instance *nci) {
   }
   // XXX: Gossip is currently not maintained actively, so ignore any failures.
   IGNORE_RET_VAL(core_gossip_pool_init(ctx));
+
+  // Set the repairs flag.
+  ctx->read_repairs_enabled = ctx->cf->pool.read_repairs_enabled;
 
   /**
    * Providing mbuf_size and alloc_msgs through the command line

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -276,6 +276,7 @@ struct context {
   dyn_state_t dyn_state;     /* state of the node.  Don't need volatile as
                                 it is ok to eventually get its new value */
   uint32_t admin_opt;        /* admin mode */
+  bool read_repairs_enabled;      /* Repairs out of sync replicas */
 };
 
 rstatus_t core_start(struct instance *nci);

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -200,7 +200,7 @@ static void dnode_client_close(struct context *ctx, struct conn *conn) {
   conn_unref(conn);
 }
 
-static rstatus_t dnode_client_handle_response(struct conn *conn, msgid_t reqid,
+static rstatus_t dnode_client_handle_response(struct context *ctx, struct conn *conn, msgid_t reqid,
                                               struct msg *rsp) {
   // Forward the response to the caller which is client connection.
   rstatus_t status = DN_OK;
@@ -218,7 +218,7 @@ static rstatus_t dnode_client_handle_response(struct conn *conn, msgid_t reqid,
   // client/coordinator. Hence all work for this request is done at this time
   ASSERT_LOG(!req->selected_rsp, "req %lu:%lu has selected_rsp set", req->id,
              req->parent_id);
-  status = msg_handle_response(req, rsp);
+  status = msg_handle_response(ctx, req, rsp);
   if (conn->waiting_to_unref) {
     dictDelete(conn->outstanding_msgs_dict, &reqid);
     log_info("Putting %s", print_obj(req));

--- a/src/dyn_dnode_msg.c
+++ b/src/dyn_dnode_msg.c
@@ -412,9 +412,10 @@ static void data_store_parse_req(struct msg *r, const struct string *hash_tag) {
   }
 }
 
-void dyn_parse_req(struct msg *r, const struct string *hash_tag) {
+void dyn_parse_req(struct msg *r, struct context *ctx) {
   bool done_parsing = false;
   struct mbuf *b = STAILQ_LAST(&r->mhdr, mbuf, next);
+  const struct string* hash_tag = &ctx->pool.hash_tag;
 
   if (dyn_parse_core(r)) {
     struct dmsg *dmsg = r->dmsg;
@@ -507,18 +508,18 @@ void dyn_parse_req(struct msg *r, const struct string *hash_tag) {
   r->result = MSG_PARSE_AGAIN;
 }
 
-static void data_store_parse_rsp(struct msg *r, const struct string *hash_tag) {
+static void data_store_parse_rsp(struct msg *r, struct context *ctx) {
   if (g_data_store == DATA_REDIS) {
-    return redis_parse_rsp(r, hash_tag);
+    return redis_parse_rsp(r, ctx);
   } else if (g_data_store == DATA_MEMCACHE) {
-    return memcache_parse_rsp(r, hash_tag);
+    return memcache_parse_rsp(r, ctx);
   } else {
     ASSERT_LOG(false, "invalid datastore");
     exit(1);
   }
 }
 
-void dyn_parse_rsp(struct msg *r, const struct string *UNUSED) {
+void dyn_parse_rsp(struct msg *r, struct context *ctx) {
   if (log_loggable(LOG_VVERB)) {
     log_debug(LOG_VVERB,
               ":::::::::::::::::::::: In dyn_parse_rsp, start to process "
@@ -576,7 +577,7 @@ void dyn_parse_rsp(struct msg *r, const struct string *UNUSED) {
 
         r->mlen = mbuf_length(decrypted_buf);
 
-        return data_store_parse_rsp(r, UNUSED);
+        return data_store_parse_rsp(r, ctx);
       }
 
       // Subtract already received bytes
@@ -586,7 +587,7 @@ void dyn_parse_rsp(struct msg *r, const struct string *UNUSED) {
     } else if (r->dyn_parse_state == DYN_POST_DONE) {
       struct mbuf *last_buf = STAILQ_LAST(&r->mhdr, mbuf, next);
       if (last_buf->flags & MBUF_FLAGS_READ_FLIP) {
-        data_store_parse_rsp(r, UNUSED);
+        data_store_parse_rsp(r, ctx);
       } else {
         r->result = MSG_PARSE_AGAIN;
       }
@@ -595,7 +596,7 @@ void dyn_parse_rsp(struct msg *r, const struct string *UNUSED) {
 
     if (done_parsing) return;
 
-    return data_store_parse_rsp(r, UNUSED);
+    return data_store_parse_rsp(r, ctx);
   }
 
   // bad case

--- a/src/dyn_dnode_msg.h
+++ b/src/dyn_dnode_msg.h
@@ -77,8 +77,8 @@ struct dmsg {
 
 TAILQ_HEAD(dmsg_tqh, dmsg);
 
-void dyn_parse_req(struct msg *r, const struct string *hash_tag);
-void dyn_parse_rsp(struct msg *r, const struct string *UNUSED);
+void dyn_parse_req(struct msg *r, struct context *ctx);
+void dyn_parse_rsp(struct msg *r, struct context *ctx);
 
 void dmsg_free(struct dmsg *dmsg);
 void dmsg_put(struct dmsg *dmsg);

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -320,7 +320,7 @@ static void dnode_peer_ack_err(struct context *ctx, struct conn *conn,
   log_info("%s Closing req %u:%u len %" PRIu32 " type %d %c %s",
            print_obj(conn), req->id, req->parent_id, req->mlen, req->type,
            conn->err ? ':' : ' ', conn->err ? strerror(conn->err) : " ");
-  rstatus_t status = conn_handle_response(
+  rstatus_t status = conn_handle_response(ctx,
       c_conn, req->parent_id ? req->parent_id : req->id, rsp);
   IGNORE_RET_VAL(status);
   if (req->swallow) req_put(req);
@@ -1005,7 +1005,7 @@ static void dnode_rsp_forward_match(struct context *ctx, struct conn *peer_conn,
 
   dnode_rsp_forward_stats(ctx, rsp);
   // c_conn owns respnse now
-  status = conn_handle_response(c_conn,
+  status = conn_handle_response(ctx, c_conn,
                                 req->parent_id ? req->parent_id : req->id, rsp);
   IGNORE_RET_VAL(status);
   if (req->swallow) {
@@ -1117,7 +1117,7 @@ static void dnode_rsp_forward(struct context *ctx, struct conn *peer_conn,
         "Peer connection s %d skipping request %u:%u, dummy err_rsp %u:%u",
         peer_conn->sd, req->id, req->parent_id, err_rsp->id,
         err_rsp->parent_id);
-    rstatus_t status = conn_handle_response(
+    rstatus_t status = conn_handle_response(ctx,
         c_conn, req->parent_id ? req->parent_id : req->id, err_rsp);
     IGNORE_RET_VAL(status);
     if (req->swallow) {

--- a/src/dyn_mbuf.c
+++ b/src/dyn_mbuf.c
@@ -174,7 +174,7 @@ uint32_t mbuf_length(struct mbuf *mbuf) {
  * Return the remaining space size for any new data in mbuf. Mbuf cannot
  * contain more than 2^32 bytes (4G).
  */
-uint32_t mbuf_size(struct mbuf *mbuf) {
+uint32_t mbuf_remaining_space(struct mbuf *mbuf) {
   ASSERT(mbuf->end >= mbuf->last);
 
   return (uint32_t)(mbuf->end - mbuf->last);
@@ -229,7 +229,7 @@ void mbuf_copy(struct mbuf *mbuf, uint8_t *pos, size_t n) {
   }
 
   /* mbuf has space for n bytes */
-  ASSERT(!mbuf_full(mbuf) && n <= mbuf_size(mbuf));
+  ASSERT(!mbuf_full(mbuf) && n <= mbuf_remaining_space(mbuf));
 
   /* no overlapping copy */
   ASSERT(pos < mbuf->start || pos >= mbuf->end);
@@ -309,13 +309,13 @@ void mbuf_deinit(void) {
 }
 
 void mbuf_write_char(struct mbuf *mbuf, char ch) {
-  ASSERT(mbuf_size(mbuf) >= 1);
+  ASSERT(mbuf_remaining_space(mbuf) >= 1);
   *mbuf->last = ch;
   mbuf->last += 1;
 }
 
 void mbuf_write_string(struct mbuf *mbuf, const struct string *s) {
-  ASSERT(s->len < mbuf_size(mbuf));
+  ASSERT(s->len < mbuf_remaining_space(mbuf));
   mbuf_copy(mbuf, s->data, s->len);
 }
 

--- a/src/dyn_mbuf.h
+++ b/src/dyn_mbuf.h
@@ -74,7 +74,7 @@ uint64_t mbuf_free_queue_size(void);
 void mbuf_dump(struct mbuf *mbuf);
 void mbuf_rewind(struct mbuf *mbuf);
 uint32_t mbuf_length(struct mbuf *mbuf);
-uint32_t mbuf_size(struct mbuf *mbuf);
+uint32_t mbuf_remaining_space(struct mbuf *mbuf);
 size_t mbuf_data_size(void);
 void mbuf_insert(struct mhdr *mhdr, struct mbuf *mbuf);
 void mbuf_insert_head(struct mhdr *mhdr, struct mbuf *mbuf);

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -356,6 +356,12 @@ done:
     return NULL;
   }
 
+  msg->args = array_create(1, sizeof(struct argpos));
+  if (msg->args == NULL) {
+    dn_free(msg);
+    return NULL;
+  }
+
   msg->vlen = 0;
   msg->end = NULL;
 
@@ -365,10 +371,10 @@ done:
   msg->nfrag_done = 0;
   msg->frag_id = 0;
 
-  msg->narg_start = NULL;
-  msg->narg_end = NULL;
-  msg->narg = 0;
-  msg->rnarg = 0;
+  msg->ntoken_start = NULL;
+  msg->ntoken_end = NULL;
+  msg->ntokens = 0;
+  msg->rntokens = 0;
   msg->nkeys = 0;
   msg->rlen = 0;
   msg->integer = 0;

--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -151,13 +151,16 @@ static struct rbnode tmo_rbs;    /* timeout rbtree sentinel */
 static size_t alloc_msgs_max; /* maximum number of allowed allocated messages */
 uint8_t g_timeout_factor = 1;
 
-func_msg_coalesce_t g_pre_coalesce;  /* message pre-coalesce */
-func_msg_coalesce_t g_post_coalesce; /* message post-coalesce */
-func_msg_fragment_t g_fragment;      /* message post-coalesce */
-func_msg_verify_t g_verify_request;  /* message post-coalesce */
+func_msg_coalesce_t g_pre_coalesce;     /* message pre-coalesce */
+func_msg_coalesce_t g_post_coalesce;    /* message post-coalesce */
+func_msg_fragment_t g_fragment;         /* message post-coalesce */
+func_msg_verify_t g_verify_request;     /* message post-coalesce */
 func_is_multikey_request g_is_multikey_request;
 func_reconcile_responses g_reconcile_responses;
-func_msg_rewrite_t g_rewrite_query; /* rewrite query in a msg if necessary */
+func_msg_rewrite_t g_rewrite_query;     /* rewrite query in a msg if necessary */
+/* rewrite query as script that updates both data and metadata */
+func_msg_rewrite_t g_rewrite_query_with_timestamp_md;
+func_msg_repair_t g_make_repair_query;  /* Send a repair msg. */
 
 #define DEFINE_ACTION(_name) string(#_name),
 static struct string msg_type_strings[] = {MSG_TYPE_CODEC(DEFINE_ACTION)
@@ -193,6 +196,8 @@ void set_datastore_ops(void) {
       g_is_multikey_request = redis_is_multikey_request;
       g_reconcile_responses = redis_reconcile_responses;
       g_rewrite_query = redis_rewrite_query;
+      g_rewrite_query_with_timestamp_md = redis_rewrite_query_with_timestamp_md;
+      g_make_repair_query = redis_make_repair_query;
       break;
     case DATA_MEMCACHE:
       g_pre_coalesce = memcache_pre_coalesce;
@@ -202,6 +207,8 @@ void set_datastore_ops(void) {
       g_is_multikey_request = memcache_is_multikey_request;
       g_reconcile_responses = memcache_reconcile_responses;
       g_rewrite_query = memcache_rewrite_query;
+      g_rewrite_query_with_timestamp_md = memcache_rewrite_query_with_timestamp_md;
+      g_make_repair_query = memcache_make_repair_query;
       break;
     default:
       return;
@@ -399,6 +406,11 @@ done:
   msg->dyn_error_code = 0;
   msg->rsp_handler = msg_local_one_rsp_handler;
   msg->consistency = DC_ONE;
+  msg->timestamp = 0;
+  msg->orig_type = MSG_UNKNOWN;
+  msg->orig_msg = NULL;
+  msg->needs_repair = false;
+
   return msg;
 }
 
@@ -615,6 +627,10 @@ void msg_put(struct msg *msg) {
     msg->keys = NULL;
   }
 
+  if (msg->orig_msg) {
+    msg_put(msg->orig_msg);
+    msg->orig_msg = NULL;
+  }
   TAILQ_INSERT_HEAD(&free_msgq, msg, m_tqe);
 }
 
@@ -671,6 +687,7 @@ void msg_init(size_t msgs_max) {
   alloc_msgs_max = msgs_max;
   TAILQ_INIT(&free_msgq);
   rbtree_init(&tmo_rbt, &tmo_rbs);
+
 }
 
 void msg_deinit(void) {
@@ -737,6 +754,43 @@ uint8_t *msg_get_full_key_copy(struct msg *msg, int idx, uint32_t *keylen) {
   copied_key[*keylen] = '\0';
 
   return copied_key;
+}
+
+static uint8_t *msg_get_arg(struct msg *req, uint32_t arg_index,
+                            uint32_t *arglen) {
+  *arglen = 0;
+  if (array_n(req->args) == 0) return NULL;
+  ASSERT_LOG(arg_index < array_n(req->args), "%s has %u keys", print_obj(req),
+             array_n(req->args));
+
+  struct argpos *argpos = array_get(req->args, arg_index);
+  uint8_t *arg_start = argpos->start;
+  uint8_t *arg_end = argpos->end;
+  *arglen = (uint32_t)(arg_end - arg_start);
+  return arg_start;
+}
+
+/*
+ * Returns the 'idx' arg in 'msg'.
+ *
+ * Transfers ownership of returned buffer to the caller, so the caller must
+ * take the responsibility of freeing it.
+ *
+ * Returns NULL if key does not exist or if we're unable to allocate memory.
+ */
+uint8_t *msg_get_arg_copy(struct msg *msg, int idx, uint32_t *arglen) {
+  // Get a pointer to the required arg in 'msg'.
+  uint8_t *arg_ptr = msg_get_arg(msg, idx, arglen);
+
+  // Allocate a new buffer for the key.
+  uint8_t *copied_arg = dn_alloc((size_t)(*arglen + 1));
+  if (copied_arg == NULL) return NULL;
+
+  // Copy contents of the key from 'msg' to our new buffer.
+  dn_memcpy(copied_arg, arg_ptr, *arglen);
+  copied_arg[*arglen] = '\0';
+
+  return copied_arg;
 }
 
 uint32_t msg_payload_crc32(struct msg *rsp) {

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -380,6 +380,11 @@ struct keypos {
   uint8_t *tag_end;   /* hashtagged key end pos */
 };
 
+struct argpos {
+  uint8_t *start;     // Argument start position
+  uint8_t *end;       // Argument end position
+};
+
 struct msg {
   object_t object;
   TAILQ_ENTRY(msg) c_tqe; /* link in client q */
@@ -413,15 +418,16 @@ struct msg {
   msg_type_t type; /* message type */
 
   struct array *keys; /* array of keypos, for req */
+  struct array *args; /* array of keypos, for req */
 
   uint32_t vlen; /* value length (memcache) */
   uint8_t *end;  /* end marker (memcache) */
 
-  uint8_t *narg_start; /* narg start (redis) */
-  uint8_t *narg_end;   /* narg end (redis) */
-  uint32_t narg;       /* # arguments (redis) */
+  uint8_t *ntoken_start; /* ntoken start (redis) */
+  uint8_t *ntoken_end;   /* ntoken end (redis) */
+  uint32_t ntokens;       /* # tokens (redis) */
   uint32_t nkeys;      /* # keys in script (redis EVAL/EVALSHA) */
-  uint32_t rnarg;      /* running # arg used by parsing fsa (redis) */
+  uint32_t rntokens;      /* running # tokens used by parsing fsa (redis) */
   uint32_t rlen;       /* running length in parsing fsa (redis) */
   uint32_t integer;    /* integer reply value (redis) */
 

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -39,40 +39,6 @@
 
 #define MAX_ALLOWABLE_PROCESSED_MSGS 500
 
-typedef void (*func_msg_parse_t)(struct msg *, const struct string *hash_tag);
-typedef rstatus_t (*func_msg_fragment_t)(struct msg *, struct server_pool *,
-                                         struct rack *, struct msg_tqh *);
-typedef rstatus_t (*func_msg_verify_t)(struct msg *, struct server_pool *,
-                                       struct rack *);
-typedef void (*func_msg_coalesce_t)(struct msg *r);
-typedef rstatus_t (*msg_response_handler_t)(struct msg *req, struct msg *rsp);
-typedef bool (*func_msg_failure_t)(struct msg *r);
-typedef bool (*func_is_multikey_request)(struct msg *r);
-typedef struct msg *(*func_reconcile_responses)(struct response_mgr *rspmgr);
-typedef rstatus_t (*func_msg_rewrite_t)(struct msg *orig_msg,
-                                        struct context *ctx, bool *did_rewrite,
-                                        struct msg **new_msg_ptr);
-
-extern func_msg_coalesce_t g_pre_coalesce;  /* message pre-coalesce */
-extern func_msg_coalesce_t g_post_coalesce; /* message post-coalesce */
-extern func_msg_fragment_t g_fragment;      /* message fragment */
-extern func_msg_verify_t g_verify_request;  /* message verify */
-extern func_is_multikey_request g_is_multikey_request;
-extern func_reconcile_responses g_reconcile_responses;
-extern func_msg_rewrite_t
-    g_rewrite_query; /* rewrite query in a msg if necessary */
-
-void set_datastore_ops(void);
-
-typedef enum msg_parse_result {
-  MSG_PARSE_OK,       /* parsing ok */
-  MSG_PARSE_ERROR,    /* parsing error */
-  MSG_PARSE_REPAIR,   /* more to parse -> repair parsed & unparsed data */
-  MSG_PARSE_FRAGMENT, /* multi-vector request -> fragment */
-  MSG_PARSE_AGAIN,    /* incomplete -> parse again */
-  MSG_OOM_ERROR
-} msg_parse_result_t;
-
 #define MSG_TYPE_CODEC(ACTION)                                                 \
   ACTION(UNKNOWN)                                                              \
   ACTION(REQ_MC_GET) /* memcache retrieval requests */                         \
@@ -228,11 +194,16 @@ typedef enum msg_parse_result {
   /* ACTION(REQ_REDIS_SELECT)*/ /* only during init */                         \
   ACTION(REQ_REDIS_PFADD)        /* redis requests - hyperloglog */            \
   ACTION(REQ_REDIS_PFCOUNT)                                                    \
+  ACTION(REQ_REDIS_CONFIG)                                                     \
+  ACTION(REQ_REDIS_SCRIPT)                                                     \
+  ACTION(REQ_REDIS_SCRIPT_LOAD)                                                \
+  ACTION(REQ_REDIS_SCRIPT_EXISTS)                                              \
+  ACTION(REQ_REDIS_SCRIPT_FLUSH)                                               \
+  ACTION(REQ_REDIS_SCRIPT_KILL)                                                \
   ACTION(RSP_REDIS_STATUS) /* redis response */                                \
   ACTION(RSP_REDIS_INTEGER)                                                    \
   ACTION(RSP_REDIS_BULK)                                                       \
   ACTION(RSP_REDIS_MULTIBULK)                                                  \
-  ACTION(REQ_REDIS_CONFIG)                                                     \
   ACTION(RSP_REDIS_ERROR)                                                      \
   ACTION(RSP_REDIS_ERROR_ERR)                                                  \
   ACTION(RSP_REDIS_ERROR_OOM)                                                  \
@@ -248,17 +219,54 @@ typedef enum msg_parse_result {
   ACTION(RSP_REDIS_ERROR_MASTERDOWN)                                           \
   ACTION(RSP_REDIS_ERROR_NOREPLICAS)                                           \
   ACTION(SENTINEL)                                                             \
-  ACTION(REQ_REDIS_SCRIPT)                                                     \
-  ACTION(REQ_REDIS_SCRIPT_LOAD)                                                \
-  ACTION(REQ_REDIS_SCRIPT_EXISTS)                                              \
-  ACTION(REQ_REDIS_SCRIPT_FLUSH)                                               \
-  ACTION(REQ_REDIS_SCRIPT_KILL)                                                \
+  ACTION(END_IDX)                                                              \
   /* ACTION( REQ_REDIS_AUTH) */                                                \
-  /* ACTION( REQ_REDIS_SELECT)*/ /* only during init */
+  /* ACTION( REQ_REDIS_SELECT)*/ /* only during init */                        \
 
 #define DEFINE_ACTION(_name) MSG_##_name,
 typedef enum msg_type { MSG_TYPE_CODEC(DEFINE_ACTION) } msg_type_t;
 #undef DEFINE_ACTION
+
+typedef void (*func_msg_parse_t)(struct msg *, const struct string *hash_tag);
+typedef rstatus_t (*func_msg_fragment_t)(struct msg *, struct server_pool *,
+                                         struct rack *, struct msg_tqh *);
+typedef rstatus_t (*func_msg_verify_t)(struct msg *, struct server_pool *,
+                                       struct rack *);
+typedef void (*func_msg_coalesce_t)(struct msg *r);
+typedef rstatus_t (*msg_response_handler_t)(struct context *ctx, struct msg *req,
+                                            struct msg *rsp);
+typedef bool (*func_msg_failure_t)(struct msg *r);
+typedef bool (*func_is_multikey_request)(struct msg *r);
+typedef struct msg *(*func_reconcile_responses)(struct response_mgr *rspmgr);
+typedef rstatus_t (*func_msg_rewrite_t)(struct msg *orig_msg,
+                                        struct context *ctx, bool *did_rewrite,
+                                        struct msg **new_msg_ptr);
+typedef rstatus_t (*func_msg_repair_t)(struct context *ctx, struct response_mgr *rspmgr,
+    struct msg **new_msg_ptr);
+typedef void (*func_init_datastore_t)();
+
+extern func_msg_coalesce_t g_pre_coalesce;  /* message pre-coalesce */
+extern func_msg_coalesce_t g_post_coalesce; /* message post-coalesce */
+extern func_msg_fragment_t g_fragment;      /* message fragment */
+extern func_msg_verify_t g_verify_request;  /* message verify */
+extern func_is_multikey_request g_is_multikey_request;
+extern func_reconcile_responses g_reconcile_responses;
+extern func_msg_rewrite_t
+    g_rewrite_query; /* rewrite query in a msg if necessary */
+extern func_msg_rewrite_t
+    g_rewrite_query_with_timestamp_md;
+extern func_msg_repair_t g_make_repair_query; /* Create a repair msg. */
+
+void set_datastore_ops(void);
+
+typedef enum msg_parse_result {
+  MSG_PARSE_OK,       /* parsing ok */
+  MSG_PARSE_ERROR,    /* parsing error */
+  MSG_PARSE_REPAIR,   /* more to parse -> repair parsed & unparsed data */
+  MSG_PARSE_FRAGMENT, /* multi-vector request -> fragment */
+  MSG_PARSE_AGAIN,    /* incomplete -> parse again */
+  MSG_OOM_ERROR
+} msg_parse_result_t;
 
 typedef enum dyn_error {
   DYNOMITE_OK,
@@ -385,6 +393,26 @@ struct argpos {
   uint8_t *end;       // Argument end position
 };
 
+// This struct is used when 'read_repairs' is enabled. It holds information required to
+// set the metadata of every write that will be used in the case of a quorum mismatch in
+// order to repair a query.
+struct write_with_ts {
+  msg_type_t cmd_type;
+  char *add_set;
+  char *rem_set;
+  uint64_t ts;
+  int num_keys;
+  struct array *keys;
+  int num_fields;
+  struct array *fields;
+  int num_values;
+  struct array *values;
+  int num_optionals;
+  struct array *optionals;
+  const char* rewrite_script;
+  int total_num_tokens;
+};
+
 struct msg {
   object_t object;
   TAILQ_ENTRY(msg) c_tqe; /* link in client q */
@@ -416,6 +444,7 @@ struct msg {
   msg_parse_result_t result; /* message parsing result */
 
   msg_type_t type; /* message type */
+  msg_type_t orig_type; /* Original message type. Only used on a query rewrite. */
 
   struct array *keys; /* array of keypos, for req */
   struct array *args; /* array of keypos, for req */
@@ -455,6 +484,10 @@ struct msg {
    * destination */
   unsigned dnode_header_prepended : 1;
   unsigned rsp_sent : 1; /* is a response sent for this request?*/
+  uint64_t timestamp;   // Timestamp of request. Used only if 'read_repiars' is enabled.
+  bool needs_repair;    // If 'true', a repair msg will be sent to 'owner'.
+  struct write_with_ts msg_info;
+  struct msg *orig_msg; // The original message if a rewrite took place.
 
   // dynomite
   struct dmsg *dmsg; /* dyn message */
@@ -481,8 +514,8 @@ static inline void msg_decr_awaiting_rsps(struct msg *req) {
   return;
 }
 
-static inline rstatus_t msg_handle_response(struct msg *req, struct msg *rsp) {
-  return req->rsp_handler(req, rsp);
+static inline rstatus_t msg_handle_response(struct context *ctx, struct msg *req, struct msg *rsp) {
+  return req->rsp_handler(ctx, req, rsp);
 }
 
 size_t msg_free_queue_size(void);
@@ -519,6 +552,7 @@ uint8_t *msg_get_tagged_key(struct msg *req, uint32_t key_index,
 uint8_t *msg_get_full_key(struct msg *req, uint32_t key_index,
                           uint32_t *keylen);
 uint8_t *msg_get_full_key_copy(struct msg *msg, int idx, uint32_t *keylen);
+uint8_t *msg_get_arg_copy(struct msg *msg, int idx, uint32_t *arglen);
 
 struct msg *req_get(struct conn *conn);
 void req_put(struct msg *msg);

--- a/src/dyn_response_mgr.h
+++ b/src/dyn_response_mgr.h
@@ -1,6 +1,6 @@
-
 #ifndef _DYN_RESPONSE_MGR_H_
 #define _DYN_RESPONSE_MGR_H_
+
 #define MAX_REPLICAS_PER_DC 3
 struct response_mgr {
   bool is_read;
@@ -24,11 +24,11 @@ void init_response_mgr(struct response_mgr *rspmgr, struct msg *, bool is_read,
 // DN_OK if response was accepted
 rstatus_t rspmgr_submit_response(struct response_mgr *rspmgr, struct msg *rsp);
 bool rspmgr_check_is_done(struct response_mgr *rspmgr);
-struct msg *rspmgr_get_response(struct response_mgr *rspmgr);
+struct msg *rspmgr_get_response(struct context *ctx, struct response_mgr *rspmgr);
 void rspmgr_free_response(struct response_mgr *rspmgr, struct msg *dont_free);
 void rspmgr_free_other_responses(struct response_mgr *rspmgr,
                                  struct msg *dont_free);
-rstatus_t msg_local_one_rsp_handler(struct msg *req, struct msg *rsp);
+rstatus_t msg_local_one_rsp_handler(struct context *ctx, struct msg *req, struct msg *rsp);
 rstatus_t rspmgr_clone_responses(struct response_mgr *src,
                                  struct array *responses);
 

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -28,6 +28,7 @@
 #include "dyn_dnode_peer.h"
 #include "dyn_server.h"
 #include "dyn_token.h"
+#include "dyn_util.h"
 
 static char *_print_datastore(const struct object *obj) {
   ASSERT(obj->type == OBJ_DATASTORE);
@@ -201,7 +202,7 @@ static void server_ack_err(struct context *ctx, struct conn *conn,
   log_info("close %s req %s len %" PRIu32 " from %s %c %s", print_obj(conn),
            print_obj(req), req->mlen, print_obj(c_conn), conn->err ? ':' : ' ',
            conn->err ? strerror(conn->err) : " ");
-  rstatus_t status = conn_handle_response(
+  rstatus_t status = conn_handle_response(ctx,
       c_conn, req->parent_id ? req->parent_id : req->id, rsp);
   IGNORE_RET_VAL(status);
   if (req->swallow) req_put(req);
@@ -692,6 +693,11 @@ struct msg *rsp_recv_next(struct context *ctx, struct conn *conn, bool alloc) {
     conn->rmsg = rsp;
   }
 
+  // Record timetamps if repairs are enabled.
+  // TODO: Consider requests that span multiple mbufs.
+  if (ctx->read_repairs_enabled) {
+    rsp->timestamp = current_timestamp_in_millis();
+  }
   return rsp;
 }
 
@@ -785,7 +791,7 @@ static void server_rsp_forward(struct context *ctx, struct conn *s_conn,
 
   server_rsp_forward_stats(ctx, rsp);
   // handler owns the response now
-  status = conn_handle_response(c_conn, req->id, rsp);
+  status = conn_handle_response(ctx, c_conn, req->id, rsp);
   IGNORE_RET_VAL(status);
 }
 

--- a/src/dyn_test.c
+++ b/src/dyn_test.c
@@ -231,7 +231,7 @@ static rstatus_t init_peer(struct node *s) {
 
 static size_t fill_buffer(struct mbuf *mbuf) {
   loga("total data size: %d", dn_strlen(data));
-  loga("mbuf size: %d", mbuf_size(mbuf));
+  loga("mbuf size: %d", mbuf_remaining_space(mbuf));
   size_t data_size = dn_strlen(data) - position;
 
   loga("data left-over size: %d", data_size);
@@ -239,7 +239,7 @@ static size_t fill_buffer(struct mbuf *mbuf) {
     return 0;
   }
 
-  size_t min_len = data_size > mbuf_size(mbuf) ? mbuf_size(mbuf) : data_size;
+  size_t min_len = data_size > mbuf_remaining_space(mbuf) ? mbuf_remaining_space(mbuf) : data_size;
   mbuf_copy(mbuf, &data[position], min_len);
   position += min_len;
 
@@ -573,12 +573,12 @@ aes_msg_test2(struct node *server)
     struct msg *msg = msg_get(conn, true, __FUNCTION__);
 
     struct mbuf *mbuf1 = mbuf_get();
-    mbuf_write_bytes(mbuf1, data, mbuf_size(mbuf1));
+    mbuf_write_bytes(mbuf1, data, mbuf_remaining_space(mbuf1));
     STAILQ_INSERT_HEAD(&msg->mhdr, mbuf1, next);
 
     struct mbuf *mbuf2 = mbuf_get();
-    mbuf_write_bytes(mbuf2, data + mbuf_size(mbuf2), strlen(data) -
-mbuf_size(mbuf2)); STAILQ_INSERT_TAIL(&msg->mhdr, mbuf2, next);
+    mbuf_write_bytes(mbuf2, data + mbuf_remaining_space(mbuf2), strlen(data) -
+mbuf_remaining_space(mbuf2)); STAILQ_INSERT_TAIL(&msg->mhdr, mbuf2, next);
 
     loga("dumping the content of the original msg: ");
     msg_dump(msg);

--- a/src/dyn_util.c
+++ b/src/dyn_util.c
@@ -591,3 +591,26 @@ char *dn_unresolve_desc(int sd) {
 
   return dn_unresolve_addr(addr, addrlen);
 }
+
+int count_digits(uint64_t arg) {
+  return snprintf(NULL, 0, "%llu", arg) - (arg < 0);
+}
+
+uint64_t current_timestamp_in_millis() {
+  struct timeval t;
+  // Get the current time.
+  gettimeofday(&t, NULL);
+  uint64_t millis = (uint64_t)(t.tv_sec*1000LL + t.tv_usec/1000);
+
+  return millis;
+}
+
+uint32_t keypos_elem_len(struct keypos* elem) {
+  if (elem == NULL) return 0;
+  return elem->tag_end - elem->tag_start;
+}
+
+uint32_t argpos_elem_len(struct argpos* elem) {
+  if (elem == NULL) return 0;
+  return elem->end - elem->start;
+}

--- a/src/dyn_util.h
+++ b/src/dyn_util.h
@@ -86,6 +86,10 @@
 #define dn_atoi(_line, _n) _dn_atoi((uint8_t *)_line, (size_t)_n)
 #define dn_atoui(_line, _n) _dn_atoui((uint8_t *)_line, (size_t)_n)
 
+// Forward declarations.
+struct keypos;
+struct argpos;
+
 int dn_set_blocking(int sd);
 int dn_set_nonblocking(int sd);
 int dn_set_reuseaddr(int sd);
@@ -379,5 +383,18 @@ char *dn_unresolve_desc(int sd);
 unsigned int dict_string_hash(const void *key);
 int dict_string_key_compare(void *privdata, const void *key1, const void *key2);
 void dict_string_destructor(void *privdata, void *val);
+
+/*
+ * Counts the total number of digits in 'arg'.
+ */
+int count_digits(uint64_t arg);
+
+/*
+ * Returns the current timestamp in milliseconds.
+ */
+uint64_t current_timestamp_in_millis(void);
+
+uint32_t keypos_elem_len(struct keypos* elem);
+uint32_t argpos_elem_len(struct argpos* elem);
 
 #endif

--- a/src/dynomite.c
+++ b/src/dynomite.c
@@ -35,6 +35,8 @@
 #include "dyn_core.h"
 #include "dyn_signal.h"
 
+#include "proto/dyn_proto.h"
+
 #if defined(SYSCONFDIR)
 #define DN_CONF_PATH SYSCONFDIR "/dynomite.yml"
 #else

--- a/src/proto/Makefile.am
+++ b/src/proto/Makefile.am
@@ -11,4 +11,5 @@ noinst_HEADERS = dyn_proto.h
 
 libproto_a_SOURCES =			\
 	dyn_memcache.c			\
-	dyn_redis.c
+	dyn_redis.c					\
+	dyn_redis_repair.c

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1616,3 +1616,13 @@ rstatus_t memcache_rewrite_query(struct msg *orig_msg, struct context *ctx,
                                  bool *did_rewrite, struct msg **new_msg_ptr) {
   return DN_OK;
 }
+
+rstatus_t memcache_rewrite_query_with_timestamp_md(struct msg *orig_msg,
+    struct context *ctx, bool *did_rewrite, struct msg **new_msg_ptr) {
+  return DN_OK;
+}
+
+rstatus_t memcache_make_repair_query(struct context *ctx, struct response_mgr *rspmgr,
+    struct msg **new_msg_ptr) {
+  return DN_OK;
+}

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -129,7 +129,7 @@ static bool memcache_touch(struct msg *r) {
   return false;
 }
 
-void memcache_parse_req(struct msg *r, const struct string *hash_tag) {
+void memcache_parse_req(struct msg *r, struct context *ctx) {
   struct mbuf *b;
   uint8_t *p, *m;
   uint8_t ch;
@@ -159,6 +159,7 @@ void memcache_parse_req(struct msg *r, const struct string *hash_tag) {
     SW_SENTINEL
   } state;
 
+  const struct string* hash_tag = &ctx->pool.hash_tag;
   state = r->state;
   b = STAILQ_LAST(&r->mhdr, mbuf, next);
 
@@ -780,7 +781,7 @@ error:
               r->id, r->result, r->type, r->state);
 }
 
-void memcache_parse_rsp(struct msg *r, const struct string *UNUSED) {
+void memcache_parse_rsp(struct msg *r, struct context *ctx) {
   struct mbuf *b;
   uint8_t *p, *m;
   uint8_t ch;

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -196,7 +196,7 @@ void memcache_parse_req(struct msg *r, const struct string *hash_tag) {
           m = r->token;
           r->token = NULL;
           r->type = MSG_UNKNOWN;
-          r->narg++;
+          r->ntokens++;
 
           switch (p - m) {
             case 3:
@@ -383,7 +383,7 @@ void memcache_parse_req(struct msg *r, const struct string *hash_tag) {
           kpos->start = r->token;
           kpos->end = p;
 
-          r->narg++;
+          r->ntokens++;
           r->token = NULL;
 
           /* get next state */
@@ -1325,7 +1325,7 @@ static rstatus_t memcache_fragment_retrieval(struct msg *r,
     }
     r->frag_seq[i] = sub_msg = sub_msgs[idx];
 
-    sub_msg->narg++;
+    sub_msg->ntokens++;
     status = memcache_append_key(sub_msg, kpos->start, kpos->end - kpos->start);
     if (status != DN_OK) {
       dn_free(sub_msgs);

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -37,8 +37,8 @@ struct response_mgr;
 struct server_pool;
 struct string;
 
-void memcache_parse_req(struct msg *r, const struct string *hash_tag);
-void memcache_parse_rsp(struct msg *r, const struct string *UNUSED);
+void memcache_parse_req(struct msg *r, struct context *ctx);
+void memcache_parse_rsp(struct msg *r, struct context *ctx);
 void memcache_pre_coalesce(struct msg *r);
 void memcache_post_coalesce(struct msg *r);
 bool memcache_is_multikey_request(struct msg *r);
@@ -55,8 +55,8 @@ rstatus_t memcache_make_repair_query(struct context *ctx, struct response_mgr *r
     struct msg **new_msg_ptr);
 
 
-void redis_parse_req(struct msg *r, const struct string *hash_tag);
-void redis_parse_rsp(struct msg *r, const struct string *UNUSED);
+void redis_parse_req(struct msg *r, struct context *ctx);
+void redis_parse_rsp(struct msg *r, struct context *ctx);
 void redis_pre_coalesce(struct msg *r);
 void redis_post_coalesce(struct msg *r);
 bool redis_is_multikey_request(struct msg *r);

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -25,6 +25,7 @@
 
 #include <stdbool.h>
 
+#include "../dyn_message.h"
 #include "../dyn_types.h"
 
 // Forward declarations
@@ -48,6 +49,11 @@ rstatus_t memcache_verify_request(struct msg *r, struct server_pool *pool,
                                   struct rack *rack);
 rstatus_t memcache_rewrite_query(struct msg *orig_msg, struct context *ctx,
                                  bool *did_rewrite, struct msg **new_msg_ptr);
+rstatus_t memcache_rewrite_query_with_timestamp_md(struct msg *orig_msg,
+    struct context *ctx, bool *did_rewrite, struct msg **new_msg_ptr);
+rstatus_t memcache_make_repair_query(struct context *ctx, struct response_mgr *rspmgr,
+    struct msg **new_msg_ptr);
+
 
 void redis_parse_req(struct msg *r, const struct string *hash_tag);
 void redis_parse_rsp(struct msg *r, const struct string *UNUSED);
@@ -61,5 +67,8 @@ rstatus_t redis_verify_request(struct msg *r, struct server_pool *pool,
                                struct rack *rack);
 rstatus_t redis_rewrite_query(struct msg *orig_msg, struct context *ctx,
                               bool *did_rewrite, struct msg **new_msg_ptr);
-
+rstatus_t redis_rewrite_query_with_timestamp_md(struct msg *orig_msg,
+    struct context *ctx, bool *did_rewrite, struct msg **new_msg_ptr);
+rstatus_t redis_make_repair_query(struct context *ctx, struct response_mgr *rspmgr,
+    struct msg **new_msg_ptr);
 #endif

--- a/src/proto/dyn_proto_repair.h
+++ b/src/proto/dyn_proto_repair.h
@@ -1,0 +1,538 @@
+/*
+ * Dynomite - A thin, distributed replication layer for multi non-distributed
+ * storages. Copyright (C) 2019 Netflix, Inc.
+ */
+
+#ifndef _DN_PROTO_REPAIR_H_
+#define _DN_PROTO_REPAIR_H_
+
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "../dyn_message.h"
+
+/*
+ * In order to repair mismatched replicas, we need to repair them based on some agreed
+ * upon value. In most systems that usually is based on the timestamps. Since Redis does
+ * not support timestamps, we need to add the logic that tracks timestamps as metadata.
+ *
+ * The way we achieve recording timestamps is by converting all writes to Lua scripts that
+ * atomically do the operation itself and store the metadata for that key.
+ *
+ * The metadata is stored in what we call 'add sets' and 'remove sets' which are basically
+ * sorted sets that store the key name along with a corresponding timestamp that denotes
+ * when that key was last updated. All primary keys go to a 'top level add/rem set' which
+ * is currently denoted by '._add-set' and '._rem-set'.
+ *
+ * Secondary keys (fields in hash maps, sets, etc.) are stored in add/rem sets of their
+ * corresponding primary keys and are denoted by '._add-set_<key>' and '._rem-set_<key>'.
+ *
+ * The 'redis_cmd_info' static array of structures contains information that will be used
+ * by  the "rewrite with metadata" and "repair" logic. This array is indexed by the command
+ * index that is set in dyn_message.h.
+ *
+ * All queries that will be rewritten to include metadata are denoted by
+ * 'redis_cmd_info[CMD_IDX].has_repair_support' where 'CMD_IDX' is the index of the
+ * corresponding query. All read queries that return the requested values along with the
+ * metadata are denoted by 'redis_cmd_info[CMD_IDX].is_repairable'.
+ * If queries do not have "rewrite with MD" or "repair" support, we fallback to the old
+ * behavior which is based on quorum checksums.
+ *
+ * Every repairable read ('is_repairable' == true) returns data in the Redis wire protocol
+ * in the following format:
+ * <status> <ts> <value>
+ *
+ * , where status can be one of 'X', 'R' or 'E'. They stand for:
+ *    X = value not found
+ *    R = value was deleted (i.e. it was found in the rem-set)
+ *    E = value exists (it was found in the add-set)
+ *
+ * This format was chosen because it's the most optimized in terms of returning values to
+ * the client, i.e. we can just move the start pointer of the buffer just before '<value>'
+ * by skipping '<status>' and '<ts>' thereby avoiding the need to copy the value to yet
+ * another buffer.
+ *
+ * Currently the only read commands that have repair support return only one value at a
+ * time. In the future when queries that can return multiple values will be returned,
+ * the format will be naturally extended to be:
+ * <status_1> <ts_1> <status_2> <ts_2> .. <status_n> <ts_n> <val_1> <val_2> .. <val_n>
+ *
+ * This will allow us to skip all the metadata with a simple pointer move just as we do
+ * now.
+ *
+ * On repair supported reads, if we find that the timestamps between responses from the
+ * responding replicas are not the same, we pick the replica that has the largest TS, take
+ * its value and send a new write command to the replicas that are out of date with the
+ * most updated value.
+ *
+ * Since we need to know the exact keys, fields and values while writing with metadata or
+ * while repairing, we do a "post-parsing" step that records these in order to efficiently
+ * populate the arguments for the Lua script that we will send to Redis on behalf of the
+ * read/write. (see post_parse_msg())
+ * This may change if we modify the parser itself to record these tokens efficiently.
+ * TODO: Support parsing of optional fields.
+ *
+ * The Lua scripts that we use as templates for supported commands are listed below as
+ * compile time constants.
+ *
+ * This is still in the beta stage and has some limitations:
+ * - Large values may cause overflows ( > 512 bytes)
+ * - Limited command support due to parser limitations:
+ *     - Sorted sets and lists need optional command parsing support.
+ * - Repairing on the read path vs. the background has perf implications. In the future,
+ *   all the heavy lifting will happen in the background in order to have a 0 perf
+ *   overhead on the read and write paths.
+ *
+ */
+#define SET_SCRIPT "$4\r\nEVAL\r\n$640\r\n"\
+  "local key = KEYS[1]\n"\
+  "local add_set = KEYS[2]\n"\
+  "local rem_set = KEYS[3]\n"\
+  "local orig_cmd = ARGV[1]\n"\
+  "local num_fields = ARGV[2]\n"\
+  "local cur_ts = ARGV[3]\n"\
+  "local value = ARGV[4]\n\n"\
+  "local last_seen_ts_in_add = redis.call('ZSCORE', add_set, key)\n"\
+  "local last_seen_ts_in_rem = redis.call('ZSCORE', rem_set, key)\n\n"\
+  "if (last_seen_ts_in_rem) then\n"\
+  "  if (tonumber(cur_ts) < tonumber(last_seen_ts_in_rem)) then\n"\
+  "    return -1\n"\
+  "  end\n"\
+  "  redis.call('ZREM', rem_set, key)\n"\
+  "elseif (last_seen_ts_in_add) then\n"\
+  "  if (tonumber(cur_ts) < tonumber(last_seen_ts_in_add)) then\n"\
+  "    return -1\n"\
+  "  end\n"\
+  "end\n\n"\
+  "redis.call('ZADD', add_set, cur_ts, key)\n"\
+  "return redis.call(orig_cmd, key, value)\n\r\n"
+
+#define GET_SCRIPT "$4\r\nEVAL\r\n$490\r\n"\
+  "local key = KEYS[1]\n"\
+  "local add_set = KEYS[2]\n"\
+  "local rem_set = KEYS[3]\n"\
+  "local orig_cmd = ARGV[1]\n"\
+  "local num_fields = ARGV[2]\n"\
+  "local cur_ts = ARGV[3]\n\n"\
+  "local value = redis.call(orig_cmd, key)\n\n"\
+  "local last_seen_ts_in_add = redis.call('ZSCORE', add_set, key)\n"\
+  "if (last_seen_ts_in_add) then\n"\
+  "  return {'E', last_seen_ts_in_add, value}\n"\
+  "end\n\n"\
+  "local last_seen_ts_in_rem = redis.call('ZSCORE', rem_set, key)\n"\
+  "if (last_seen_ts_in_rem) then\n"\
+  "  return {'R', last_seen_ts_in_rem, value}\n"\
+  "end\n\n"\
+  "return {'X', 0, value}\n\r\n"
+
+#define DEL_SCRIPT "$4\r\nEVAL\r\n$793\r\n"\
+  "local key = KEYS[1]\n"\
+  "local add_set = KEYS[2]\n"\
+  "local rem_set = KEYS[3]\n"\
+  "local orig_cmd = ARGV[1]\n"\
+  "local num_fields = ARGV[2]\n"\
+  "local cur_ts = ARGV[3]\n\n"\
+  "local last_seen_ts_in_add = redis.call('ZSCORE', add_set, key)\n"\
+  "local last_seen_ts_in_rem = redis.call('ZSCORE', rem_set, key)\n"\
+  "if (last_seen_ts_in_rem) then\n"\
+  "  if (tonumber(cur_ts) < tonumber(last_seen_ts_in_rem)) then\n"\
+  "    return 0\n"\
+  "  end\n"\
+  "  redis.call('ZREM', rem_set, key)\n"\
+  "elseif (last_seen_ts_in_add) then\n"\
+  "  return 0\n"\
+  "end\n\n"\
+  "local exists = redis.call('EXISTS', key)\n"\
+  "if (exists) then\n"\
+  "  local composite_add_set = add_set .. '_' .. key\n"\
+  "  local composite_rem_set = rem_set .. '_' .. key\n"\
+  "  redis.call('DEL', composite_add_set)\n"\
+  "  redis.call('DEL', composite_rem_set)\n\n"\
+  "  redis.call('ZADD', add_set, cur_ts, key)\n"\
+  "  return redis.call(orig_cmd, key)\n"\
+  "end\n"\
+  "return 0\n\r\n"
+
+#define HSET_SCRIPT "$4\r\nEVAL\r\n$1613\r\n"\
+  "local key = KEYS[1]\n"\
+  "local top_level_add_set = KEYS[2]\n"\
+  "local top_level_rem_set = KEYS[3]\n"\
+  "local add_set = top_level_add_set .. '_' .. key\n"\
+  "local rem_set = top_level_rem_set .. '_' .. key\n"\
+  "local orig_cmd = ARGV[1]\n"\
+  "local num_fields = ARGV[2]\n"\
+  "local cur_ts = ARGV[3]\n\n"\
+  "local start_loop = 4\n"\
+  "local end_loop = (num_fields * 2) + 3\n\n"\
+  "local top_level_rem_set_ts = redis.call('ZSCORE', top_level_rem_set, key)\n"\
+  "if (top_level_rem_set_ts) then\n"\
+  "  if (tonumber(cur_ts) < tonumber(top_level_rem_set_ts)) then\n"\
+  "    return 0\n"\
+  "  end\n"\
+  "  redis.call('ZREM', top_level_rem_set, key)\n"\
+  "end\n\n"\
+  "local top_level_add_set_ts = redis.call('ZSCORE', top_level_add_set, key)\n"\
+  "if (top_level_add_set_ts) then\n"\
+  "  if (tonumber(cur_ts) > tonumber(top_level_add_set_ts)) then\n"\
+  "    redis.call('ZADD', top_level_add_set, cur_ts, key)\n"\
+  "  end\n"\
+  "else\n"\
+  "  redis.call('ZADD', top_level_add_set, cur_ts, key)\n"\
+  "end\n\n"\
+  "local skiploop\n"\
+  "local ret\n"\
+  "for i=start_loop,end_loop,2\n"\
+  "do\n"\
+  "  skiploop = false\n"\
+  "  local field = ARGV[i]\n"\
+  "  local value = ARGV[i+1]\n"\
+  "  local last_seen_ts_in_add = redis.call('ZSCORE', add_set, field)\n"\
+  "  local last_seen_ts_in_rem = redis.call('ZSCORE', rem_set, field)\n"\
+  "  if (last_seen_ts_in_rem) then\n"\
+  "    if (tonumber(cur_ts) < tonumber(last_seen_ts_in_rem)) then\n"\
+  "      skiploop = true\n"\
+  "    end\n"\
+  "    redis.call('ZREM', rem_set, field)\n"\
+  "  elseif (last_seen_ts_in_add) then\n"\
+  "    if (tonumber(cur_ts) < tonumber(last_seen_ts_in_add)) then\n"\
+  "      skiploop = true\n"\
+  "    end\n"\
+  "  end\n\n"\
+  "  if (skiploop == false) then\n"\
+  "    redis.call('ZADD', add_set, cur_ts, field)\n"\
+  "    ret = redis.call(orig_cmd, key, field, value)\n"\
+  "  end\n"\
+  "end\n\n"\
+  "if tonumber(num_fields) > 1 then\n"\
+  "  return \"OK\"\n"\
+  "else\n"\
+  "  return ret\n"\
+  "end\n\r\n"
+
+#define HDEL_SCRIPT "$4\r\nEVAL\r\n$1175\r\n"\
+  "local key = KEYS[1]\n"\
+  "local top_level_add_set = KEYS[2]\n"\
+  "local top_level_rem_set = KEYS[3]\n"\
+  "local add_set = top_level_add_set .. '_' .. key\n"\
+  "local rem_set = top_level_rem_set .. '_' .. key\n"\
+  "local orig_cmd = ARGV[1]\n"\
+  "local num_fields = ARGV[2]\n"\
+  "local cur_ts = ARGV[3]\n\n"\
+  "local start_loop = 4\n"\
+  "local end_loop = num_fields + 3\n\n"\
+  "local skiploop\n"\
+  "local ret = 0\n"\
+  "for i=start_loop,end_loop,1\n"\
+  "do\n"\
+  "  skiploop = false\n"\
+  "  local field = ARGV[i]\n"\
+  "  local last_seen_ts_in_add = redis.call('ZSCORE', add_set, field)\n"\
+  "  local last_seen_ts_in_rem = redis.call('ZSCORE', rem_set, field)\n"\
+  "  if (last_seen_ts_in_rem) then\n"\
+  "    if (tonumber(cur_ts) < tonumber(last_seen_ts_in_rem)) then\n"\
+  "      skiploop = true\n"\
+  "    else\n"\
+  "      redis.call('ZREM', rem_set, field)\n"\
+  "    end\n"\
+  "  elseif (last_seen_ts_in_add) then\n"\
+  "    if (tonumber(cur_ts) < tonumber(last_seen_ts_in_add)) then\n"\
+  "      skiploop = true\n"\
+  "    end\n"\
+  "  end\n\n"\
+  "  if (skiploop == false) then\n"\
+  "    redis.call('ZADD', add_set, cur_ts, field)\n"\
+  "    ret = ret + redis.call(orig_cmd, key, field)\n"\
+  "  end\n"\
+  "end\n\n"\
+  "local card = redis.call('ZCARD', rem_set)\n"\
+  "if (card == 0) then\n"\
+  "  redis.call('ZADD', top_level_add_set, cur_ts, key)\n"\
+  "  redis.call('ZREM', top_level_rem_set, key)\n"\
+  "end\n\n"\
+  "return ret\n\r\n"
+
+#define HGET_SCRIPT "$4\r\nEVAL\r\n$982\r\n"\
+  "local key = KEYS[1]\n"\
+  "local top_level_add_set = KEYS[2]\n"\
+  "local top_level_rem_set = KEYS[3]\n"\
+  "local add_set = top_level_add_set .. '_' .. key\n"\
+  "local rem_set = top_level_rem_set .. '_' .. key\n"\
+  "local orig_cmd = ARGV[1]\n"\
+  "local num_fields = ARGV[2]\n"\
+  "local cur_ts = ARGV[3]\n"\
+  "local field = ARGV[4]\n\n"\
+  "local status_field = 'E'\n"\
+  "local ts = 0\n\n"\
+  "local tl_removed_ts = redis.call('ZSCORE', top_level_rem_set, key)\n"\
+  "if (tl_removed_ts) then\n"\
+  "  status_field = 'R'\n"\
+  "  ts = tl_removed_ts\nelse\n"\
+  "  local removed_ts = redis.call('ZSCORE', rem_set, field)\n"\
+  "  if (removed_ts) then\n"\
+  "    ts = removed_ts\n"\
+  "    status_field = 'R'\n"\
+  "  end\n"\
+  "end\n\n"\
+  "if (status_field ~= 'R') then\n"\
+  "  local tl_exists = redis.call('ZSCORE', top_level_add_set, key)\n"\
+  "  if (tl_exists) then\n"\
+  "    local exists_ts = redis.call('ZSCORE', add_set, field)\n"\
+  "    if (not exists_ts) then\n"\
+  "      status_field = 'X'\n"\
+  "    else\n"\
+  "      ts = exists_ts\n"\
+  "    end\n"\
+  "  else\n"\
+  "    status_field = 'X'\n"\
+  "  end\n"\
+  "end\n\n"\
+  "local value = redis.call(orig_cmd, key, field)\n"\
+  "return {status_field, ts, value}\n\r\n"
+
+#define SADD_SCRIPT "$4\r\nEVAL\r\n$1526\r\n"\
+  "local key = KEYS[1]\n"\
+  "local top_level_add_set = KEYS[2]\n"\
+  "local top_level_rem_set = KEYS[3]\n"\
+  "local add_set = top_level_add_set .. '_' .. key\n"\
+  "local rem_set = top_level_rem_set .. '_' .. key\n"\
+  "local orig_cmd = ARGV[1]\n"\
+  "local num_fields = ARGV[2]\n"\
+  "local cur_ts = ARGV[3]\n\n"\
+  "local start_loop = 4\n"\
+  "local end_loop = num_fields + 3\n\n"\
+  "local top_level_rem_set_ts = redis.call('ZSCORE', top_level_rem_set, key)\n"\
+  "if (top_level_rem_set_ts) then\n"\
+  "  if (tonumber(cur_ts) < tonumber(top_level_rem_set_ts)) then\n"\
+  "    return 0\n"\
+  "  end\n"\
+  "  redis.call('ZREM', top_level_rem_set, key)\n"\
+  "end\n\n"\
+  "local top_level_add_set_ts = redis.call('ZSCORE', top_level_add_set, key)\n"\
+  "if (top_level_add_set_ts) then\n"\
+  "  if (tonumber(cur_ts) > tonumber(top_level_add_set_ts)) then\n"\
+  "    redis.call('ZADD', top_level_add_set, cur_ts, key)\n"\
+  "  end\n"\
+  "else\n"\
+  "  redis.call('ZADD', top_level_add_set, cur_ts, key)\n"\
+  "end\n\n"\
+  "local skiploop\n"\
+  "local ret = 0\n"\
+  "for i=start_loop,end_loop,1\n"\
+  "do\n"\
+  "  skiploop = false\n"\
+  "  local field = ARGV[i]\n"\
+  "  local last_seen_ts_in_add = redis.call('ZSCORE', add_set, field)\n"\
+  "  local last_seen_ts_in_rem = redis.call('ZSCORE', rem_set, field)\n"\
+  "  if (last_seen_ts_in_rem) then\n"\
+  "    if (tonumber(cur_ts) < tonumber(last_seen_ts_in_rem)) then\n"\
+  "      skiploop = true\n"\
+  "    end\n"\
+  "    redis.call('ZREM', rem_set, field)\n"\
+  "  elseif (last_seen_ts_in_add) then\n"\
+  "    if (tonumber(cur_ts) < tonumber(last_seen_ts_in_add)) then\n"\
+  "      skiploop = true\n"\
+  "    end\n"\
+  "  end\n\n"\
+  "  if (skiploop == false) then\n"\
+  "    redis.call('ZADD', add_set, cur_ts, field)\n"\
+  "    ret = ret + redis.call(orig_cmd, key, field)\n"\
+  "  end\n"\
+  "end\n\n"\
+  "return ret\n\r\n"
+
+#define MAX_ARG_FMT_STR_LEN 512
+
+#define ADD_SET_STR "._add-set"
+#define REM_SET_STR "._rem-set"
+
+struct cmd_info {
+  char cmd_str[20];
+  uint32_t num_args;
+  uint32_t min_num_keys;
+  uint32_t min_num_fields;
+  uint32_t min_num_values;
+  uint32_t num_optionals;
+  bool has_repair_support;
+  bool is_delete;
+  bool is_repairable;
+  int first_key_pos;
+  int variadic_key_jump;
+  int first_field_pos;
+  int variadic_field_jump;
+  int first_value_pos;
+  int variadic_value_jump;
+  const char* rewrite_script;
+  msg_type_t repair_by_add;
+  msg_type_t repair_by_rem;
+};
+
+struct cmd_info proto_cmd_info[] = {
+  {"UNKNOWN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+
+  // Begin memcache commands. All Memcache commands are not supported. (idx 1 onwards)
+  {"MC_GET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_GETS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_DELETE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_CAS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_SET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_ADD", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_REPLACE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_APPEND", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_PREPEND", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_INCR", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_DECR", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_TOUCH", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_QUIT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_NUM", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_STORED", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_NOT_STORED", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_EXISTS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_NOT_FOUND", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_END", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_VALUE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_DELETED", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_TOUCHED", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_ERROR", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_CLIENT_ERROR", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MC_SERVER_ERROR", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+
+  // Begin Redis commands. They are partially supported. (idx 26 onwards)
+  {"DEL", 0, 1, 0, 0, 0, true, true, false, 0, 0, -1, 0, -1, 0, DEL_SCRIPT, 0, 0},
+  {"EXISTS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"EXPIRE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"EXPIREAT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"PEXPIRE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"PEXPIREAT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"PERSIST", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"PTTL", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SCAN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SORT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"TTL", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"TYPE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"APPEND", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"BITCOUNT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"BITPOS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"DECR", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"DECRBY", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"DUMP", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GET", 0, 1, 0, 0, 0, true, false, true, 0, 0, -1, 0, -1, 0, GET_SCRIPT,
+      MSG_REQ_REDIS_SET, MSG_REQ_REDIS_DEL},
+  {"GETBIT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GETRANGE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GETSET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"INCR", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"INCRBY", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"INCRBYFLOAT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MSET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MSET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"MGET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"PSETEX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SET", 1, 1, 0, 1, 0, true, false, false, 0, 0, -1, 0, 1, 0, SET_SCRIPT, 0, 0}, // idx 55
+  {"SETBIT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SETEX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SETNX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SETRANGE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"STRLEN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HDEL", 1, 1, 1, 0, 0, true, true, false, 0, 0, 1, 1, -1, 0, HDEL_SCRIPT, 0, 0}, // idx 61
+  {"HEXISTS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HGET", 1, 1, 1, 0, 0, true, false, true, 0, 0, 1, 0, -1, 0, HGET_SCRIPT,
+      MSG_REQ_REDIS_HSET, MSG_REQ_REDIS_HDEL}, // idx 63
+  {"HGETALL", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HINCRBY", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HINCRBYFLOAT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HKEYS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HLEN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HMGET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HMSET", 2, 1, 1, 1, 0, true, false, false, 0, 0, 1, 2, 2, 2, HSET_SCRIPT, 0, 0}, // idx 70
+  {"HSET", 2, 1, 1, 1, 0, true, false, false, 0, 0, 1, 0, 2, 0, HSET_SCRIPT, 0, 0}, // idx 71
+  {"HSETNX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HSCAN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HVALS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"HSTRLEN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"KEYS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"INFO", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LINDEX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LINSERT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LLEN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LPOP", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LPUSH", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LPUSHX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LRANGE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LREM", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LSET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"LTRIM", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"PING", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"QUIT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"RPOP", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"RPOPLPUSH", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"RPUSH", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"RPUSHX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SADD", 1, 1, 1, 0, 0, true, false, false, 0, 0, 1, 1, -1, 0, SADD_SCRIPT, 0, 0}, // idx 94
+  {"SCARD", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SDIFF", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SDIFFSTORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SINTER", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SINTERSTORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SISMEMBER", 1, 1, 1, 0, 0, true, false, true, 0, 0, 1, 0, -1, 0, HGET_SCRIPT,
+      MSG_REQ_REDIS_SADD, MSG_REQ_REDIS_SREM}, // idx 100
+  {"SLAVEOF", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SMEMBERS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SMOVE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SPOP", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SRANDMEMBER", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SREM", 1, 1, 1, 0, 0, true, true, false, 0, 0, 1, 1, -1, 0, HDEL_SCRIPT, 0, 0}, // idx 106
+  {"SUNION", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SUNIONSTORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SSCAN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZADD", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZCARD", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZCOUNT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZINCRBY", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZINTERSTORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZLEXCOUNT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZRANGE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZRANGEBYLEX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZRANGEBYSCORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZRANK", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZREM", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZREMRANGEBYRANK", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZREMRANGEBYLEX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZREMRANGEBYSCORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZREVRANGE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZREVRANGEBYLEX", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZREVRANGEBYSCORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZREVRANK", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZSCORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZUNIONSTORE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"ZSCAN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"EVAL", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"EVALSHA", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GEOADD", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GEORADIUS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GEODIST", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GEOHASH", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GEOPOS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"GEORADIOUSBYMEMBER", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"UNLINK", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONSET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONGET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONDEL", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONTYPE", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONMGET", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONARRAPPEND", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONARRINSERT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONARRLEN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONOBJKEYS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"JSONOBJLEN", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"CONFIG", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SCRIPT", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SCRIPT_LOAD", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SCRIPT_EXISTS", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SCRIPT_FLUSH", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0},
+  {"SCRIPT_KILL", 0, 0, 0, 0, 0, false, false, false, -1, -1, -1, -1, -1, -1, NULL, 0, 0}
+
+  // Ignore RSP msg types.
+};
+
+#endif

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -411,8 +411,6 @@ rstatus_t redis_rewrite_query(struct msg *orig_msg, struct context *ctx,
     case MSG_REQ_REDIS_SMEMBERS:
 
       if (orig_msg->owner->read_consistency == DC_SAFE_QUORUM) {
-        // SMEMBERS should have only one key.
-        ASSERT(orig_msg->nkeys == 1);
 
         // Get a new 'msg' structure.
         new_msg = msg_get(orig_msg->owner, true, __FUNCTION__);

--- a/src/proto/dyn_redis_repair.c
+++ b/src/proto/dyn_redis_repair.c
@@ -1,0 +1,669 @@
+/*
+* Dynomite - A thin, distributed replication layer for multi non-distributed
+* storages. Copyright (C) 2019 Netflix, Inc.
+*/
+
+#include <ctype.h>
+#include <stdio.h>
+
+#include "../dyn_core.h"
+#include "../dyn_dnode_peer.h"
+#include "../dyn_util.h"
+#include "dyn_proto.h"
+#include "dyn_proto_repair.h"
+
+static int total_tokens_of_type(int variadic_jump, int start_pos, int min_num_tokens,
+    int nelem) {
+
+  if (variadic_jump == 0) return min_num_tokens;
+
+  int total = (nelem - start_pos) / variadic_jump;
+  total += (nelem - start_pos) % variadic_jump;
+  return total;
+}
+
+static rstatus_t parse_tokens_of_type(int num_tokens, int out_token_idx,
+    int variadic_jump, int start_pos, struct array *source_info,
+    bool is_key, struct array **out) {
+  if (num_tokens == 0) return DN_OK;
+
+  if (*out == NULL) {
+    *out = array_create(num_tokens, sizeof(struct argpos));
+    if (*out == NULL) return DN_ENOMEM;
+  }
+
+  // If the variadic jump is 0 or 1, we need to jump by 1 in case num_tokens > 0. Else we
+  // jump by the variadic jump position itself.
+  int jump_by = (variadic_jump == 0 || variadic_jump == 1) ? 1 : variadic_jump;
+
+  for (; num_tokens > 0; -- num_tokens) {
+    if (!is_key) {
+      struct argpos *token_pos = (struct argpos*)array_push(*out);
+      struct argpos *orig_token_pos =
+          (struct argpos*)array_get(source_info, start_pos - 1 + out_token_idx);
+      token_pos->start = orig_token_pos->start;
+      token_pos->end = orig_token_pos->end;
+      out_token_idx += jump_by;
+    } else {
+      // TODO: Make more concise.
+      struct keypos *token_pos = (struct keypos*)array_push(*out);
+      struct keypos *orig_token_pos =
+          (struct keypos*)array_get(source_info, start_pos - 1 + out_token_idx);
+      token_pos->start = orig_token_pos->start;
+      token_pos->end = orig_token_pos->end;
+      token_pos->tag_start = orig_token_pos->tag_start;
+      token_pos->tag_end = orig_token_pos->tag_end;
+      out_token_idx += jump_by;
+    }
+  }
+
+  return DN_OK;
+}
+
+static rstatus_t get_values_from_source(int num_tokens, int start_pos,
+    struct array *source_info, struct array **out_values) {
+  *out_values = array_create(num_tokens, sizeof(struct argpos));
+  if (*out_values == NULL) return DN_ENOMEM;
+
+  int i;
+  for (i = 0; i < num_tokens; ++i) {
+    struct argpos *value_pos = (struct argpos*)array_push(*out_values);
+    struct argpos *orig_value_pos = (struct argpos*)array_get(source_info, start_pos++);
+    value_pos->start = orig_value_pos->start;
+    value_pos->end = orig_value_pos->end;
+  }
+
+  return DN_OK;
+}
+
+/*
+ * Parses the original 'struct msg' and fills in 'orig_msg->msg_info' with all
+ * the keys, fields, values and optional fields.
+ *
+ * TODO: Consider getting rid of this function if we move to a per-command parser model.
+ *
+ */
+rstatus_t post_parse_msg(struct msg *orig_msg) {
+
+  struct write_with_ts *out_struct = &orig_msg->msg_info;
+  ASSERT(out_struct != NULL);
+
+  out_struct->cmd_type = orig_msg->type;
+  out_struct->ts = orig_msg->timestamp;
+  struct cmd_info *orig_cmd_info = &proto_cmd_info[orig_msg->type];
+  out_struct->num_fields = orig_cmd_info->min_num_fields;
+  out_struct->num_values = orig_cmd_info->min_num_values;
+  out_struct->keys = NULL;
+  out_struct->fields = NULL;
+  out_struct->values = NULL;
+
+  {
+    int start_from_arg_pos; 
+    // If the first key position is '0', then it wouldn't be found in the 'args'
+    // array and we need to account for it from the 'keys' array.
+    if (orig_cmd_info->first_key_pos == 0) {
+      start_from_arg_pos = 0;
+
+      // TODO: Refactor
+      if (orig_cmd_info->variadic_key_jump > 0) {
+        out_struct->num_keys = 1; // Counting the one in 'orig_msg->keys'.
+      } else {
+        out_struct->num_keys = 0;
+      }
+    } else {
+      start_from_arg_pos = orig_cmd_info->first_key_pos - 1;
+      out_struct->num_keys = 0;
+    }
+    out_struct->num_keys += total_tokens_of_type(
+        orig_cmd_info->variadic_key_jump,
+        start_from_arg_pos,
+        orig_cmd_info->min_num_keys,
+        orig_msg->args->nelem);
+  }
+
+  if (out_struct->num_keys > 0) {
+    // TODO: Make more concise.
+    out_struct->keys = array_create(out_struct->num_keys, sizeof(struct keypos));
+    if (out_struct->keys == NULL) goto error;
+
+    int key_idx = 0;
+    if (orig_cmd_info->first_key_pos == 0) {
+      struct keypos *kpos = (struct keypos*)array_push(out_struct->keys);
+      struct keypos *orig_kpos = (struct keypos*)array_get(orig_msg->keys, 0);
+      kpos->start = orig_kpos->start;
+      kpos->end = orig_kpos->end;
+      kpos->tag_start = orig_kpos->tag_start;
+      kpos->tag_end = orig_kpos->tag_end;
+      ++key_idx;
+    }
+
+    if (parse_tokens_of_type(out_struct->num_keys - key_idx, key_idx,
+        orig_cmd_info->variadic_key_jump, orig_cmd_info->first_key_pos,
+        orig_msg->args, true, &out_struct->keys) != DN_OK) {
+      goto error;
+    }
+  }
+
+  out_struct->num_fields = total_tokens_of_type(
+      orig_cmd_info->variadic_field_jump,
+      orig_cmd_info->first_field_pos - 1 /* start_pos */,
+      orig_cmd_info->min_num_fields,
+      orig_msg->args->nelem);
+
+  if (parse_tokens_of_type(out_struct->num_fields, 0,
+          orig_cmd_info->variadic_field_jump, orig_cmd_info->first_field_pos,
+          orig_msg->args, false, &out_struct->fields) != DN_OK) {
+    goto error;
+  }
+
+  out_struct->num_values = total_tokens_of_type(
+      orig_cmd_info->variadic_value_jump,
+      orig_cmd_info->first_value_pos - 1 /* start_pos */,
+      orig_cmd_info->min_num_values,
+      orig_msg->args->nelem);
+
+  if (parse_tokens_of_type(out_struct->num_values, 0,
+          orig_cmd_info->variadic_value_jump, orig_cmd_info->first_value_pos,
+          orig_msg->args, false, &out_struct->values) != DN_OK) {
+    goto error;
+  }
+
+  // Swap the add and remove sets if this is a delete command.
+  if (orig_cmd_info->is_delete) {
+    out_struct->add_set = REM_SET_STR;
+    out_struct->rem_set = ADD_SET_STR;
+  } else {
+    out_struct->add_set = ADD_SET_STR;
+    out_struct->rem_set = REM_SET_STR;
+  }
+ 
+  out_struct->rewrite_script = orig_cmd_info->rewrite_script;
+  return DN_OK;
+error:
+
+  // Destroy allocated arrays.
+  array_destroy(out_struct->keys);
+  array_destroy(out_struct->fields);
+  array_destroy(out_struct->values);
+  return DN_ERROR;
+}
+
+/*
+ * Populates a 'write_with_ts' structure based on the information contained in
+ * 'most_updated_rsp'.
+ *
+ */
+rstatus_t obtain_info_from_latest_rsp(struct response_mgr *rspmgr,
+    struct msg *most_updated_rsp, bool repair_by_add,
+    struct write_with_ts *repair_msg_info) {
+
+  msg_type_t orig_msg_type = rspmgr->msg->orig_type;
+  msg_type_t repair_msg_type = (repair_by_add == true) ?
+                                proto_cmd_info[orig_msg_type].repair_by_add :
+                                proto_cmd_info[orig_msg_type].repair_by_rem;
+
+  struct write_with_ts *orig_msg_info = &rspmgr->msg->orig_msg->msg_info;
+  int i = 0;
+
+  // Copy all the relevant information from the 'most_updated_rsp' to craft a
+  // 'struct write_with_ts' to be used while creating the repair msg.
+  repair_msg_info->cmd_type = repair_msg_type;
+  repair_msg_info->rewrite_script = proto_cmd_info[repair_msg_type].rewrite_script;
+  repair_msg_info->ts = most_updated_rsp->timestamp;
+
+  repair_msg_info->num_keys = orig_msg_info->num_keys;
+  repair_msg_info->num_fields = orig_msg_info->num_fields;
+  repair_msg_info->num_values = orig_msg_info->num_values;
+
+  repair_msg_info->keys = orig_msg_info->keys;
+  repair_msg_info->fields = orig_msg_info->fields;
+
+  if (repair_by_add) {
+    repair_msg_info->add_set = ADD_SET_STR;
+    repair_msg_info->rem_set = REM_SET_STR;
+  } else {
+    repair_msg_info->add_set = REM_SET_STR;
+    repair_msg_info->rem_set = ADD_SET_STR;
+  }
+
+  repair_msg_info->total_num_tokens = orig_msg_info->total_num_tokens;
+
+  // TODO: When we support multi value gets, we should update this logic. This will
+  // work only for a single value get since we're only checking a single status.
+  // (Eg: GET, HGET vs. SMEMBERS)
+  struct argpos* status_pos = (struct argpos*)array_get(most_updated_rsp->args, 0);
+  if (*status_pos->start == 'E') {
+    if (repair_msg_info->num_fields) {
+      if (get_values_from_source(repair_msg_info->num_fields,
+          repair_msg_info->num_fields * 2 /* start_pos */,
+          most_updated_rsp->args, &repair_msg_info->values) != DN_OK) {
+        goto error;
+      }
+      repair_msg_info->num_values += repair_msg_info->num_fields;
+      repair_msg_info->total_num_tokens += repair_msg_info->num_fields;
+    } else {
+      if (get_values_from_source(repair_msg_info->num_keys,
+          repair_msg_info->num_keys * 2 /* start_pos */,
+          most_updated_rsp->args, &repair_msg_info->values) != DN_OK) {
+        goto error;
+      }
+      repair_msg_info->num_values += repair_msg_info->num_keys;
+      repair_msg_info->total_num_tokens += repair_msg_info->num_keys;
+    }
+  }
+  return DN_OK;
+
+ error:
+  array_destroy(repair_msg_info->values);
+  return DN_ERROR;
+}
+
+/*
+ * Appends a string argument based on the Redis wire protocol to the string pointed to by
+ * 'out_str_ptr' and moves the pointer forward by the number of bytes appended.
+ *
+ * Returns the total number of bytes appended.
+ */
+static size_t append_redis_prtcl_varchar_arg_to_str(char *arg, int len,
+    char** out_str_ptr) {
+  int n = sprintf(*out_str_ptr, "$%d\r\n%.*s\r\n", len, len, arg);
+  *out_str_ptr += n;
+
+  return n;
+}
+
+static size_t append_redis_prtcl_int_arg_to_str(int arg, int len,
+    char** out_str_ptr) {
+  int n = sprintf(*out_str_ptr, "$%d\r\n%d\r\n", len, arg);
+  *out_str_ptr += n;
+
+  return n;
+}
+
+
+static size_t append_redis_prtcl_llu_arg_to_str(unsigned long long arg, int len,
+    char** out_str_ptr) {
+  int n = sprintf(*out_str_ptr, "$%d\r\n%llu\r\n", len, arg);
+  *out_str_ptr += n;
+
+  return n;
+}
+
+/*
+ * Using the information found in 'write_with_ts', this function populates 'out_fmt_str'
+ * with an argument string based on the Redis wire protocol that will be passed to a
+ * Lua script.
+ *
+ * It also updates 'src' with the total number of tokens.
+ *
+ * The format is:
+ * <key1>..(<keyN>) <+set> <-set> <orig_cmd> <num_flds> <ts> (<fld1>) (<val1>) (<fldN>) ..
+ *
+ * Tokens shown above with parantheses are optional.
+ *
+ * Returns the total size of the final stirng.
+ *
+ */
+static size_t create_redis_prtcl_script_args(
+    struct write_with_ts *src, char *out_fmt_str) {
+  ASSERT(out_fmt_str != NULL);
+
+  int n, i;
+  int total_len = 0;
+  char *str_ptr = out_fmt_str;
+
+  int num_keys = src->num_keys;
+  int num_fields = src->num_fields;
+  int num_values = src->num_values;
+
+  // Add 2 by default, one for the 'EVAL' command and one for the script itself.
+  src->total_num_tokens = 2;
+
+  // Adding 2 to 'num_keys' for the add and remove sets.
+  total_len += append_redis_prtcl_int_arg_to_str(
+      num_keys + 2, count_digits(num_keys + 2), &str_ptr);
+  ++src->total_num_tokens;
+
+  // Add all the keys touched in the query.
+  for (i = 0; i < src->num_keys; ++i) {
+    struct keypos *elem = array_get(src->keys, i);
+    uint32_t elem_len = keypos_elem_len(elem);
+    total_len += append_redis_prtcl_varchar_arg_to_str(
+        (char*)elem->tag_start, elem_len, &str_ptr);
+    ++src->total_num_tokens;
+  }
+  // Add the add-set and rem-set keys.
+  int add_set_len = strlen(src->add_set);
+  int rem_set_len = strlen(src->rem_set);
+  total_len += append_redis_prtcl_varchar_arg_to_str(src->add_set, add_set_len, &str_ptr);
+  total_len += append_redis_prtcl_varchar_arg_to_str(src->rem_set, rem_set_len, &str_ptr);
+  src->total_num_tokens += 2;
+
+  // Add the command string. (Eg: SET, HSET, etc.)
+  char *orig_cmd_str = proto_cmd_info[src->cmd_type].cmd_str;
+  total_len += append_redis_prtcl_varchar_arg_to_str(
+      orig_cmd_str, strlen(orig_cmd_str), &str_ptr);
+
+  // Add the number of fields.
+  total_len += append_redis_prtcl_int_arg_to_str(
+      num_fields, count_digits(num_fields), &str_ptr);
+
+  // Add the timestamp.
+  int num_ts_digits = count_digits(src->ts);
+  total_len += append_redis_prtcl_llu_arg_to_str(
+      src->ts, count_digits(src->ts), &str_ptr);
+
+  src->total_num_tokens += 3;
+
+  if (num_fields > 0 || num_values > 0) {
+
+    // If we have both fields and values present, each field and value must be present in
+    // pairs (since all Redis commands follow that protocol), else we list all the fields
+    // or all the values.
+    int total_iterations = (num_fields > 0 && num_values > 0) ? num_fields :
+        ((num_fields > 0) ? num_fields : num_values);
+
+    for (i = 0; i < total_iterations; ++i) {
+      if (num_fields > 0) {
+        struct argpos *field_elem = array_get(src->fields, i);
+        uint32_t field_len = argpos_elem_len(field_elem);
+        total_len += append_redis_prtcl_varchar_arg_to_str(
+            (char*)field_elem->start, field_len, &str_ptr);
+        ++src->total_num_tokens;
+      }
+
+      if (num_values > 0) {
+        struct argpos *value_elem = array_get(src->values, i);
+        uint32_t value_len = argpos_elem_len(value_elem);
+        total_len += append_redis_prtcl_varchar_arg_to_str(
+            (char*)value_elem->start, value_len, &str_ptr);
+        ++src->total_num_tokens;
+      }
+    }
+  }
+
+  // NULL terminate the string.
+  strcpy(str_ptr, "\0");
+  return total_len;
+}
+
+/*
+ * Uses 'msg_info' and 'arg_str' to create a repair msg and parse it so that its ready
+ * to be understood by Redis.
+ *
+ */
+static rstatus_t finalize_repair_msg(struct context *ctx, struct conn *conn,
+    struct write_with_ts *msg_info, char* arg_str,  struct msg **new_msg_ptr) {
+
+  rstatus_t ret_status;
+  struct msg *new_msg = NULL;
+  new_msg = msg_get(conn, true, __FUNCTION__);
+  if (new_msg == NULL) {
+    ret_status = DN_ENOMEM;
+    goto error;
+  }
+
+  // Prepend the total number of tokens as mandated by the Redis wire protocol, followed
+  // by the script and finally the argument string to the script.
+  ret_status = msg_prepend_format(new_msg, "*%d\r\n%s%s", msg_info->total_num_tokens,
+      msg_info->rewrite_script, arg_str);
+  if (ret_status != DN_OK) goto error;
+
+  {
+    // Set the 'pos' of the 'new_msg' so that the parser knows where to begin parsing from
+    struct mbuf *new_mbuf = STAILQ_LAST(&new_msg->mhdr, mbuf, next);
+    new_msg->pos = new_mbuf->pos;
+  }
+
+  // Parse the newly formed repair msg.
+  new_msg->parser(new_msg, &ctx->pool.hash_tag);
+  if (new_msg->result != MSG_PARSE_OK) {
+    ret_status = DN_ERROR;
+    goto error;
+  }
+
+  *new_msg_ptr = new_msg;
+  return ret_status;
+
+ error:
+  if (new_msg != NULL) msg_put(new_msg);
+  return ret_status;
+}
+
+/*
+ * Finds all the timetamps from responses in rspmgr, updates the respective 'msg'
+ * structures with their timestamp, and finds the response that has the latest
+ * timestamp.
+ *
+ * Returns the response with the largest timestamp if it exists. 'repair_by_add' is
+ * set according to whether the latest value for that key exists or not.
+ *
+ * Returns NULL if all the timestamps are the same.
+ *
+ */
+static struct msg* find_most_updated_rsp(struct response_mgr *rspmgr,
+    bool *repair_by_add) {
+  int i;
+  uint64_t biggest_ts = 0;
+  struct msg *most_updated_rsp = NULL;
+  bool at_least_one_repair = false;
+  for (i = 0; i < rspmgr->good_responses; ++i) {
+    struct msg *cur_rsp = rspmgr->responses[i];
+
+    // Find the status of the key.
+    struct argpos *key_status_arg = (struct argpos*)array_get(cur_rsp->args, 0);
+    uint8_t *key_status = key_status_arg->start;
+    if (*key_status == 'X') {  // Key does not exist
+      continue;
+    }
+
+    struct argpos *ts_arg = (struct argpos*)array_get(cur_rsp->args, 1);
+    uint8_t *j;
+    cur_rsp->timestamp = 0;
+
+    // Find the timestamp from the response buffer and tag the 'struct msg' with it.
+    for (j = ts_arg->start; j < ts_arg->end; ++j) {
+      char digit_ch = *j;
+      ASSERT(isdigit(digit_ch));
+      cur_rsp->timestamp = cur_rsp->timestamp * 10 + (uint64_t)(digit_ch - '0');
+    }
+
+    if (cur_rsp->timestamp > biggest_ts) {
+      if (most_updated_rsp != NULL) {
+        most_updated_rsp->needs_repair = true;
+        at_least_one_repair = true;
+      }
+      biggest_ts = cur_rsp->timestamp;
+      most_updated_rsp = cur_rsp;
+      *repair_by_add = (*key_status == 'E');
+    } else if (cur_rsp->timestamp < biggest_ts) {
+      cur_rsp->needs_repair = true;
+      at_least_one_repair = true;
+    }
+  }
+
+  // If no one needs a repair, return NULL.
+  return (at_least_one_repair) ? most_updated_rsp : NULL;
+}
+
+
+/*
+ * The response buffers are returned in an internal Dynomite format which the
+ * client should not see. This function adjusts the response buffer of the most
+ * updated response (based on timestamp) to what the client would expect to see.
+ *
+ */
+static void adjust_rsp_buffers_for_client(struct response_mgr *rspmgr,
+    uint32_t num_values) {
+  ;int num_value_digits = count_digits(num_values);
+
+  // All responses begin with <status> & <ts>, so the first value, if present, will be at
+  // position 2 in the args array of all responses.
+  int start_idx_from_rsp = 2;
+
+  int i;
+  for (i = 0; i <rspmgr->good_responses; ++i) {
+    struct msg *cur_rsp = rspmgr->responses[i];
+    // If it's an outdated response, we won't show it to the client anyway, so don't waste
+    // time adjusting its buffer.
+    if (cur_rsp->needs_repair == true) continue;
+
+    struct mbuf *rsp_mbuf = STAILQ_FIRST(&cur_rsp->mhdr);
+
+    struct argpos* status_pos = (struct argpos*)array_get(cur_rsp->args, 0);
+    if (*status_pos->start == 'X') {
+      // If the value does not exist, we will get back a buffer of the format:
+      // "*3\r\n$1\r\nX\r\n:0\r\n:0\r\n", so we just move the pointer to point to
+      // ":0"
+      rsp_mbuf->pos = status_pos->start + 7;
+      continue;
+    }
+
+    // Update 'pos' pointer so that the metadata is not returned back to the client.
+    if (*status_pos->start == 'R') {
+      // If the item does not exist, the 2nd position in the buffer will be -1,
+      // which is interpreted as "(nil)" by the client, so we just point the response
+      // buffer to that.
+      struct argpos* ts_pos =
+          (struct argpos*)array_get(cur_rsp->args, start_idx_from_rsp - 1);
+
+      rsp_mbuf->pos = ts_pos->end + 2;
+      continue;
+    }
+
+    struct argpos* first_value_pos =
+        (struct argpos*)array_get(cur_rsp->args, start_idx_from_rsp);
+
+    // Here we're making space to write the total number of value tokens.
+    // In reverse order, it's 2 for "\r\n", 'first_val_len_digits', 1 for "$",
+    // 2 more for "\r\n", the number of token digits and finally 1 for "*".
+    // If the value is an integer, we don't include the multibulk len and its
+    // corressponding CRLF bytes.
+    int go_back_by = 2 + num_value_digits + 1;
+    if (*first_value_pos->start != ':') {
+      int first_val_len_digits =
+          count_digits(first_value_pos->end - first_value_pos->start);
+      go_back_by += 2 + first_val_len_digits + 1;
+    }
+    rsp_mbuf->pos = first_value_pos->start - go_back_by;
+
+    // Now we just need to write the "*" and the total number of tokens, the remaining
+    // already exists as expected.
+    *rsp_mbuf->pos = '*';
+    int num_values_copy = num_values;
+    int num_value_digits_copy = num_value_digits;
+    while(num_value_digits_copy > 0) {
+      int digit = num_values_copy % 10;
+      *(rsp_mbuf->pos + num_value_digits_copy) = digit + '0';
+
+      --num_value_digits_copy;
+      num_values_copy /= 10;
+    }
+  }
+}
+
+/*
+ * Looks at responses in 'rspmgr' and determines if any of them are outdated.
+ * If there exist outdated responses, it creates a repair msg which will repair
+ * the peers that contained the outdated msg and returns it via the out param
+ * 'new_msg_ptr'.
+ *
+ */
+rstatus_t redis_make_repair_query(struct context *ctx, struct response_mgr *rspmgr,
+    struct msg **new_msg_ptr) {
+
+  if (ctx->read_repairs_enabled == 0) return DN_OK;
+
+  *new_msg_ptr = NULL;
+  msg_type_t msg_type = rspmgr->msg->orig_type;
+  if (msg_type == MSG_UNKNOWN) {
+    msg_type = rspmgr->msg->type;
+  }
+  if (!proto_cmd_info[msg_type].is_repairable) return DN_OK;
+
+  struct msg *new_msg = NULL;
+  rstatus_t ret_status = DN_OK;
+
+  int i;
+  uint64_t biggest_ts = 0;
+  struct msg* most_updated_rsp = NULL;
+  bool repair_by_add = false;
+  bool at_least_one_repair = false;
+  uint32_t num_values = 0;
+
+  // Redis commands either lookup keys or fields (secondary keys), so the number of
+  // expected values would be based on either one of them.
+  if (rspmgr->msg->orig_msg->msg_info.num_fields > 0) {
+    num_values = rspmgr->msg->orig_msg->msg_info.num_fields;
+  } else {
+    num_values = rspmgr->msg->orig_msg->msg_info.num_keys;
+  }
+
+  most_updated_rsp = find_most_updated_rsp(rspmgr, &repair_by_add);
+  // Avoid crafting a repair message if there's nothing to repair.
+  if (most_updated_rsp == NULL) {
+    ret_status = DN_OK;
+    goto done;
+  }
+
+  struct write_with_ts repair_msg_info;
+  rstatus_t status = obtain_info_from_latest_rsp(rspmgr, most_updated_rsp,
+      repair_by_add, &repair_msg_info);
+
+  // TODO: Dynamically allocate 'arg_fmt_str'.
+  char arg_fmt_str[MAX_ARG_FMT_STR_LEN];
+  size_t arg_fmt_str_len = create_redis_prtcl_script_args(&repair_msg_info, (char*)&arg_fmt_str);
+
+  ret_status = finalize_repair_msg(ctx, rspmgr->msg->owner, &repair_msg_info,
+      (char*)&arg_fmt_str, new_msg_ptr);
+  if (ret_status != DN_OK) {
+    goto done;
+  }
+
+ done:
+  adjust_rsp_buffers_for_client(rspmgr, num_values);
+  return DN_OK;
+}
+
+/*
+ * Converts 'orig_msg' to a Lua script that atomically does the original operation and
+ * updates the metadata for that key(s), if that command has read repair support.
+ *
+ * Sets 'did_rewrite' to 'true' if the rewrite happened.
+ *
+ */
+rstatus_t redis_rewrite_query_with_timestamp_md(struct msg *orig_msg, struct context *ctx,
+    bool *did_rewrite, struct msg **new_msg_ptr) {
+
+  ASSERT(orig_msg != NULL);
+  ASSERT(orig_msg->is_request);
+  ASSERT(did_rewrite != NULL);
+
+  *did_rewrite = false;
+
+  struct msg *new_msg = NULL;
+  uint8_t *key = NULL;
+  rstatus_t ret_status = DN_OK;
+
+  // If we don't support read repairs for a command, return.
+  if (proto_cmd_info[orig_msg->type].has_repair_support == false) return DN_OK;
+
+  rstatus_t status = post_parse_msg(orig_msg);
+  if (status != DN_OK) goto error;
+
+  char arg_fmt_str[MAX_ARG_FMT_STR_LEN];
+  size_t arg_fmt_str_len = create_redis_prtcl_script_args(
+      &orig_msg->msg_info, (char*)&arg_fmt_str);
+
+  ret_status = finalize_repair_msg(ctx, orig_msg->owner, &orig_msg->msg_info,
+      (char*)&arg_fmt_str, new_msg_ptr);
+  if (ret_status != DN_OK) goto error;
+  *did_rewrite = true;
+  return ret_status;
+
+error:
+  if (key != NULL) dn_free(key);
+  // Return the newly allocated message back to the free message queue.
+  if (new_msg != NULL) msg_put(new_msg);
+  return ret_status;
+}

--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -12,7 +12,7 @@ from plumbum import local
 
 from dyno_cluster import DynoCluster
 from func_test import comparison_test
-from utils import generate_ips, setup_temp_dir
+from utils import generate_ips, setup_temp_dir, sleep_with_animation
 from redis_node import RedisNode
 
 REDIS_PORT = 1212
@@ -49,7 +49,7 @@ def main():
         stack.enter_context(dynomite_cluster)
 
         # Wait for a while for the above nodes to start.
-        sleep(SETTLE_TIME)
+        sleep_with_animation(SETTLE_TIME, "Waiting for cluster to start")
 
         # Run all the functional comparison tests.
         comparison_test(standalone_redis, dynomite_cluster, False)

--- a/test/dyno_cluster.py
+++ b/test/dyno_cluster.py
@@ -115,6 +115,19 @@ class DynoCluster(object):
         with open(CLUSTER_DESC_FILEPATH, 'w') as outfile:
             yaml.dump(yaml_cluster_desc, outfile, default_flow_style=False)
 
+    def _print_cluster_topology(self):
+        tokens = tokens_for_cluster(self.request['cluster_desc'], None)
+        print("Cluster topology:-");
+        for dc, racks in tokens:
+            print("\tDC: %s" % dc)
+            for rack, tokens in racks:
+                print("\t\tRack: %s" % rack)
+                # Nested loop is okay here since the #nodes will always be small.
+                for node in self.nodes:
+                    if node.spec.dc == dc and node.spec.rack == rack:
+                        print("\t\t\tNode: %s  || PID: %s" % (node.name, \
+                            node.get_dyno_node_pid()))
+
     def _delete_running_cluster_file(self):
         os.remove(CLUSTER_DESC_FILEPATH)
 
@@ -129,6 +142,7 @@ class DynoCluster(object):
 
         # Now that the cluster is up, write its description to a file.
         self._write_running_cluster_file()
+        self._print_cluster_topology()
 
     def teardown(self):
         for n in self.nodes:

--- a/test/redis_node.py
+++ b/test/redis_node.py
@@ -22,7 +22,7 @@ class RedisNode(Node):
 
     def launch(self):
         self.proc_future = \
-            (redis_bin['--bind', self.ip, '--port', self.port] > self.logfile) & BG(-9)
+            (redis_bin['--bind', self.ip, '--port', self.port, '--loglevel', 'verbose'] > self.logfile) & BG(-9)
 
     def teardown(self):
         self.proc_future.proc.kill()

--- a/test/start_cluster.py
+++ b/test/start_cluster.py
@@ -6,7 +6,7 @@ from plumbum import local
 from time import sleep
 
 from dyno_cluster import DynoCluster
-from utils import generate_ips, setup_temp_dir
+from utils import generate_ips, setup_temp_dir, sleep_with_animation
 
 SETTLE_TIME = 5
 
@@ -33,7 +33,7 @@ def main():
         dynomite_cluster.launch()
 
         # Wait for a while for the above nodes to start.
-        sleep(SETTLE_TIME)
+        sleep_with_animation(SETTLE_TIME, "Waiting for cluster to start")
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,6 +4,8 @@ import os
 import signal
 import string
 import yaml
+import time
+import sys
 
 from ip_util import int2quad
 from ip_util import quad2int
@@ -15,7 +17,22 @@ from itertools import count
 
 BASE_IPADDRESS = quad2int('127.0.1.1')
 RING_SIZE = 2**32
+TEARDOWN_SETTLE_TIME = 1
 
+
+def sleep_with_animation(seconds, optional_msg=""):
+    ticker = "|/-\\"
+    print("\n")
+    for i in range(seconds * 10):
+        time.sleep(0.1)
+        sys.stdout.write(\
+            "\r" + ticker[i % len(ticker)] + \
+            "\t" + ticker[i % len(ticker)] + \
+            "\t" + optional_msg + \
+            "\t" + ticker[i % len(ticker)] + \
+            "\t" + ticker[i % len(ticker)])
+        sys.stdout.flush()
+    print("\n")
 
 def string_generator(size=6, chars=string.ascii_letters + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
@@ -56,6 +73,7 @@ def teardown_running_cluster(cluster_desc_filepath, delete_test_dir=False):
                 # Delete the test directory of this cluster.
                 shutil.rmtree(yaml_desc['test_dir'])
         os.remove(cluster_desc_filepath)
+        sleep_with_animation(TEARDOWN_SETTLE_TIME, "Tearing down cluster")
 
 def setup_temp_dir():
     tempdir = LocalPath(mkdtemp(dir='.', prefix='test_run.'))


### PR DESCRIPTION
 In order to repair mismatched replicas, we need to repair them based on some agreed
 upon value. In most systems that usually is based on the timestamps. Since Redis does
 not support timestamps, we need to add the logic that tracks timestamps as metadata.

 The way we achieve recording timestamps is by converting all writes to Lua scripts that
 atomically do the operation itself and store the metadata for that key.

 The metadata is stored in what we call 'add sets' and 'remove sets' which are basically
 sorted sets that store the key name along with a corresponding timestamp that denotes
 when that key was last updated. All primary keys go to a 'top level add/rem set' which
 is currently denoted by '._add-set' and '._rem-set'.

 Secondary keys (fields in hash maps, sets, etc.) are stored in add/rem sets of their
 corresponding primary keys and are denoted by '._add-set_<key>' and '._rem-set_<key>'.

 A majority of the logic lives in src/proto/dyn_redis_repair.c.

 The 'redis_cmd_info' static array of structures contains information that will be used
 by  the "rewrite with metadata" and "repair" logic. This array is indexed by the command
 index that is set in dyn_message.h.

 All queries that will be rewritten to include metadata are denoted by
 'redis_cmd_info[CMD_IDX].has_repair_support' where 'CMD_IDX' is the index of the
 corresponding query. All read queries that return the requested values along with the
 metadata are denoted by 'redis_cmd_info[CMD_IDX].is_repairable'.
 If queries do not have "rewrite with MD" or "repair" support, we fallback to the old
 behavior which is based on quorum checksums.

 Every repairable read ('is_repairable' == true) returns data in the Redis wire protocol
 in the following format:
 \<status> \<ts> \<value>

 , where status can be one of 'X', 'R' or 'E'. They stand for:
    X = value not found
    R = value was deleted (i.e. it was found in the rem-set)
    E = value exists (it was found in the add-set)

 This format was chosen because it's the most optimized in terms of returning values to
 the client, i.e. we can just move the start pointer of the buffer just before '<value>'
 by skipping '<status>' and '<ts>' thereby avoiding the need to copy the value to yet
 another buffer.

 Currently the only read commands that have repair support return only one value at a
 time. In the future when queries that can return multiple values will be returned,
 the format will be naturally extended to be:
 <status_1> <ts_1> <status_2> <ts_2> .. <status_n> <ts_n> <val_1> <val_2> .. <val_n>

 This will allow us to skip all the metadata with a simple pointer move just as we do
 now.

 On repair supported reads, if we find that the timestamps between responses from the
 responding replicas are not the same, we pick the replica that has the largest TS, take
 its value and send a new write command to the replicas that are out of date with the
 most updated value.

 Since we need to know the exact keys, fields and values while writing with metadata or
 while repairing, we do a "post-parsing" step that records these in order to efficiently
 populate the arguments for the Lua script that we will send to Redis on behalf of the
 read/write. (see post_parse_msg())
 This may change if we modify the parser itself to record these tokens efficiently.
 TODO: Support parsing of optional fields.

 The Lua scripts that we use as templates for supported commands are listed below as
 compile time constants.

 This is still in the beta stage and has some limitations:
 - Large values may cause overflows ( > 512 bytes)
 - Limited command support due to parser limitations:
     - Sorted sets and lists need optional command parsing support.
 - Repairing on the read path vs. the background has perf implications. In the future,
   all the heavy lifting will happen in the background in order to have a 0 perf
   overhead on the read and write paths.