### PR TITLE
Add support for LPOP and BRPOP

### DIFF
--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -119,6 +119,8 @@
   ACTION(REQ_REDIS_KEYS)                                                       \
   ACTION(REQ_REDIS_INFO)                                                       \
   ACTION(REQ_REDIS_LINDEX) /* redis requests - lists */                        \
+  ACTION(REQ_REDIS_BLPOP)                                                      \
+  ACTION(REQ_REDIS_BRPOP)                                                      \
   ACTION(REQ_REDIS_LINSERT)                                                    \
   ACTION(REQ_REDIS_LLEN)                                                       \
   ACTION(REQ_REDIS_LPOP)                                                       \

--- a/src/proto/dyn_redis.c
+++ b/src/proto/dyn_redis.c
@@ -136,6 +136,8 @@ static bool redis_arg1(struct msg *r) {
     case MSG_REQ_REDIS_CONFIG:
     case MSG_REQ_REDIS_SCRIPT_LOAD:
     case MSG_REQ_REDIS_SCRIPT_EXISTS:
+    case MSG_REQ_REDIS_BLPOP:
+    case MSG_REQ_REDIS_BRPOP:
 
       return true;
 
@@ -797,6 +799,7 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
               break;
             }
 
+
             if (str4icmp(m, 'l', 'r', 'e', 'm')) {
               r->type = MSG_REQ_REDIS_LREM;
               r->is_read = 0;
@@ -918,6 +921,19 @@ void redis_parse_req(struct msg *r, struct context *ctx) {
             break;
 
           case 5:
+
+            if (str5icmp(m, 'b', 'l', 'p', 'o', 'p')) {
+              r->type = MSG_REQ_REDIS_BLPOP;
+              r->is_read = 0;
+              break;
+            }
+
+            if (str5icmp(m, 'b', 'r', 'p', 'o', 'p')) {
+              r->type = MSG_REQ_REDIS_BRPOP;
+              r->is_read = 0;
+              break;
+            }
+
             if (str5icmp(m, 'h', 'k', 'e', 'y', 's')) {
               r->type = MSG_REQ_REDIS_HKEYS;
               r->msg_routing = ROUTING_TOKEN_OWNER_LOCAL_RACK_ONLY;


### PR DESCRIPTION
Usage -
1. blpop key [key...] timeout
2. brpop key [key...] timeout

E.g. -

1. blpop:
127.0.1.1:8102> LPUSH test_list how
(integer) 1
127.0.1.1:8102> LPUSH test_list are
(integer) 2
127.0.1.1:8102> LPUSH test_list you
(integer) 3
127.0.1.1:8102> blpop test_list 1
1) "test_list"
2) "you"
127.0.1.1:8102> blpop test_list 1
1) "test_list"
2) "are"
127.0.1.1:8102> blpop test_list 1
1) "test_list"
2) "how"
127.0.1.1:8102> blpop test_list 1

2. brpop :
127.0.1.1:8102> LPUSH test_list how
(integer) 1
127.0.1.1:8102> LPUSH test_list are
(integer) 2
127.0.1.1:8102> LPUSH test_list you
(integer) 3
127.0.1.1:8102> brpop test_list 1
1) "test_list"
2) "how"
127.0.1.1:8102> brpop test_list 1
1) "test_list"
2) "are"
127.0.1.1:8102> brpop test_list 1
1) "test_list"
2) "you"