### PR TITLE
Fix crash during a MSG_PARSE_AGAIN parse state w/ repairs

### DIFF
--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -1830,7 +1830,8 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
 
             m = next_mbuf->pos + new_mbuf_offset;
             b = next_mbuf;
-            ++r->latest_parsed_mbuf_idx;
+
+            if (mbuf_full(b)) ++r->latest_parsed_mbuf_idx;
           }
           if (arg1_across_mbufs == false) {
             rstatus_t argstatus = record_arg(p , m , r->args);
@@ -1847,6 +1848,8 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
           r->rlen -= (uint32_t)(b->last - p);
           m = b->last - 1;
           p = m;
+
+          if (mbuf_full(b)) ++r->latest_parsed_mbuf_idx;
           break;
         }
 
@@ -1968,7 +1971,7 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
 
             m = next_mbuf->pos + new_mbuf_offset;
             b = next_mbuf;
-            ++r->latest_parsed_mbuf_idx;
+            if (mbuf_full(b)) ++r->latest_parsed_mbuf_idx;
           }
           if (arg2_across_mbufs == false) {
             // TODO: Verify if this is the correct behavior for EVAL/EVALSHA
@@ -1986,6 +1989,8 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
           r->rlen -= (uint32_t)(b->last - p);
           m = b->last - 1;
           p = m;
+
+          if (mbuf_full(b)) ++r->latest_parsed_mbuf_idx;
           break;
         }
 
@@ -2121,7 +2126,7 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
 
             m = next_mbuf->pos + new_mbuf_offset;
             b = next_mbuf;
-            ++r->latest_parsed_mbuf_idx;
+            if (mbuf_full(b)) ++r->latest_parsed_mbuf_idx;
           }
           if (arg3_across_mbufs == false) {
             rstatus_t argstatus = record_arg(p , m , r->args);
@@ -2138,6 +2143,8 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
           r->rlen -= (uint32_t)(b->last - p);
           m = b->last - 1;
           p = m;
+
+          if (mbuf_full(b)) ++r->latest_parsed_mbuf_idx;
           break;
         }
 
@@ -2228,7 +2235,7 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
 
             m = next_mbuf->pos + new_mbuf_offset;
             b = next_mbuf;
-            ++r->latest_parsed_mbuf_idx;
+            if (mbuf_full(b)) ++r->latest_parsed_mbuf_idx;
           }
           if (argn_across_mbufs == false) {
             rstatus_t argstatus = record_arg(p , m , r->args);
@@ -2245,6 +2252,8 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
           r->rlen -= (uint32_t)(b->last - p);
           m = b->last - 1;
           p = m;
+
+          if (mbuf_full(b)) ++r->latest_parsed_mbuf_idx;
           break;
         }
 
@@ -2289,15 +2298,13 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
   r->pos = p;
   r->state = state;
 
-  // We reached here since we finished parsing the current 'mbuf' in 'r->mhdr'.
-  ++r->latest_parsed_mbuf_idx;
-
   // If we have to parse again, we won't be able to write with the timestamp.
   r->rewrite_with_ts_possible = false;
   if (b->last == b->end && r->token != NULL) {
     r->pos = r->token;
     r->token = NULL;
     r->result = MSG_PARSE_REPAIR;
+
   } else {
     r->result = MSG_PARSE_AGAIN;
   }


### PR DESCRIPTION
When read repairs are enabled, we attempt to keep a track of the last
parsed mbuf if the request is large enough to be split across multiple
buffers.

The code would previously update the latest_parsed_mbuf_idx field if the
current token length surpassed (mbuf)->last. This turns out to be incorrect
since we may parse with partial network reads as well.

The fix is to check if mbuf_full() before updating said index. Confirmed its
working with large requests across mbufs and partial network read requests.