### PR TITLE
Capture pthread_create() return value with appropriate data type

### DIFF
--- a/src/dyn_gossip.c
+++ b/src/dyn_gossip.c
@@ -840,12 +840,12 @@ static void *gossip_loop(void *arg) {
 }
 
 rstatus_t gossip_start(struct server_pool *sp) {
-  rstatus_t status;
   pthread_t tid;
 
-  status = pthread_create(&tid, NULL, gossip_loop, sp);
-  if (status < 0) {
-    log_error("gossip service create failed: %s", strerror(status));
+  int pthread_status;
+  pthread_status = pthread_create(&tid, NULL, gossip_loop, sp);
+  if (pthread_status < 0) {
+    log_error("gossip service create failed: %s", strerror(pthread_status));
     return DN_ERROR;
   }
 

--- a/src/dyn_stats.c
+++ b/src/dyn_stats.c
@@ -1346,17 +1346,16 @@ static rstatus_t stats_listen(struct stats *st) {
 }
 
 static rstatus_t stats_start_aggregator(struct stats *st) {
-  rstatus_t status;
-
   if (!stats_enabled) {
     return DN_OK;
   }
 
   THROW_STATUS(stats_listen(st));
 
-  status = pthread_create(&st->tid, NULL, stats_loop, st);
-  if (status < 0) {
-    log_error("stats aggregator create failed: %s", strerror(status));
+  int pthread_status;
+  pthread_status = pthread_create(&st->tid, NULL, stats_loop, st);
+  if (pthread_status < 0) {
+    log_error("stats aggregator create failed: %s", strerror(pthread_status));
     return DN_ERROR;
   }
 

--- a/src/entropy/dyn_entropy_util.c
+++ b/src/entropy/dyn_entropy_util.c
@@ -627,14 +627,13 @@ void *entropy_loop(void *arg) {
  */
 
 rstatus_t entropy_conn_start(struct entropy *cn) {
-  rstatus_t status;
-
   THROW_STATUS(entropy_listen(cn));
 
-  status = pthread_create(&cn->tid, NULL, entropy_loop, cn);
-  if (status < 0) {
+  int pthread_status;
+  pthread_status = pthread_create(&cn->tid, NULL, entropy_loop, cn);
+  if (pthread_status < 0) {
     log_error("reconciliation thread for socket create failed: %s",
-              strerror(status));
+              strerror(pthread_status));
     return DN_ERROR;
   }
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -38,7 +38,7 @@ def string_generator(size=6, chars=string.ascii_letters + string.digits):
     return ''.join(random.choice(chars) for _ in range(size))
 
 def number_generator(size=4, chars=string.digits):
-    return ''.join(random.choice(chars) for _ in range(size))
+    return int(''.join(random.choice(chars) for _ in range(size)))
 
 def dict_request(request, key1, key2):
     """Converts the request into an easy to consume dict format."""


### PR DESCRIPTION
Even though rstatus_t is an int typedef, it's not appropriate to
capture integers that do not denote 'rstatus_t' values into an
rstatus_t variable, as it decreases readability of code.