### PR TITLE
Dynomite,  Support REDIS SELECT 0 command

### DIFF
--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -225,7 +225,7 @@ typedef enum msg_parse_result {
   ACTION(REQ_REDIS_JSONOBJKEYS)                                                \
   ACTION(REQ_REDIS_JSONOBJLEN)                                                 \
   /* ACTION(REQ_REDIS_AUTH) */                                                 \
-  /* ACTION(REQ_REDIS_SELECT)*/ /* only during init */                         \
+  ACTION(REQ_REDIS_SELECT) /* SELECT with arg '0' is valid */                  \
   ACTION(REQ_REDIS_PFADD)        /* redis requests - hyperloglog */            \
   ACTION(REQ_REDIS_PFCOUNT)                                                    \
   ACTION(RSP_REDIS_STATUS) /* redis response */                                \

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -89,8 +89,6 @@ static bool redis_arg0(struct msg *r) {
 
     case MSG_REQ_REDIS_KEYS:
     case MSG_REQ_REDIS_PFCOUNT:
-      
-      
       return true;
 
     default:
@@ -136,7 +134,6 @@ static bool redis_arg1(struct msg *r) {
     case MSG_REQ_REDIS_CONFIG:
     case MSG_REQ_REDIS_SCRIPT_LOAD:
     case MSG_REQ_REDIS_SCRIPT_EXISTS:
-
 
       return true;
 
@@ -1662,7 +1659,6 @@ void redis_parse_req(struct msg *r, const struct string *hash_tag) {
         if (*m != CR) {
           goto error;
         } else {
-            
           struct keypos *kpos;
 
           p = m; /* move forward by rlen bytes */


### PR DESCRIPTION
In some cases Redis clients do SELECT 0, even if no db explicitly specified.

Purpose of this PR to support SELECT 0 and return error if other value is provided.
