### PR TITLE
Disable initializing anti-entropy as it's not used

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -132,6 +132,9 @@ static rstatus_t core_event_base_create(struct context *ctx) {
 }
 
 /**
+ *
+ * NOTE: DEPRECATED and not currently used in the codebase.
+ *
  * Initialize anti-entropy.
  * @param[in,out] ctx Context.
  * @return rstatus_t Return status code.
@@ -265,11 +268,6 @@ rstatus_t core_start(struct instance *nci) {
   }
 
   status = core_stats_create(ctx);
-  if (status != DN_OK) {
-    goto error;
-  }
-
-  status = core_entropy_init(ctx);
   if (status != DN_OK) {
     goto error;
   }

--- a/src/entropy/dyn_entropy_util.c
+++ b/src/entropy/dyn_entropy_util.c
@@ -405,6 +405,9 @@ rstatus_t entropy_key_iv_load(struct context *ctx) {
 }
 
 /*
+ *
+ * NOTE: DEPRECATED and not currently used in the codebase.
+ *
  * Function:  entropy_snd_init
  * --------------------
  * Initiates the data for the connection towards another cluster for


### PR DESCRIPTION
The initialization always fails in any case, so let's stop doing it
and mark the anti-entropy part of the code as deprecated.