### PR TITLE
[Beta] Support DC_EACH_SAFE_QUORUM consistenct level

### DIFF
--- a/src/dyn_conf.c
+++ b/src/dyn_conf.c
@@ -2010,10 +2010,12 @@ static rstatus_t conf_validate_pool(struct conf *cf, struct conf_pool *cp) {
     g_read_consistency = DC_SAFE_QUORUM;
   else if (!dn_strcasecmp(cp->read_consistency.data, CONF_STR_DC_QUORUM))
     g_read_consistency = DC_QUORUM;
+  else if (!dn_strcasecmp(cp->read_consistency.data, CONF_STR_DC_EACH_SAFE_QUORUM))
+    g_read_consistency = DC_EACH_SAFE_QUORUM;
   else {
     log_error(
         "conf: directive \"read_consistency:\"must be one of 'DC_ONE' "
-        "'DC_QUORUM' 'DC_SAFE_QUORUM'");
+        "'DC_QUORUM' 'DC_SAFE_QUORUM' 'DC_EACH_SAFE_QUORUM'");
     return DN_ERROR;
   }
 
@@ -2023,10 +2025,12 @@ static rstatus_t conf_validate_pool(struct conf *cf, struct conf_pool *cp) {
     g_write_consistency = DC_SAFE_QUORUM;
   else if (!dn_strcasecmp(cp->write_consistency.data, CONF_STR_DC_QUORUM))
     g_write_consistency = DC_QUORUM;
+  else if (!dn_strcasecmp(cp->write_consistency.data, CONF_STR_DC_EACH_SAFE_QUORUM))
+    g_write_consistency = DC_EACH_SAFE_QUORUM;
   else {
     log_error(
         "conf: directive \"write_consistency:\"must be one of 'DC_ONE' "
-        "'DC_QUORUM' 'DC_SAFE_QUORUM'");
+        "'DC_QUORUM' 'DC_SAFE_QUORUM' 'DC_EACH_SAFE_QUORUM'");
     return DN_ERROR;
   }
 

--- a/src/dyn_conf.h
+++ b/src/dyn_conf.h
@@ -47,6 +47,7 @@
 #define CONF_STR_DC_ONE "dc_one"
 #define CONF_STR_DC_QUORUM "dc_quorum"
 #define CONF_STR_DC_SAFE_QUORUM "dc_safe_quorum"
+#define CONF_STR_DC_EACH_SAFE_QUORUM "dc_each_safe_quorum"
 
 #define UNSET_NUM 0
 

--- a/src/dyn_dnode_client.c
+++ b/src/dyn_dnode_client.c
@@ -306,7 +306,8 @@ static void dnode_req_forward(struct context *ctx, struct conn *conn,
     // racks
     struct mbuf *orig_mbuf = STAILQ_FIRST(&req->mhdr);
     struct datacenter *dc = server_get_dc(pool, &pool->dc);
-    req_forward_all_local_racks(ctx, conn, req, orig_mbuf, key, keylen, dc);
+
+    req_forward_all_racks_for_dc(ctx, conn, req, orig_mbuf, key, keylen, dc);
   }
 }
 

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -5,15 +5,109 @@
 #include "dyn_message.h"
 #include "dyn_server.h"
 
-void init_response_mgr(struct response_mgr *rspmgr, struct msg *req,
-                       bool is_read, uint8_t max_responses, struct conn *conn) {
+
+int init_response_mgr_each_quorum_helper(struct msg *req,
+    struct response_mgr *rspmgr, struct conn *c_conn, struct datacenter *dc);
+
+rstatus_t init_response_mgr_all_dcs(struct context *ctx, struct msg *req,
+    struct conn *c_conn, struct datacenter *local_dc) {
+
+  ASSERT(req->consistency == DC_EACH_SAFE_QUORUM);
+
+
+  uint32_t total_responses_to_await = 0;
+  int num_dcs_in_quorum = array_n(&ctx->pool.datacenters);
+  req->additional_each_rspmgrs =
+      (struct response_mgr**) dn_alloc(num_dcs_in_quorum * (sizeof(struct response_mgr*)));
+  if (req->additional_each_rspmgrs == NULL) return DN_ENOMEM;
+
+  // Initialize the response managers for all remote DCs. (The 0th idx in the
+  // 'additional_each_rspmgrs' array is reserved for the local DC).
+  int i;
+  for (i = 1; i < num_dcs_in_quorum; ++i) {
+    req->additional_each_rspmgrs[i] = (struct rspmgr*) dn_alloc(sizeof(struct response_mgr));
+    if (req->additional_each_rspmgrs[i] == NULL) {
+      goto enomem;
+    }
+
+    uint32_t dc_idx = 0;
+    struct datacenter *remote_dc = NULL;
+    do {
+      remote_dc = (struct datacenter*) array_get(&ctx->pool.datacenters, dc_idx);
+      ++dc_idx;
+    } while(string_compare(remote_dc->name, local_dc->name) == 0); // Skip the local DC.
+
+    int max_rsps_for_dc = init_response_mgr_each_quorum_helper(
+        req, req->additional_each_rspmgrs[i], c_conn, remote_dc);
+    if (max_rsps_for_dc == -1) goto enomem;
+
+    total_responses_to_await += max_rsps_for_dc;
+  }
+
+  // Now do the same as the above for the local DC.
+  // Point the 0th index to the statically allocated response_mgr.
+  req->additional_each_rspmgrs[0] = &req->rspmgr;
+
+  int max_rsps_for_dc = init_response_mgr_each_quorum_helper(
+      req, req->additional_each_rspmgrs[0], c_conn, local_dc);
+  if (max_rsps_for_dc == -1) goto enomem;
+  total_responses_to_await += max_rsps_for_dc;
+
+  // Update the total number of responses to wait for.
+  req->awaiting_rsps = total_responses_to_await;
+
+  return DN_OK;
+ enomem: ;
+  int j = 1;
+  while (req->additional_each_rspmgrs[j] != NULL) {
+    if (req->additional_each_rspmgrs[j]->dc_name.data != NULL) {
+      string_deinit(&req->additional_each_rspmgrs[j]->dc_name);
+    }
+    dn_free(req->additional_each_rspmgrs[j]);
+    ++j;
+  }
+  dn_free(req->additional_each_rspmgrs);
+  return DN_ENOMEM;
+}
+
+
+/*
+ * Helper function that initializes a 'struct response_mgr' and copies the appropriate
+ * DC name to it. Only used under DC_EACH_SAFE_QUORUM.
+ *
+ * Returns maximum number of responses possible for 'dc'.
+ * Returns -1 on an error.
+ */
+int init_response_mgr_each_quorum_helper(struct msg *req,
+    struct response_mgr *rspmgr, struct conn *c_conn, struct datacenter *dc) {
+
+  ASSERT(req->consistency == DC_EACH_SAFE_QUORUM);
+
+  uint8_t rack_cnt = (uint8_t) array_n(&dc->racks);
+
+  // Initialize the response mgr.
+  init_response_mgr(req, rspmgr, rack_cnt, c_conn);
+
+  // Copy the name of the DC to the response manager.
+  if (string_duplicate(&rspmgr->dc_name, dc->name) != DN_OK) {
+    return -1;
+  }
+
+  return rspmgr->max_responses;
+}
+
+void init_response_mgr(struct msg *req, struct response_mgr *rspmgr,
+    uint8_t max_responses_for_dc, struct conn *c_conn) {
+
   memset(rspmgr, 0, sizeof(struct response_mgr));
-  rspmgr->is_read = is_read;
-  rspmgr->max_responses = max_responses;
-  rspmgr->quorum_responses = (uint8_t)(max_responses / 2 + 1);
-  rspmgr->conn = conn;
+  rspmgr->is_read = req->is_read;
+  rspmgr->max_responses = max_responses_for_dc;
+  rspmgr->quorum_responses = (uint8_t)(max_responses_for_dc / 2 + 1);
+  rspmgr->conn = c_conn;
   rspmgr->msg = req;
-  req->awaiting_rsps = max_responses;
+  req->awaiting_rsps = max_responses_for_dc;
+
+  req->rspmgrs_inited = true;
 }
 
 static bool rspmgr_is_quorum_achieved(struct response_mgr *rspmgr) {

--- a/src/dyn_response_mgr.h
+++ b/src/dyn_response_mgr.h
@@ -1,6 +1,8 @@
 #ifndef _DYN_RESPONSE_MGR_H_
 #define _DYN_RESPONSE_MGR_H_
 
+#include "dyn_string.h"
+
 #define MAX_REPLICAS_PER_DC 3
 struct response_mgr {
   bool is_read;
@@ -9,18 +11,29 @@ struct response_mgr {
      here. But we have only 3 ASGs */
   struct msg *responses[MAX_REPLICAS_PER_DC];
   uint32_t checksums[MAX_REPLICAS_PER_DC];
-  uint8_t
-      good_responses;     // non-error responses received. (nil) is not an error
-  uint8_t max_responses;  // max responses expected.
-  uint8_t quorum_responses;  // responses expected to form a quorum
-  uint8_t error_responses;   // error responses received
-  struct msg *err_rsp;       // first error response
+  // Number of non-error responses received. (nil) is not an error.
+  uint8_t good_responses;
+  // Maximum number of responses possible.
+  uint8_t max_responses;
+  // Number of responses required to form a quorum.
+  uint8_t quorum_responses;
+  // Number of error responses received.
+  uint8_t error_responses;
+  // First error response
+  struct msg *err_rsp;
   struct conn *conn;
-  struct msg *msg;  // corresponding request
+  // Corresponding request
+  struct msg *msg;
+  // The DC that this response manager is responsible for.
+  struct string dc_name;
 };
 
-void init_response_mgr(struct response_mgr *rspmgr, struct msg *, bool is_read,
-                       uint8_t max_responses, struct conn *conn);
+rstatus_t init_response_mgr_all_dcs(struct context *ctx, struct msg *req,
+    struct conn *c_conn, struct datacenter *local_dc);
+
+void init_response_mgr(struct msg *req, struct response_mgr *rspmgr,
+    uint8_t max_responses_for_dc, struct conn *c_conn);
+
 // DN_OK if response was accepted
 rstatus_t rspmgr_submit_response(struct response_mgr *rspmgr, struct msg *rsp);
 bool rspmgr_check_is_done(struct response_mgr *rspmgr);


### PR DESCRIPTION
For low-throughput but high-consistency use-cases, DC_EACH_SAFE_QUORUM
expects each DC to achieve quorum individually before responding to
the client.

This is currently under beta testing.