### PR TITLE
Change read repair toggle REST call to explicit switch

### DIFF
--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1063,10 +1063,17 @@ static void parse_request(int sd, struct stats_cmd *st_cmd) {
             st_cmd->cmd = CMD_PING;
           }
           return;
-        } else if (strncmp(reqline[1], "/toggle_read_repairs", 20) == 0) {
+        } else if (strncmp(reqline[1], "/read_repairs", 13) == 0) {
+          log_notice("Setting read_repairs (enabled/disabled): %s", reqline[1]);
+          char *op = reqline[1] + 13;
           st_cmd->cmd = CMD_TOGGLE_READ_REPAIRS;
-          g_read_repairs_enabled = !g_read_repairs_enabled;
-          loga("Read repairs enabled: $d", g_read_repairs_enabled);
+          if (strncmp(op, "/enable", 7) == 0) {
+            g_read_repairs_enabled = true;
+          } else if (strncmp(op, "/disable", 8) == 0) {
+            g_read_repairs_enabled = false;
+          } else {
+            st_cmd->cmd = CMD_UNKNOWN;
+          }
           return;
         }
 

--- a/test/dyno_cluster.py
+++ b/test/dyno_cluster.py
@@ -162,12 +162,12 @@ class DynoCluster(object):
 
     def enable_read_repairs(self):
         for node in self.nodes:
-            r = make_get_rest_call('http://%s:22222/toggle_read_repairs' % node.ip)
+            r = make_get_rest_call('http://%s:22222/read_repairs/enable' % node.ip)
             assert r.text.find('ENABLED') != -1
 
     def disable_read_repairs(self):
         for node in self.nodes:
-            r = make_get_rest_call('http://%s:22222/toggle_read_repairs' % node.ip)
+            r = make_get_rest_call('http://%s:22222/read_repairs/disable' % node.ip)
             assert r.text.find('DISABLED') != -1
 
     def set_cluster_consistency_level(self, quorum_option):


### PR DESCRIPTION
In order to avoid any confusion, this patch changes the read repair
toggle to an explicit switch.