### PR TITLE
Updated link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Contributions will be accepted to the [dev](https://github.com/Netflix/dynomite/
 
     c. Push to your branch (git push origin my_branch)
 
-    d. Initiate a pull request on github ( http://help.github.com/send-pull-requests/ )
+    d. Initiate a pull request on github ( http://help.github.com/en/articles/creating-a-pull-request/ )
 
     e. Done :)
 


### PR DESCRIPTION
Old link was 404
Link in the form http://help.github.com/creating-a-pull-request (like the previous) does not exist as far as I know
http instead of https (like the previous)

See also: https://github.com/Netflix/conductor/pull/1163/commits/3bc54fdb52ad558812f4f6e2176f199ffa8e1318