### PR TITLE
docs: fix simple typo, timetamps -> timestamps

### DIFF
--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -339,7 +339,7 @@ struct msg *req_recv_next(struct context *ctx, struct conn *conn, bool alloc) {
     conn->rmsg = req;
   }
 
-  // Record timetamps if repairs are enabled.
+  // Record timestamps if repairs are enabled.
   if (is_read_repairs_enabled()) {
     req->timestamp = current_timestamp_in_millis();
   }

--- a/src/dyn_server.c
+++ b/src/dyn_server.c
@@ -694,7 +694,7 @@ struct msg *rsp_recv_next(struct context *ctx, struct conn *conn, bool alloc) {
     conn->rmsg = rsp;
   }
 
-  // Record timetamps if repairs are enabled.
+  // Record timestamps if repairs are enabled.
   // TODO: Consider requests that span multiple mbufs.
   if (is_read_repairs_enabled()) {
     rsp->timestamp = current_timestamp_in_millis();

--- a/src/proto/dyn_redis_repair.c
+++ b/src/proto/dyn_redis_repair.c
@@ -698,7 +698,7 @@ static rstatus_t finalize_repair_msg(struct context *ctx, struct conn *conn,
 }
 
 /*
- * Finds all the timetamps from responses in rspmgr, updates the respective 'msg'
+ * Finds all the timestamps from responses in rspmgr, updates the respective 'msg'
  * structures with their timestamp, and finds the response that has the latest
  * timestamp.
  *


### PR DESCRIPTION
There is a small typo in src/dyn_client.c, src/dyn_server.c, src/proto/dyn_redis_repair.c.

Should read `timestamps` rather than `timetamps`.

