### PR TITLE
Fix msg_repair()

### DIFF
--- a/src/dyn_message.c
+++ b/src/dyn_message.c
@@ -881,8 +881,10 @@ static rstatus_t msg_repair(struct context *ctx, struct conn *conn,
     return DN_ENOMEM;
   }
 
-  mbuf = STAILQ_LAST(&msg->mhdr, mbuf, next);
-  mbuf_remove(&msg->mhdr, mbuf);
+  // This was added to handle a specific case which doesn't seem reproducible
+  // now. Revisit if things seem off.
+  //mbuf = STAILQ_LAST(&msg->mhdr, mbuf, next);
+  //mbuf_remove(&msg->mhdr, mbuf);
   mbuf_insert(&msg->mhdr, nbuf);
   msg->pos = nbuf->pos;
 


### PR DESCRIPTION
msg_repair() seems to have been broken in previous patches. This patch
undoes the changes made to it earlier. Revist if removing it causes
issues in the future.