### PR TITLE
Support the Redis "QUIT" command properly

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -365,9 +365,13 @@ static bool req_filter(struct context *ctx, struct conn *conn,
   if (req->quit) {
     ASSERT(conn->rmsg == NULL);
     log_debug(LOG_VERB, "%s filter quit %s", print_obj(conn), print_obj(req));
+
+    // The client expects to receive an "+OK\r\n" response, so make sure
+    // to do that.
+    IGNORE_RET_VAL(simulate_ok_rsp(ctx, conn, req));
+
     conn->eof = 1;
     conn->recv_ready = 0;
-    req_put(req);
     return true;
   }
 

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -641,6 +641,16 @@ rstatus_t dnode_peer_req_forward(struct context *ctx, struct conn *c_conn,
 void dnode_peer_gossip_forward(struct context *ctx, struct conn *conn,
                                struct mbuf *data);
 
+/*
+ * Simulates a successful response as though the datastore sent it.
+ * Also, does the necessary to make sure that the response path is
+ * able to send this response back to the client.
+ *
+ * Returns DN_OK on success and an appropriate error otherwise.
+ */
+rstatus_t simulate_ok_rsp(struct context *ctx, struct conn *conn,
+    struct msg *msg);
+
 // Returns 'true' if 'msg_type' is a Dynomite configuration command.
 bool is_msg_type_dyno_config(msg_type_t msg_type);
 


### PR DESCRIPTION
The QUIT command so far was handled by just closing the connection on
the server side and did not respect the contract of the QUIT command.

The Redis documentation states that the QUIT command must return
"+OK\r\n" back to the client so that the client can close the connection
on its side.

This patch takes advantage of simulating a datastore response from the
previous patch to achieve this.