### PR TITLE
Fixes crash on large payloads for MGET/MSET/SCAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: c
 script: bash ./travis.sh
 
+before_install:
+  - sudo pip3 install --upgrade pip
+  
 addons:
   apt:
+   update: true
    packages:
-   - python3
+   - python3.9
    - python3-pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ language: c
 script: bash ./travis.sh
 
 before_install:
-  - sudo pip3 install --upgrade pip
+  - sudo apt remove --purge python3-pip
+  - curl -O https://bootstrap.pypa.io/pip/3.5/get-pip.py
+  - sudo -E python3 get-pip.py
+  - sudo -E python3 -m pip install --upgrade "pip < 22.3"
   
 addons:
   apt:
    update: true
    packages:
    - python3.9
-   - python3-pip

--- a/src/dyn_client.c
+++ b/src/dyn_client.c
@@ -1099,6 +1099,12 @@ void req_recv_done(struct context *ctx, struct conn *conn, struct msg *req,
   if (status != DN_OK) goto error;
 
   status = fragment_query_if_necessary(req, conn, &frag_msgq);
+  if (status == DYNOMITE_PAYLOAD_TOO_LARGE) {
+    dictAdd(conn->outstanding_msgs_dict, &req->id, req);
+    req->nfrag = 0; // Since we failed to fragment the payload, we don't have any fragments for this request
+    goto error;
+  }
+
   if (status != DN_OK) goto error;
 
   status = rewrite_query_with_timestamp_md(&req, ctx);

--- a/src/dyn_message.h
+++ b/src/dyn_message.h
@@ -294,6 +294,7 @@ typedef enum dyn_error {
   BAD_FORMAT,
   DYNOMITE_NO_QUORUM_ACHIEVED,
   DYNOMITE_SCRIPT_SPANS_NODES,
+  DYNOMITE_PAYLOAD_TOO_LARGE,
 } dyn_error_t;
 
 static inline char *dn_strerror(dyn_error_t err) {
@@ -318,6 +319,8 @@ static inline char *dn_strerror(dyn_error_t err) {
       return "Failed to achieve Quorum";
     case DYNOMITE_SCRIPT_SPANS_NODES:
       return "Keys in the script cannot span multiple nodes";
+    case DYNOMITE_PAYLOAD_TOO_LARGE:
+      return "MSET/MGET/SCAN payload too large";
     default:
       return strerror(err);
   }
@@ -329,6 +332,7 @@ static inline char *dyn_error_source(dyn_error_t err) {
     case DYNOMITE_INVALID_STATE:
     case DYNOMITE_NO_QUORUM_ACHIEVED:
     case DYNOMITE_SCRIPT_SPANS_NODES:
+    case DYNOMITE_PAYLOAD_TOO_LARGE:
       return "Dynomite:";
     case PEER_CONNECTION_REFUSE:
     case PEER_HOST_DOWN:


### PR DESCRIPTION
Fixes the issue with payloads which exceed the size of a single MBUF causing dynomite server to crash.

We now return DYNOMITE_PAYLOAD_TOO_LARGE with an exception back to the client.