### PR TITLE
[Unsupported] Allow setting per-connection consistency through fake R…

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -343,6 +343,7 @@ struct msg *req_recv_next(struct context *ctx, struct conn *conn, bool alloc) {
   if (is_read_repairs_enabled()) {
     req->timestamp = current_timestamp_in_millis();
   }
+
   return req;
 }
 
@@ -367,6 +368,11 @@ static bool req_filter(struct context *ctx, struct conn *conn,
     conn->eof = 1;
     conn->recv_ready = 0;
     req_put(req);
+    return true;
+  }
+
+  // If this is a Dynomite configuration message, don't forward it.
+  if (is_msg_type_dyno_config(req->type)) {
     return true;
   }
 

--- a/src/dyn_connection.c
+++ b/src/dyn_connection.c
@@ -127,8 +127,7 @@ inline void conn_set_read_consistency(struct conn *conn, consistency_t cons) {
 }
 
 inline consistency_t conn_get_read_consistency(struct conn *conn) {
-  // return conn->read_consistency;
-  return g_read_consistency;
+  return conn->read_consistency;
 }
 
 inline void conn_set_write_consistency(struct conn *conn, consistency_t cons) {
@@ -136,8 +135,7 @@ inline void conn_set_write_consistency(struct conn *conn, consistency_t cons) {
 }
 
 inline consistency_t conn_get_write_consistency(struct conn *conn) {
-  // return conn->write_consistency;
-  return g_write_consistency;
+  return conn->write_consistency;
 }
 
 rstatus_t conn_event_del_conn(struct conn *conn) {

--- a/src/dyn_response_mgr.c
+++ b/src/dyn_response_mgr.c
@@ -182,7 +182,7 @@ static void rspmgr_incr_non_quorum_responses_stats(
  */
 bool perform_repairs_if_necessary(struct context *ctx, struct response_mgr *rspmgr) {
 
-  struct msg* repair_msg;
+  struct msg* repair_msg = NULL;
   rstatus_t repair_create_status = g_make_repair_query(ctx, rspmgr, &repair_msg);
 
   if (repair_create_status == DN_OK && repair_msg != NULL) {

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -886,10 +886,11 @@ void req_send_done(struct context *ctx, struct conn *conn, struct msg *req) {
    * enqueue message (request) in server outq, if response is expected.
    * Otherwise, free the request
    */
-  if (req->expect_datastore_reply || (conn->type == CONN_SERVER))
+  if (req->expect_datastore_reply || (conn->type == CONN_SERVER)) {
     conn_enqueue_outq(ctx, conn, req);
-  else
+  } else {
     req_put(req);
+  }
 }
 
 static void req_server_enqueue_imsgq(struct context *ctx, struct conn *conn,


### PR DESCRIPTION
…edis cmd

Ideally we shouldn't be doing this and should have a connection handshake
stage to set connection level configuration. However, this is quite
urgent for a specific use-case at the moment and will be changed in
the future. Production code relying on this is not a good idea.

In this we introduce a new fake Redis command that's parsed by the
Redis parser called:
'DYNO_CONFIG:CONN_CONSISTENCY <quorum-setting>'

This will change the consistency level only for that connection.

A new Dynomtie parsing result called MSG_PARSE_DYNO_CONFIG signifies
a connection level configuration was received. We simulate a response
to the client by replying with "+OK\r\n".

Testing: Made sure that a key with a quorum failure is accessible after
calling 'DYNO_CONFIG:CONN_CONSISTENCY DC_ONE' in the same client session.