### PR TITLE
Turning on repairs shouldn't invoke repairs for in-flight queries

### DIFF
--- a/src/proto/dyn_redis_repair.c
+++ b/src/proto/dyn_redis_repair.c
@@ -867,6 +867,10 @@ rstatus_t redis_make_repair_query(struct context *ctx, struct response_mgr *rspm
   bool repair_by_add = false;
   uint32_t num_values = 0;
 
+  // If we enabled read repairs halfway, in flight commands will not be
+  // repairable.
+  if (rspmgr->msg->orig_msg == NULL) return DN_OK;
+
   // Redis commands either lookup keys or fields (secondary keys), so the number of
   // expected values would be based on either one of them.
   if (rspmgr->msg->orig_msg->msg_info.num_fields > 0) {


### PR DESCRIPTION
Turning on repairs with constant traffic runs the risk of in-flight
queries trying to be repaired. This is incorrect and we should
make sure to not take the repair path for these queries.

This was found in a TEST cluster and I confirmed that this patch
fixes it.