### PR TITLE
Remove incorrect assert in redis_rewrite_query()

### DIFF
--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -411,8 +411,6 @@ rstatus_t redis_rewrite_query(struct msg *orig_msg, struct context *ctx,
     case MSG_REQ_REDIS_SMEMBERS:
 
       if (orig_msg->owner->read_consistency == DC_SAFE_QUORUM) {
-        // SMEMBERS should have only one key.
-        ASSERT(orig_msg->nkeys == 1);
 
         // Get a new 'msg' structure.
         new_msg = msg_get(orig_msg->owner, true, __FUNCTION__);


### PR DESCRIPTION
The 'nkeys' member of 'struct msg' is used to indicate the number
of keys in a script. It was previously incorrectly interpreted as
the number of keys in the query instead. This patch removes this assert.