### PR TITLE
Replicas shouldn't update top level rem-set on final field delete

### DIFF
--- a/src/proto/dyn_proto_repair.h
+++ b/src/proto/dyn_proto_repair.h
@@ -211,7 +211,7 @@
   "  return ret\n"\
   "end\n\r\n"
 
-#define HDEL_SCRIPT "$4\r\nEVAL\r\n$1175\r\n"\
+#define HDEL_SCRIPT "$4\r\nEVAL\r\n$1122\r\n"\
   "local key = KEYS[1]\n"\
   "local top_level_add_set = KEYS[2]\n"\
   "local top_level_rem_set = KEYS[3]\n"\
@@ -248,7 +248,6 @@
   "end\n\n"\
   "local card = redis.call('ZCARD', rem_set)\n"\
   "if (card == 0) then\n"\
-  "  redis.call('ZADD', top_level_add_set, cur_ts, key)\n"\
   "  redis.call('ZREM', top_level_rem_set, key)\n"\
   "end\n\n"\
   "return ret\n\r\n"


### PR DESCRIPTION
This applies to hashmaps, sorted sets and sets.

Consider the following example:
If a sorted set in Dynomite has 2 or more items across replicas,
but if one of the replicas has a missed update(s) and therefore has
only 1 item, removing that item using dynomite previously updated
the top level REM set in that replica.

This is incorrect because now trying to read the other (non-deleted)
field, would cause read repairs to compare its timestamp against the
TS in the top level REM set in the inconsistent replica, and delete
the item incorrectly thinking that someone removed the entire map/set/set
in that broken replica.

This patch fixes it by not updating the top level REM set for field
deletes. Only a DEL will update the top level REM set for maps/sets/zsets.

This was noticed in a TEST cluster.