### PR TITLE
Read-repair enabled messages should update read/write metrics correctly

### DIFF
--- a/src/proto/dyn_redis_repair.c
+++ b/src/proto/dyn_redis_repair.c
@@ -934,7 +934,10 @@ rstatus_t redis_rewrite_query_with_timestamp_md(struct msg *orig_msg, struct con
   update_total_num_tokens(&orig_msg->msg_info);
 
   ret_status = finalize_repair_msg(ctx, orig_msg->owner, &orig_msg->msg_info, new_msg_ptr);
+
   if (ret_status != DN_OK) goto error;
+  (*new_msg_ptr)->is_read = orig_msg->is_read;
+
   *did_rewrite = true;
   return ret_status;
 


### PR DESCRIPTION
The rewritten messages all got tracked as write messages since we
didn't adopt the 'is_read' parameter from the original 'msg'
object.

Confirmed that reads/writes are correct with this patch.