### PR TITLE
Auto cleanup repair Metadata on deletes if all replicas agree

### DIFF
--- a/src/dyn_core.c
+++ b/src/dyn_core.c
@@ -94,6 +94,7 @@ static rstatus_t core_dnode_peer_pool_preconnect(struct context *ctx) {
   IGNORE_RET_VAL(status);
   return status;
 }
+
 static rstatus_t core_dnode_peer_init(struct context *ctx) {
   /* initialize peers */
   THROW_STATUS(dnode_initialize_peers(ctx));

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -244,6 +244,8 @@ typedef rstatus_t (*func_msg_rewrite_t)(struct msg *orig_msg,
                                         struct msg **new_msg_ptr);
 typedef rstatus_t (*func_msg_repair_t)(struct context *ctx, struct response_mgr *rspmgr,
     struct msg **new_msg_ptr);
+typedef rstatus_t (*func_clear_repair_md_t)(struct context *ctx, struct msg *req,
+    struct msg **new_msg_ptr);
 typedef void (*func_init_datastore_t)();
 
 extern func_msg_coalesce_t g_pre_coalesce;  /* message pre-coalesce */
@@ -257,6 +259,7 @@ extern func_msg_rewrite_t
 extern func_msg_rewrite_t
     g_rewrite_query_with_timestamp_md;
 extern func_msg_repair_t g_make_repair_query; /* Create a repair msg. */
+extern func_clear_repair_md_t g_clear_repair_md_for_key;
 
 void set_datastore_ops(void);
 

--- a/src/dyn_task.c
+++ b/src/dyn_task.c
@@ -1,7 +1,11 @@
-#include "dyn_task.h"
+/*
+ * Dynomite - A thin, distributed replication layer for multi non-distributed
+ * storages. Copyright (C) 2019 Netflix, Inc.
+ */
 
 #include <stdbool.h>
 
+#include "dyn_task.h"
 #include "dyn_util.h"
 
 /**

--- a/src/proto/dyn_memcache.c
+++ b/src/proto/dyn_memcache.c
@@ -1627,3 +1627,8 @@ rstatus_t memcache_make_repair_query(struct context *ctx, struct response_mgr *r
     struct msg **new_msg_ptr) {
   return DN_OK;
 }
+
+rstatus_t memcache_clear_repair_md_for_key(struct context *ctx, struct msg *req,
+    struct msg **new_msg_ptr) {
+  return DN_OK;
+}

--- a/src/proto/dyn_proto.h
+++ b/src/proto/dyn_proto.h
@@ -53,7 +53,8 @@ rstatus_t memcache_rewrite_query_with_timestamp_md(struct msg *orig_msg,
     struct context *ctx, bool *did_rewrite, struct msg **new_msg_ptr);
 rstatus_t memcache_make_repair_query(struct context *ctx, struct response_mgr *rspmgr,
     struct msg **new_msg_ptr);
-
+rstatus_t memcache_clear_repair_md_for_key(struct context *ctx, struct msg *req,
+    struct msg **new_msg_ptr);
 
 void redis_parse_req(struct msg *r, struct context *ctx);
 void redis_parse_rsp(struct msg *r, struct context *ctx);
@@ -71,4 +72,7 @@ rstatus_t redis_rewrite_query_with_timestamp_md(struct msg *orig_msg,
     struct context *ctx, bool *did_rewrite, struct msg **new_msg_ptr);
 rstatus_t redis_make_repair_query(struct context *ctx, struct response_mgr *rspmgr,
     struct msg **new_msg_ptr);
+rstatus_t redis_clear_repair_md_for_key(struct context *ctx, struct msg *req,
+    struct msg **new_msg_ptr);
+
 #endif


### PR DESCRIPTION
This patch implements the automatic cleanup of metadata for delete
commands (DEL, ZREM, HDEL and SREM) when ALL the replicas in the
quorum set agree.

This is to ensure that we don't have "tombstones" present indefinitely
for deleted keys and fields.

For commands that don't receive all replica responses, the "rem set"
data will still be present. However, this would be a minority of the
cases, and we can implement logic in the side car to get rid of this.