### PR TITLE
func_test.py: make script test run with DC_ONE consistency

### DIFF
--- a/test/func_test.py
+++ b/test/func_test.py
@@ -2,7 +2,6 @@
 import redis
 import argparse
 import random
-import string
 import sys
 import time
 from utils import string_generator, number_generator
@@ -66,6 +65,11 @@ def run_multikey_test(c, max_keys=1000, max_payload=10):
 def run_script_tests(c):
     TEST_NAME="SCRIPTS"
     print("Running %s tests" % TEST_NAME)
+
+    # set consistency level to DC_ONE for this tor run correctly
+    # TODO: Remove when no longer true
+    dyno_cluster = c.get_dynomite_cluster()
+    dyno_cluster.set_cluster_consistency_level("DC_ONE")
 
     # This script basically executes 'GET <key>'.
     SCRIPT_BODY='{}'.format("return redis.call('get', KEYS[1])")
@@ -267,6 +271,8 @@ def comparison_test(redis, dynomite, debug):
 
     run_multikey_test(c)
     run_hash_tests(c, max_keys=10, max_fields=100)
+
+    # this sets consistency level to DC_ONE for this to run correctly
     run_script_tests(c)
 
     # Run read repairs tests last since we change the state of the cluster to use


### PR DESCRIPTION
this fix is required to run `test/cluster_generator.py` tests w/ cluster
definitions that default to DC_SAFE_QUORUM consistency levels.

I'm now able to run:
`> test/cluster_generator.py test/safe_quorum_request.yaml`