### PR TITLE
Fix SCRIPT EXISTS crash

### DIFF
--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -1065,6 +1065,7 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
               // This is not to be confused with 'EXISTS'. This is the second half of the
               // command 'SCRIPT EXISTS'.
               r->type = MSG_REQ_REDIS_SCRIPT_EXISTS;
+              r->msg_routing = ROUTING_ALL_NODES_ALL_RACKS_ALL_DCS;
               r->is_read = 1;
               break;
             }


### PR DESCRIPTION
SCRIPT EXISTS was using the wrong message routing option causing all
the replica messages to go to the local redis instance. And Dynomite
would crash since it processes only one of the 3 replies that Redis
returns, leaving the local redis server message queue in an inconsistent
state.