### PR TITLE
small cleanups on test/ python scripts.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+certifi==2019.6.16
+chardet==3.0.4
+idna==2.8
+pkg-resources==0.0.0
+plumbum==1.6.7
+PyYAML==5.1.2
+redis==3.3.7
+requests==2.22.0
+urllib3==1.25.3

--- a/test/cluster_generator.py
+++ b/test/cluster_generator.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 from contextlib import ExitStack
-from time import sleep
 from urllib.request import urlopen
 import argparse
 import json
 import random
 import sys
-import yaml
 
 from plumbum import local
 

--- a/test/dyno_cluster.py
+++ b/test/dyno_cluster.py
@@ -2,10 +2,7 @@
 from collections import namedtuple
 from plumbum import local
 import os
-import redis
 import random
-import shutil
-import signal
 import yaml
 
 from dyno_node import DynoNode
@@ -71,7 +68,7 @@ class DynoCluster(object):
     def __init__(self, request_file, ips):
         # Load the YAML file describing the cluster.
         with open(request_file, 'r') as fh:
-            self.request = yaml.load(fh)
+            self.request = yaml.safe_load(fh)
 
         self.ips = ips
         self.nodes = []

--- a/test/func_test.py
+++ b/test/func_test.py
@@ -274,25 +274,3 @@ def comparison_test(redis, dynomite, debug):
     run_read_repair_test(c)
     print("All test ran fine")
 
-def main(args):
-    # This test assumes for now that the nodes are running at the given ports.
-    # This is done by travis.sh. Please check that file and the corresponding
-    # yml files for each dynomite instance there to get an idea of the topology.
-    r = RedisNode(ip="127.0.1.1", port=1212)
-    d1 = DynoNode(ip="127.0.1.2", data_store_port=22121)
-    d2 = DynoNode(ip="127.0.1.3", data_store_port=22122)
-    d3 = DynoNode(ip="127.0.1.4", data_store_port=22123)
-    d4 = DynoNode(ip="127.0.1.5", data_store_port=22124)
-    d5 = DynoNode(ip="127.0.1.6", data_store_port=22125)
-    dyno_nodes = [d1,d2,d3,d4,d5]
-    cluster = DynoCluster(dyno_nodes)
-    try:
-        comparison_test(r, cluster, args.debug)
-    except ResultMismatchError as r:
-        print(r)
-        return 1
-    return 0
-
-if __name__ == "__main__":
-    args = parse_args()
-    sys.exit(main(args))

--- a/test/func_test.py
+++ b/test/func_test.py
@@ -2,14 +2,9 @@
 import redis
 import argparse
 import random
-import string
-import sys
 import time
 from utils import string_generator, number_generator
-from dyno_node import DynoNode
-from redis_node import RedisNode
-from dyno_cluster import DynoCluster
-from dual_run import dual_run, ResultMismatchError
+from dual_run import dual_run
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -273,4 +268,3 @@ def comparison_test(redis, dynomite, debug):
     # DC_SAFE_QUORUM
     run_read_repair_test(c)
     print("All test ran fine")
-

--- a/test/start_cluster.py
+++ b/test/start_cluster.py
@@ -3,7 +3,6 @@ import argparse
 import sys
 
 from plumbum import local
-from time import sleep
 
 from dyno_cluster import DynoCluster
 from utils import generate_ips, setup_temp_dir, sleep_with_animation

--- a/test/utils.py
+++ b/test/utils.py
@@ -59,7 +59,7 @@ def teardown_running_cluster(cluster_desc_filepath, delete_test_dir=False):
     running_cluster_file = Path(cluster_desc_filepath)
     if running_cluster_file.is_file():
         with open(cluster_desc_filepath, 'r') as fh:
-            yaml_desc = yaml.load(fh)
+            yaml_desc = yaml.safe_load(fh)
             for cluster in yaml_desc['cluster_desc']:
                 print("Killing existing '{}'".format(cluster['name']))
                 for pid in cluster['pids']:


### PR DESCRIPTION
This change includes a few very small fixes to python scripts in the test/ directory.

I've broken the change roughly by commits, but here is the list of changes:
 - add a `requirements.txt` so that it is easy to run the tests on `test/..`
 - remove dead code from test/func_test.py that is broken and cannot work.
 - remove unused imports on a few files
 - change `yaml.load(f)` into `yaml.safe_load(f)` given modern versions of yaml always print a runtime safety warning that `load(f)` is unsave given it evaluates code inside `f`.

I have a few other changes and wanted to split out these small fixes into a separate change.
Hopefully these changes aren't contentious.
