### PR TITLE
Treat each rack continuum as an array

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -50,7 +50,8 @@ static void core_print_peer_status(void *arg1) {
       struct rack *rack = array_get(&dc->racks, rack_index);
       uint8_t i = 0;
       for (i = 0; i < rack->ncontinuum; i++) {
-        struct continuum *c = &rack->continuum[i];
+        struct continuum *c = (struct continuum*) array_get(&rack->continuums, i);
+        ASSERT(c != NULL);
         uint32_t peer_index = c->index;
         struct node *peer = *(struct node **)array_get(&sp->peers, peer_index);
         if (!peer) log_panic("peer is null. Topology not inited proerly");

--- a/src/dyn_core.h
+++ b/src/dyn_core.h
@@ -126,7 +126,7 @@ struct instance {
 
 struct continuum {
   uint32_t index;          /* dyn_peer index */
-  uint32_t value;          /* hash value, used by ketama */
+  uint32_t value;          /* hash value, used ONLY by ketama */
   struct dyn_token *token; /* used in vnode/dyn_token situations */
 };
 
@@ -136,7 +136,7 @@ struct rack {
   uint32_t ncontinuum; /* # continuum points */
   uint32_t
       nserver_continuum; /* # servers - live and dead on continuum (const) */
-  struct continuum *continuum; /* continuum */
+  struct array continuums;
 };
 
 struct datacenter {

--- a/src/dyn_dnode_peer.c
+++ b/src/dyn_dnode_peer.c
@@ -785,7 +785,7 @@ uint32_t dnode_peer_idx_for_key_on_rack(struct server_pool *pool,
                                         uint32_t keylen) {
   struct dyn_token token;
   pool->key_hash(key, keylen, &token);
-  return vnode_dispatch(rack->continuum, rack->ncontinuum, &token);
+  return vnode_dispatch(&rack->continuums, rack->ncontinuum, &token);
 }
 
 static struct node *dnode_peer_for_key_on_rack(struct server_pool *pool,

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -508,7 +508,9 @@ dictType dc_string_dict_type = {
 };
 
 static rstatus_t rack_init(struct rack *rack) {
-  rack->continuum = dn_alloc(sizeof(struct continuum));
+
+  // TODO: Initialize the array to the size of the ring instead of to 1.
+  THROW_STATUS(array_init(&rack->continuums, 1, sizeof(struct continuum)));
   rack->ncontinuum = 0;
   rack->nserver_continuum = 0;
   rack->name = dn_alloc(sizeof(struct string));
@@ -521,9 +523,7 @@ static rstatus_t rack_init(struct rack *rack) {
 }
 
 static rstatus_t rack_deinit(struct rack *rack) {
-  if (rack->continuum != NULL) {
-    dn_free(rack->continuum);
-  }
+  array_deinit(&rack->continuums);
 
   return DN_OK;
 }

--- a/src/dyn_vnode.h
+++ b/src/dyn_vnode.h
@@ -1,6 +1,16 @@
+/*
+ * Dynomite - A thin, distributed replication layer for multi non-distributed
+ * storages. Copyright (C) 2019 Netflix, Inc.
+ */
+
 #pragma once
 #include <dyn_types.h>
 
+// Initializes (on first call) and updates (on subsequent calls) the per rack continuums
+// and makes sure the tokens managed by the continuums are ascending.
 rstatus_t vnode_update(struct server_pool *pool);
-uint32_t vnode_dispatch(struct continuum *continuum, uint32_t ncontinuum,
+
+// Returns the index of the continuum from 'continuums' where 'token' falls.
+// If 'token' falls into interval (a,b], we return b.
+uint32_t vnode_dispatch(struct array *continuums, uint32_t ncontinuum,
                         struct dyn_token *token);


### PR DESCRIPTION
Each rack has a 'struct continuum' pointer in it. This is used to determine
which token belongs to which node (see dyn_vnode.c).

While it has only a single pointer, the code uses it as though it's
an array of struct pointers. This potentially could lead to a lot of
confusion.

This patch addresses this by explicitly changing the member to an array
of structs.

Manually tested to make sure that there is no change to how the keys are
sharded.